### PR TITLE
If the room display name already starts with a '#', don't add another one.

### DIFF
--- a/nio/events.py
+++ b/nio/events.py
@@ -601,9 +601,9 @@ class RoomNameEvent(Event):
         sender = parsed_dict["sender"]
         timestamp = parsed_dict["origin_server_ts"]
 
-        canonical_alias = parsed_dict["content"]["name"]
+        room_name = parsed_dict["content"]["name"]
 
-        return cls(event_id, sender, timestamp, canonical_alias)
+        return cls(event_id, sender, timestamp, room_name)
 
 
 @attr.s

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -86,10 +86,12 @@ class MatrixRoom(object):
         Return the name of the room, if it's a named room. Otherwise return
         None.
         """
-        if self.name:
+        if self.name and self.name != '#':
             return self.name if self.name.startswith('#') else '#' + self.name
         elif self.canonical_alias:
             return self.canonical_alias
+        elif self.name == '#':
+            return '##'
         else:
             return None
 

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -95,7 +95,7 @@ class MatrixRoom(object):
 
     def group_name(self):
         """
-        Returns the group-style name of the room, i.e. a name based on the room
+        Return the group-style name of the room, i.e. a name based on the room
         members.
         """
         # Sort user display names, excluding our own user and using the

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -87,7 +87,7 @@ class MatrixRoom(object):
         None.
         """
         if self.name:
-            return "#" + self.name
+            return self.name if self.name.startswith('#') else '#' + self.name
         elif self.canonical_alias:
             return self.canonical_alias
         else:

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -46,11 +46,13 @@ class TestClass(object):
         assert room.is_named
         assert not room.is_group
 
-    def test_name_calculation(self):
+    def test_name_calculation_when_unnamed_with_no_members(self):
         room = self.test_room
         assert room.display_name == "Empty room?"
         assert room.named_room_name() == None
 
+    def test_name_calculation_when_unnamed_with_members(self):
+        room = self.test_room
         room.add_member("@alice:example.org", "Alice")
         assert room.display_name == "Alice"
 
@@ -64,11 +66,39 @@ class TestClass(object):
         assert (room.display_name ==
                 "Alice (@alice:example.org) and 2 others")
 
-        room.canonical_alias = "Alias for test room"
-        assert room.display_name == "Alias for test room"
+    def test_name_calculation_with_canonical_alias(self):
+        room = self.test_room
+        room.canonical_alias = "#test:termina.org.uk"
+        assert room.display_name == "#test:termina.org.uk"
 
+    def test_name_calculation_prefer_name_over_alias(self):
+        room = self.test_room
+        room.canonical_alias = "#test:termina.org.uk"
         room.name = "Test room"
         assert room.display_name == "#Test room"
+
+    def test_name_calculation_when_hash_already_prefixed(self):
+        room = self.test_room
+
+        room.name = "#test"
+        assert room.display_name == "#test"
+
+    def test_name_calculation_when_name_equals_hash(self):
+        """If the room name is set to '#', prefer using the canonical alias, if
+           it exists. This is because we always prefix named rooms by '#' to
+           distinguish them from non-named group-like rooms which are named
+           after its members.
+
+           Otherwise, in the unlikely case that the room name is '#' and there
+           is no canonical alias, display it as '##'.
+        """
+        room = self.test_room
+
+        room.name = "#"
+        assert room.display_name == "##"
+
+        room.canonical_alias = "#test:example.org"
+        assert room.display_name == "#test:example.org"
 
     def test_user_name_calculation(self):
         room = self.test_room


### PR DESCRIPTION
We need this because we prefix named rooms with '#', even if we are
using the room name and not the canonical alias (unlike Riot).