### PR TITLE
Support for room creation event

### DIFF
--- a/nio/events.py
+++ b/nio/events.py
@@ -104,6 +104,8 @@ class Event(object):
 
         if event_dict["type"] == "m.room.message":
             return RoomMessage.parse_event(event_dict)
+        elif event_dict["type"] == "m.room.create":
+            return RoomCreateEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.member":
             return RoomMemberEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.canonical_alias":
@@ -611,6 +613,27 @@ class RedactedEvent(Event):
 @attr.s
 class RoomEncryptionEvent(Event):
     pass
+
+
+@attr.s
+class RoomCreateEvent(Event):
+    creator = attr.ib()
+    federate = attr.ib(default=True)
+    room_version = attr.ib(default="1")
+
+    @classmethod
+    @verify(Schemas.room_create)
+    def from_dict(cls, parsed_dict):
+        # type: (Dict[Any, Any]) -> Union[RoomCreateEvent, BadEventType]
+        event_id = parsed_dict["event_id"]
+        sender = parsed_dict["sender"]
+        timestamp = parsed_dict["origin_server_ts"]
+
+        creator = parsed_dict["content"]["creator"]
+        federate = parsed_dict["content"]["m.federate"]
+        version = parsed_dict["content"]["room_version"]
+
+        return cls(event_id, sender, timestamp, creator, federate, version)
 
 
 @attr.s

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -59,6 +59,7 @@ class MatrixRoom(object):
         self.federate = True          # type: bool
         self.room_version = "1"       # type: str
         self.canonical_alias = None   # type: Optional[str]
+        self.topic = None             # type: Optional[str]
         self.name = None              # type: Optional[str]
         self.users = dict()           # type: Dict[str, MatrixUser]
         self.names = defaultdict(list)  # type: DefaultDict[str, List[str]]

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -34,6 +34,7 @@ from .events import (
     RoomAliasEvent,
     RoomEncryptionEvent,
     RoomMemberEvent,
+    RoomCreateEvent,
     RoomNameEvent,
     RoomTopicEvent,
 )
@@ -54,6 +55,9 @@ class MatrixRoom(object):
         # yapf: disable
         self.room_id = room_id        # type: str
         self.own_user_id = own_user_id
+        self.creator = ""             # type: str
+        self.federate = True          # type: bool
+        self.room_version = "1"       # type: str
         self.canonical_alias = None   # type: Optional[str]
         self.name = None              # type: Optional[str]
         self.users = dict()           # type: Dict[str, MatrixUser]
@@ -230,6 +234,11 @@ class MatrixRoom(object):
 
         if isinstance(event, RoomMemberEvent):
             self._handle_membership(event)
+
+        elif isinstance(event, RoomCreateEvent):
+            self.creator = event.creator
+            self.federate = event.federate
+            self.room_version = event.room_version
 
         elif isinstance(event, RoomNameEvent):
             self.name = event.name

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -592,6 +592,24 @@ class Schemas(object):
         "required": ["type", "sender", "content"],
     }
 
+    room_create = {
+        "type": "object",
+        "properties": {
+            "sender": {"type": "string", "format": "user_id"},
+            "type": {"type": "string"},
+            "content": {
+                "type": "object",
+                "properties": {
+                    "creator": {"type": "string", "format": "user_id"},
+                    "m.federate": {"type": "boolean", "default": True},
+                    "room_version": {"type": "string", "default": "1"},
+                },
+                "required": ["creator"],
+            },
+        },
+        "required": ["type", "sender", "content"],
+    }
+
     room_canonical_alias = {
         "type": "object",
         "properties": {

--- a/tests/data/events/create.json
+++ b/tests/data/events/create.json
@@ -1,0 +1,15 @@
+{
+    "content": {
+        "creator": "@example:localhost",
+        "m.federate": true,
+        "room_version": "1"
+    },
+    "event_id": "$151957878228ekrDs:localhost",
+    "origin_server_ts": 1519578782185,
+    "sender": "@example:localhost",
+    "state_key": "",
+    "type": "m.room.create",
+    "unsigned": {
+      "age": 1392989709
+    }
+}

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -9,6 +9,7 @@ from nio.events import (
     BadEvent,
     UnknownBadEvent,
     RedactedEvent,
+    RoomCreateEvent,
     RoomTopicEvent,
     RoomNameEvent,
     RoomAliasEvent,
@@ -41,6 +42,12 @@ class TestClass(object):
             "tests/data/events/redacted_invalid.json")
         response = RedactedEvent.from_dict(parsed_dict)
         assert isinstance(response, BadEvent)
+
+    def test_create_event(self):
+        parsed_dict = TestClass._load_response(
+            "tests/data/events/create.json")
+        event = RoomCreateEvent.from_dict(parsed_dict)
+        assert isinstance(event, RoomCreateEvent)
 
     def test_topic_event(self):
         parsed_dict = TestClass._load_response(

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -6,7 +6,8 @@ from nio.events import (
     InviteNameEvent,
     InviteAliasEvent,
     InviteMemberEvent,
-    RoomNameEvent
+    RoomNameEvent,
+    RoomCreateEvent
 )
 
 TEST_ROOM = "!test:example.org"
@@ -140,6 +141,15 @@ class TestClass(object):
 
         room.handle_ephemeral_event(TypingNoticeEvent([BOB_ID]))
         assert room.typing_users == [BOB_ID]
+
+    def test_create_event(self):
+        room = self.test_room
+        assert not room.creator
+        room.handle_event(RoomCreateEvent("event_id", BOB_ID, 0, BOB_ID, False))
+        assert room.creator == BOB_ID
+        assert room.federate is False
+        assert room.room_version == "1"
+
 
     def test_name_event(self):
         room = self.test_room


### PR DESCRIPTION
https://matrix.org/docs/spec/client_server/latest.html#m-room-create
Some standard events when a room is created (`m.room.create`, `m.room.join_rules`, `m.room.history_visibility`, `m.room.guest_access`) are returned as `UnknownEvent`.
I plan to add support for them, please tell me if I did any mistake.