### PR TITLE
Add profile get displayname API

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -810,6 +810,26 @@ class Api(object):
         )
 
     @staticmethod
+    def profile_get_displayname(access_token, user_id):
+        # type (str, str) -> Tuple[str, str, str]
+        """Get display name.
+
+        Returns the HTTP method, HTTP path and data for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+            user_id (str): User id to get display name for.
+        """
+        query_parameters = {"access_token": access_token}
+        path = "profile/{user}/displayname".format(user=user_id)
+
+        return (
+            "GET",
+            Api._build_path(path, query_parameters),
+            ""
+        )
+
+    @staticmethod
     def profile_set_displayname(access_token, user_id, display_name):
         # type (str, str, str) -> Tuple[str, str, str]
         """Set display name.

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -84,6 +84,7 @@ from ..responses import (
     KeysUploadError,
     RoomTypingResponse,
     RoomReadMarkersResponse,
+    ProfileGetDisplayNameResponse,
     ProfileSetDisplayNameResponse,
     RoomKeyRequestResponse
 )
@@ -615,6 +616,30 @@ class HttpClient(Client):
         return self._send(
             request,
             RequestInfo(JoinedMembersResponse, (room_id, ))
+        )
+
+    @connected
+    @logged_in
+    def get_displayname(self, user_id=None):
+        # type: (str) -> Tuple[UUID, bytes]
+        """Get an user's display name.
+
+        This queries the display name of an user from the server.
+        The currently logged in user is queried if no user is specified.
+
+        Returns a unique uuid that identifies the request and the bytes that
+        should be sent to the socket.
+
+        Args:
+            user_id (str): User id of the user to get the display name for.
+        """
+        request = self._build_request(Api.profile_get_displayname(
+            self.access_token,
+            user_id or self.user_id
+        ))
+        return self._send(
+            request,
+            RequestInfo(ProfileGetDisplayNameResponse)
         )
 
     @connected

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -797,6 +797,13 @@ class UpdateDeviceResponse(EmptyResponse):
 
 @attr.s
 class ProfileGetDisplayNameResponse(Response):
+    """Response representing a successful get display name request.
+
+    Attributes:
+        displayname (str, optional): The display name of the user.
+            None if the user doesn't have a display name.
+    """
+
     displayname = attr.ib(type=Optional[str], default=None)
 
     def __str__(self):

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -812,10 +812,6 @@ class ProfileGetDisplayNameResponse(Response):
         # type: (...) -> Union[ProfileGetDisplayNameResponse, ErrorResponse]
         return cls(parsed_dict.get("displayname"))
 
-    @staticmethod
-    def create_error(parsed_dict):
-        return ProfileGetDisplayNameError.from_dict(parsed_dict)
-
 
 class ProfileSetDisplayNameResponse(EmptyResponse):
     @staticmethod

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -106,6 +106,8 @@ __all__ = [
     "RoomReadMarkersError",
     "UploadResponse",
     "UploadError",
+    "ProfileGetDisplayNameResponse",
+    "ProfileGetDisplayNameError",
     "ProfileSetDisplayNameResponse",
     "ProfileSetDisplayNameError",
     "RoomKeyRequestResponse",
@@ -383,6 +385,10 @@ class UpdateDeviceError(ErrorResponse):
 
 
 class JoinedMembersError(_ErrorWithRoomId):
+    pass
+
+
+class ProfileGetDisplayNameError(ErrorResponse):
     pass
 
 
@@ -787,6 +793,28 @@ class UpdateDeviceResponse(EmptyResponse):
     @staticmethod
     def create_error(parsed_dict):
         return UpdateDeviceError.from_dict(parsed_dict)
+
+
+@attr.s
+class ProfileGetDisplayNameResponse(Response):
+    displayname = attr.ib(type=Optional[str], default=None)
+
+    def __str__(self):
+        # type: () -> str
+        return "Display name: {}".format(self.displayname)
+
+    @classmethod
+    @verify(Schemas.get_displayname, ProfileGetDisplayNameError)
+    def from_dict(
+        cls,
+        parsed_dict  # type: (Dict[Any, Any])
+    ):
+        # type: (...) -> Union[ProfileGetDisplayNameResponse, ErrorResponse]
+        return cls(parsed_dict.get("displayname"))
+
+    @staticmethod
+    def create_error(parsed_dict):
+        return ProfileGetDisplayNameError.from_dict(parsed_dict)
 
 
 class ProfileSetDisplayNameResponse(EmptyResponse):

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1212,4 +1212,11 @@ class Schemas(object):
         }
     }
 
+    get_displayname = {
+        "type": "object",
+        "properties": {
+            "displayname": {"type": "string"},
+        },
+    }
+
     empty = {"type": "object", "properties": {}, "additionalProperties": False}

--- a/tests/data/get_displayname_response.json
+++ b/tests/data/get_displayname_response.json
@@ -1,0 +1,3 @@
+{
+    "displayname": "Bob"
+}

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -21,7 +21,8 @@ from nio.responses import (
     SyncError,
     UploadResponse,
     RoomKeyRequestResponse,
-    RoomKeyRequestError
+    RoomKeyRequestError,
+    ProfileGetDisplayNameResponse
 )
 
 TEST_ROOM_ID = "!test:example.org"
@@ -168,3 +169,9 @@ class TestClass(object):
                 "!SVkFJHzfwvuaIEawgC:localhost"
             ].timeline.events
         ) == 1
+
+    def test_get_displayname(self):
+        parsed_dict = TestClass._load_response(
+            "tests/data/get_displayname_response.json")
+        response = ProfileGetDisplayNameResponse.from_dict(parsed_dict)
+        assert isinstance(response, ProfileGetDisplayNameResponse)


### PR DESCRIPTION
https://matrix.org/docs/spec/client_server/latest.html#get-matrix-client-r0-profile-userid-displayname
There currently is no way to get our own display name if we haven't joined any room, or the name of another user that doesn't share any room with us.