### PR TITLE
Add avatars support

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -864,6 +864,48 @@ class Api(object):
         )
 
     @staticmethod
+    def profile_get_avatar(access_token, user_id):
+        # type (str, str) -> Tuple[str, str, str]
+        """Get avatar URL.
+
+        Returns the HTTP method, HTTP path and data for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+            user_id (str): User id to get avatar for.
+        """
+        query_parameters = {"access_token": access_token}
+        path = "profile/{user}/avatar_url".format(user=user_id)
+
+        return (
+            "GET",
+            Api._build_path(path, query_parameters),
+            ""
+        )
+
+    @staticmethod
+    def profile_set_avatar(access_token, user_id, avatar_url):
+        # type (str, str, str) -> Tuple[str, str, str]
+        """Set avatar url.
+
+        Returns the HTTP method, HTTP path and data for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+            user_id (str): User id to set display name for.
+            avatar_url (str): matrix content URI of the avatar to set.
+        """
+        query_parameters = {"access_token": access_token}
+        content = {"avatar_url": avatar_url}
+        path = "profile/{user}/avatar_url".format(user=user_id)
+
+        return (
+            "PUT",
+            Api._build_path(path, query_parameters),
+            Api.to_json(content)
+        )
+
+    @staticmethod
     def whoami(access_token):
         # type (str) -> Tuple[str, str]
         """Get information about the owner of a given access token.

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -724,7 +724,9 @@ class Client(object):
         room = self.rooms[response.room_id]
 
         for member in response.members:
-            room.add_member(member.user_id, member.display_name)
+            room.add_member(
+                member.user_id, member.display_name, member.avatar_url
+            )
 
         if room.encrypted and self.olm is not None:
             self.olm.update_tracked_users(room)

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -39,8 +39,9 @@ from ..responses import (DeleteDevicesAuthResponse, DeleteDevicesResponse,
                          KeysClaimResponse, KeysQueryResponse, KeysUploadError,
                          KeysUploadResponse, LoginResponse,
                          PartialSyncResponse, ProfileGetDisplayNameResponse,
-                         ProfileSetDisplayNameResponse, Response,
-                         RoomForgetResponse, RoomInviteResponse,
+                         ProfileSetDisplayNameResponse,
+                         ProfileGetAvatarResponse, ProfileSetAvatarResponse,
+                         Response, RoomForgetResponse, RoomInviteResponse,
                          RoomKeyRequestResponse, RoomKickResponse,
                          RoomLeaveResponse, RoomMessagesResponse,
                          RoomPutStateResponse, RoomReadMarkersResponse,
@@ -675,6 +676,55 @@ class HttpClient(Client):
         return self._send(
             request,
             RequestInfo(ProfileSetDisplayNameResponse)
+        )
+
+    @connected
+    @logged_in
+    def get_avatar(self, user_id=None):
+        # type: (str) -> Tuple[UUID, bytes]
+        """Get an user's avatar URL.
+
+        This queries the avatar matrix content URI of an user from the server.
+        The currently logged in user is queried if no user is specified.
+
+        Returns a unique uuid that identifies the request and the bytes that
+        should be sent to the socket.
+
+        Args:
+            user_id (str): User id of the user to get the avatar for.
+        """
+        request = self._build_request(Api.profile_get_avatar(
+            self.access_token,
+            user_id or self.user_id
+        ))
+        return self._send(
+            request,
+            RequestInfo(ProfileGetAvatarResponse)
+        )
+
+    @connected
+    @logged_in
+    def set_avatar(self, avatar_url):
+        # type: (str) -> Tuple[UUID, bytes]
+        """Set user's avatar URL.
+
+        This tells the server to set avatar of the currently logged
+        in user to supplied matrix content URI.
+
+        Returns a unique uuid that identifies the request and the bytes that
+        should be sent to the socket.
+
+        Args:
+            avatar_url (str): matrix content URI of the avatar to set.
+        """
+        request = self._build_request(Api.profile_set_avatar(
+            self.access_token,
+            self.user_id,
+            avatar_url
+        ))
+        return self._send(
+            request,
+            RequestInfo(ProfileSetAvatarResponse)
         )
 
     @connected

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -97,6 +97,10 @@ __all__ = [
     "ProfileGetDisplayNameError",
     "ProfileSetDisplayNameResponse",
     "ProfileSetDisplayNameError",
+    "ProfileGetAvatarResponse",
+    "ProfileGetAvatarError",
+    "ProfileSetAvatarResponse",
+    "ProfileSetAvatarError",
     "RoomKeyRequestResponse",
     "RoomKeyRequestError",
     "ToDeviceResponse",
@@ -386,6 +390,14 @@ class ProfileGetDisplayNameError(ErrorResponse):
 
 
 class ProfileSetDisplayNameError(ErrorResponse):
+    pass
+
+
+class ProfileGetAvatarError(ErrorResponse):
+    pass
+
+
+class ProfileSetAvatarError(ErrorResponse):
     pass
 
 
@@ -824,6 +836,37 @@ class ProfileSetDisplayNameResponse(EmptyResponse):
     @staticmethod
     def create_error(parsed_dict):
         return ProfileSetDisplayNameError.from_dict(parsed_dict)
+
+
+@attr.s
+class ProfileGetAvatarResponse(Response):
+    """Response representing a successful get avatar request.
+
+    Attributes:
+        avatar_url (str, optional): The matrix content URI for the user's
+            avatae. None if the user doesn't have an avatar.
+    """
+
+    avatar_url = attr.ib(type=Optional[str], default=None)
+
+    def __str__(self):
+        # type: () -> str
+        return "Avatar URL: {}".format(self.avatar_url)
+
+    @classmethod
+    @verify(Schemas.get_avatar, ProfileGetAvatarError)
+    def from_dict(
+        cls,
+        parsed_dict  # type: (Dict[Any, Any])
+    ):
+        # type: (...) -> Union[ProfileGetAvatarResponse, ErrorResponse]
+        return cls(parsed_dict.get("avatar_url"))
+
+
+class ProfileSetAvatarResponse(EmptyResponse):
+    @staticmethod
+    def create_error(parsed_dict):
+        return ProfileSetAvatarError.from_dict(parsed_dict)
 
 
 @attr.s

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1220,6 +1220,14 @@ class Schemas(object):
         "required": ["displayname"]
     }
 
+    get_avatar = {
+        "type": "object",
+        "properties": {
+            "avatar_url": {"type": "string"},
+        },
+        "required": ["avatar_url"]
+    }
+
     key_verification_start = {
         "type": "object",
         "properties": {

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1215,7 +1215,7 @@ class Schemas(object):
     get_displayname = {
         "type": "object",
         "properties": {
-            "displayname": {"type": "string"},
+            "displayname": {"type": ["string", "null"]},
         },
         "required": ["displayname"]
     }
@@ -1223,7 +1223,7 @@ class Schemas(object):
     get_avatar = {
         "type": "object",
         "properties": {
-            "avatar_url": {"type": "string"},
+            "avatar_url": {"type": ["string", "null"]},
         },
         "required": ["avatar_url"]
     }

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -324,7 +324,6 @@ class TestClass(object):
         assert room.encrypted
         assert client.should_query_keys
 
-
     def test_device_store(self, tempdir):
         client = Client("ephemeral", "DEVICEID", tempdir)
         client.receive_response(self.login_response)

--- a/tests/data/get_avatar_response.json
+++ b/tests/data/get_avatar_response.json
@@ -1,0 +1,3 @@
+{
+    "avatar_url": "mxc://matrix.org/SDGdghriugerRg"
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,7 +8,7 @@ This module contains helpers for the nio tests.
 
 import os
 from random import choice
-from string import ascii_uppercase
+from string import ascii_uppercase, ascii_letters
 
 from faker import Faker
 from faker.providers import BaseProvider
@@ -20,6 +20,7 @@ from hyperframe.frame import (AltSvcFrame, ContinuationFrame, DataFrame,
 
 from nio.crypto import OlmAccount, OlmDevice
 from nio.store import Ed25519Key
+
 
 SAMPLE_SETTINGS = {
     SettingsFrame.HEADER_TABLE_SIZE: 4096,
@@ -33,6 +34,12 @@ faker = Faker()
 class Provider(BaseProvider):
     def mx_id(self):
         return "@{}:{}".format(faker.user_name(), faker.hostname())
+
+    def avatar_url(self):
+        return "mxc://{}/{}#auto".format(
+            faker.hostname(),
+            "".join(choice(ascii_letters) for i in range(24))
+        )
 
     def device_id(self):
         return "".join(choice(ascii_uppercase) for i in range(10))

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -9,6 +9,7 @@ from nio.responses import (DeleteDevicesAuthResponse, DevicesResponse,
                            JoinedMembersResponse, KeysClaimResponse,
                            KeysQueryResponse, KeysUploadResponse, LoginError,
                            LoginResponse, PartialSyncResponse,
+                           ProfileGetAvatarResponse,
                            ProfileGetDisplayNameResponse, RoomKeyRequestError,
                            RoomKeyRequestResponse, RoomMessagesResponse,
                            SyncError, SyncResponse, ToDeviceError,
@@ -164,6 +165,12 @@ class TestClass(object):
             "tests/data/get_displayname_response.json")
         response = ProfileGetDisplayNameResponse.from_dict(parsed_dict)
         assert isinstance(response, ProfileGetDisplayNameResponse)
+
+    def test_get_avatar(self):
+        parsed_dict = TestClass._load_response(
+            "tests/data/get_avatar_response.json")
+        response = ProfileGetAvatarResponse.from_dict(parsed_dict)
+        assert isinstance(response, ProfileGetAvatarResponse)
 
     def test_to_device(self):
         message = "message"


### PR DESCRIPTION
This adds support for avatars in `MatrixRoom`, `MatrixUser`, and the [get](https://matrix.org/docs/spec/client_server/latest.html#get-matrix-client-r0-profile-userid-avatar-url)/[set](https://matrix.org/docs/spec/client_server/latest.html#put-matrix-client-r0-profile-userid-avatar-url) avatar API.