### PR TITLE
wont work for me with out this change

### DIFF
--- a/nio/_compat.py
+++ b/nio/_compat.py
@@ -18,7 +18,9 @@ import sys
 
 if sys.version_info >= (3, 5):
     import importlib
-
+    if sys.version_info >= (3, 6):
+        from importlib import util
+    
     # The imp module is deprecated by importlib but importlib doesn't have the
     # find_spec function on python2. Use the imp module for py2 until we
     # deprecate python2 support.


### PR DESCRIPTION
with out this change i get 
> module 'importlib' has no attribute 'util'
I am not sure if this exist with an earlier change, im rather tired atm, but I believe it said after python 3.5