### PR TITLE
Handle m.room.canonical_alias with absent alias

### DIFF
--- a/nio/events/invite_events.py
+++ b/nio/events/invite_events.py
@@ -74,7 +74,7 @@ class InviteAliasEvent(InviteEvent):
     def from_dict(cls, parsed_dict):
         # type: (Dict[Any, Any]) -> Union[InviteAliasEvent, BadEventType]
         sender = parsed_dict["sender"]
-        canonical_alias = parsed_dict["content"]["alias"]
+        canonical_alias = parsed_dict["content"].get("alias")
 
         return cls(sender, canonical_alias)
 

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -312,7 +312,7 @@ class RoomAliasEvent(Event):
     @verify(Schemas.room_canonical_alias)
     def from_dict(cls, parsed_dict):
         # type: (Dict[Any, Any]) -> Union[RoomAliasEvent, BadEventType]
-        canonical_alias = parsed_dict["content"]["alias"]
+        canonical_alias = parsed_dict["content"].get("alias")
 
         return cls(parsed_dict, canonical_alias)
 

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -683,7 +683,7 @@ class Schemas(object):
             "content": {
                 "type": "object",
                 "properties": {"alias": {"type": "string"}},
-                "required": ["alias"],
+                "required": [],
             },
         },
         "required": ["type", "sender", "content"],


### PR DESCRIPTION
On my homeserver, removing a room alias results in an event with an empty content object, like so:

```json
{
  "origin_server_ts": 1532312562923,
  "sender": "@[redacted]",
  "event_id": "$[redacted]",
  "unsigned": {
    "prev_content": {"alias": "#[redacted]"},
    "prev_sender": "@[redacted]",
    "replaces_state": "$[redacted]",
    "age": 27083364217
  },
  "state_key": "",
  "content": {},
  "type": "m.room.canonical_alias"
}
```

[From the specification](https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-canonical-alias):

> A room with an `m.room.canonical_alias` event with an absent, null, or empty `alias` field should be treated the same as a room with no `m.room.canonical_alias` event.