### PR TITLE
method has typo: add_ephermeral_callback -> add_ephemeral_callback

### DIFF
--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 import attr
 from logbook import Logger
+import warnings
 
 from ..crypto import ENCRYPTION_ENABLED
 from ..events import (BadEventType, Event, KeyVerificationEvent, MegolmEvent,
@@ -943,8 +944,10 @@ class Client(object):
         """
         Deprecated: typo in function name
         """
-        logger.warn(
-                "add_ephermeral_callback is deprecated. Use add_ephemeral_callback.")
+        warnings.warn(
+            "deprecated. Use add_ephemeral_callback.",
+            DeprecationWarning
+        )
         self.add_ephemeral_callback(callback, filter)
 
     def add_ephemeral_callback(self, callback, filter):

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -940,6 +940,14 @@ class Client(object):
         self.event_callbacks.append(cb)
 
     def add_ephermeral_callback(self, callback, filter):
+        """
+        Deprecated: typo in function name
+        """
+        logger.warn(
+                "add_ephermeral_callback is deprecated. Use add_ephemeral_callback.")
+        self.add_ephemeral_callback(callback, filter)
+
+    def add_ephemeral_callback(self, callback, filter):
         # type: (Callable[[MatrixRoom, Event], None], Tuple[Type]) -> None
         """Add a callback that will be executed on ephemeral room events.
 


### PR DESCRIPTION
Typo in method name: ephermeral -> ephemeral. This patch renames to add_ephemeral_callback. The original method then warns that it is deprecated and then calls add_ephemeral_callback