### PR TITLE
Room avatar url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 *.pyc
 .hypothesis/
 .tox/
+doc/build
+matrix_nio.egg-info/

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -79,6 +79,8 @@ class Event(object):
             return RoomNameEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.topic":
             return RoomTopicEvent.from_dict(event_dict)
+        elif event_dict["type"] == "m.room.avatar":
+            return RoomAvatarEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.power_levels":
             return PowerLevelsEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.encryption":
@@ -341,6 +343,19 @@ class RoomTopicEvent(Event):
         canonical_alias = parsed_dict["content"]["topic"]
 
         return cls(parsed_dict, canonical_alias)
+
+
+@attr.s
+class RoomAvatarEvent(Event):
+    avatar_url = attr.ib()
+
+    @classmethod
+    @verify(Schemas.room_avatar)
+    def from_dict(cls, parsed_dict):
+        # type (Dict[Any, Any]) -> Union[RoomAvatarEvent, BadEventType]
+        room_avatar_url = parsed_dict["content"]["url"]
+
+        return cls(parsed_dict, room_avatar_url)
 
 
 @attr.s

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -154,7 +154,7 @@ class MatrixRoom(object):
         return self.users[user_id].avatar_url
 
     @property
-    def get_avatar_url(self):
+    def gen_avatar_url(self):
         """
         Calculate the room avatar_url
 
@@ -164,9 +164,12 @@ class MatrixRoom(object):
         if self.room_avatar_url:
             return self.room_avatar_url
         elif self.is_group:
-            for user in self.users:
-                if user != self.own_user_id:
-                    return self.avatar_url(user)
+            user = next(
+                (u for u in self.users if u != self.own_user_id),
+                None
+            )
+            return self.avatar_url(user)
+
         return None
 
     @property

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -28,7 +28,7 @@ from .events import (Event, InviteAliasEvent, InviteMemberEvent,
                      RoomAliasEvent, RoomCreateEvent, RoomEncryptionEvent,
                      RoomGuestAccessEvent, RoomHistoryVisibilityEvent,
                      RoomJoinRulesEvent, RoomMemberEvent, RoomNameEvent,
-                     RoomTopicEvent)
+                     RoomTopicEvent, RoomAvatarEvent)
 from .log import logger_group
 from .responses import RoomSummary, TypingNoticeEvent
 
@@ -60,6 +60,7 @@ class MatrixRoom(object):
         self.power_levels = PowerLevels()  # type: PowerLevels
         self.typing_users = []        # type: List[str]
         self.summary = None           # type: Optional[RoomSummary]
+        self.room_avatar_url = None        # type: Optional[str]
         # yapf: enable
 
     @property
@@ -151,6 +152,22 @@ class MatrixRoom(object):
             return None
 
         return self.users[user_id].avatar_url
+
+    @property
+    def get_avatar_url(self):
+        """
+        Calculate the room avatar_url
+
+        Either the room.avatar_url or the avatar_url of the first user
+        not myself
+        """
+        if self.room_avatar_url:
+            return self.room_avatar_url
+        elif self.is_group:
+            for user in self.users:
+                if user != self.own_user_id:
+                    return self.avatar_url(user)
+        return None
 
     @property
     def machine_name(self):
@@ -273,6 +290,9 @@ class MatrixRoom(object):
 
         elif isinstance(event, RoomTopicEvent):
             self.topic = event.topic
+
+        elif isinstance(event, RoomAvatarEvent):
+            self.room_avatar_url = event.avatar_url
 
         elif isinstance(event, RoomEncryptionEvent):
             self.encrypted = True

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -717,6 +717,25 @@ class Schemas(object):
         "required": ["type", "sender", "content"],
     }
 
+    room_avatar = {
+        type: "object",
+        "properties": {
+            "sender": {"type": "string", "format": "user_id"},
+            "type": {"type": "string"},
+            "content": {
+                "type": "object",
+                "info": {
+                    "h": {"type": "integer"},
+                    "w": {"type": "integer"},
+                    "mimetype": {"type", "string"},
+                    "size": {"type": "integer"},
+                },
+                "url": {"type": "string"},
+            },
+        },
+        "required": ["type", "sender", "content"]
+    }
+
     room_power_levels = {
         "type": "object",
         "properties": {

--- a/tests/data/events/room_avatar.json
+++ b/tests/data/events/room_avatar.json
@@ -1,0 +1,21 @@
+{
+    "content": {
+        "info": {
+            "h": 398,
+            "mimetype": "image/jpeg",
+            "size": 31037,
+            "w": 394
+        },
+        "url": "mxc://domain.com/JWEIFJgwEIhweiWJE"
+    },
+    "event_id": "$143273582443PhrSn:domain.com",
+    "origin_server_ts": 1432735824653,
+    "room_id": "!jEsUZKDJdhlrceRyVU:domain.com",
+    "sender": "@example:domain.com",
+    "state_key": "",
+    "type": "m.room.avatar",
+    "unsigned": {
+        "age": 1234
+    }
+}
+

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -10,7 +10,8 @@ from nio.events import (BadEvent, OlmEvent, PowerLevelsEvent, RedactedEvent,
                         RoomGuestAccessEvent, RoomHistoryVisibilityEvent,
                         RoomJoinRulesEvent, RoomMemberEvent, RoomMessageEmote,
                         RoomMessageNotice, RoomMessageText, RoomNameEvent,
-                        RoomTopicEvent, ToDeviceEvent, UnknownBadEvent)
+                        RoomTopicEvent, RoomAvatarEvent, ToDeviceEvent,
+                        UnknownBadEvent)
 
 
 class TestClass(object):
@@ -61,6 +62,12 @@ class TestClass(object):
             "tests/data/events/topic.json")
         event = RoomTopicEvent.from_dict(parsed_dict)
         assert isinstance(event, RoomTopicEvent)
+
+    def test_room_avatar_event(self):
+        parsed_dict = TestClass._load_response(
+            "tests/data/events/room_avatar.json")
+        event = RoomAvatarEvent.from_dict(parsed_dict)
+        assert isinstance(event, RoomAvatarEvent)
 
     def test_name_event(self):
         parsed_dict = TestClass._load_response(


### PR DESCRIPTION
- `test_room_avatar_event`
- `room_avatar` schema for testing
- `RoomAvatarEvent`
- interpret `m.room.avatar` and set `room_avatar_url` in `MatrixRoom`
- additional `gen_avatar_url` for calculating the `avatar_url` on all rooms including grouped rooms