### PR TITLE
Also catch asyncio.TimeoutError in sync_forever

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -383,7 +383,7 @@ class AsyncClient(Client):
             except asyncio.CancelledError:
                 break
 
-            except (ClientConnectionError, TimeoutError):
+            except (ClientConnectionError, TimeoutError, asyncio.TimeoutError):
                 await self.run_response_callbacks(responses)
 
                 try:


### PR DESCRIPTION
`AsyncClient`'s `sync_forever` can still exit due to `asyncio.TimeoutError`, which is not a subclass of the standard `TimeoutError`:
```py3
  File "matrix-nio/nio/client/async_client.py", line 371, in sync_forever
    await self.sync(timeout, sync_filter, since, full_state)
  File "matrix-nio/nio/client/async_client.py", line 300, in sync
    response = await self._send(SyncResponse, method, path)
  File "matrix-nio/nio/client/async_client.py", line 200, in _send
    transport_response = await self.send(method, path, data)
  File "matrix-nio/nio/client/async_client.py", line 69, in wrapper
    return await func(self, *args, **kwargs)
  File "matrix-nio/nio/client/async_client.py", line 238, in send
    headers=headers
  File ".local/lib/python3.6/site-packages/aiohttp/client.py", line 499, in _request
    await resp.start(conn)
  File ".local/lib/python3.6/site-packages/aiohttp/client_reqrep.py", line 857, in start
    self._continue = None
  File ".local/lib/python3.6/site-packages/aiohttp/helpers.py", line 585, in __exit__
    raise asyncio.TimeoutError from None
```