### PR TITLE
Handling limit exceeded errors in async client

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -32,11 +32,12 @@ from ..api import Api, MessageDirection
 from ..exceptions import (GroupEncryptionError, LocalProtocolError,
                           MembersSyncError, SendRetryError)
 from ..messages import ToDeviceMessage
-from ..responses import (JoinedMembersError, JoinedMembersResponse,
+from ..responses import (ErrorResponse,
+                         JoinedMembersError, JoinedMembersResponse,
                          KeysClaimError, KeysClaimResponse, KeysQueryResponse,
-                         KeysUploadResponse, LimitExceededError, LoginError,
-                         LoginResponse, ProfileGetAvatarResponse,
-                         ProfileGetAvatarError, ProfileGetDisplayNameResponse,
+                         KeysUploadResponse, LoginError, LoginResponse,
+                         ProfileGetAvatarResponse, ProfileGetAvatarError,
+                         ProfileGetDisplayNameResponse,
                          ProfileGetDisplayNameError, ProfileGetResponse,
                          ProfileGetError, ProfileSetAvatarResponse,
                          ProfileSetAvatarError, ProfileSetDisplayNameResponse,
@@ -336,11 +337,14 @@ class AsyncClient(Client):
                 response_data
             )
 
-            if isinstance(response, LimitExceededError):
+            if isinstance(response, ErrorResponse):
                 await self.run_response_callbacks([response])
-                await asyncio.sleep(response.retry_after_ms / 1000)
-            else:
-                break
+
+                if response.retry_after_ms:
+                    await asyncio.sleep(response.retry_after_ms / 1000)
+                    continue
+
+            break
 
         await self.receive_response(response)
 

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -337,14 +337,11 @@ class AsyncClient(Client):
                 response_data
             )
 
-            if isinstance(response, ErrorResponse):
+            if isinstance(response, ErrorResponse) and response.retry_after_ms:
                 await self.run_response_callbacks([response])
-
-                if response.retry_after_ms:
-                    await asyncio.sleep(response.retry_after_ms / 1000)
-                    continue
-
-            break
+                await asyncio.sleep(response.retry_after_ms / 1000)
+            else:
+                break
 
         await self.receive_response(response)
 

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -274,6 +274,8 @@ class ErrorResponse(Response):
 
 @attr.s
 class LimitExceededError(ErrorResponse):
+    """A response representing a "Too many requests" error from the server."""
+
     retry_after_ms = attr.ib(default=2000, type=int)
     room_id = attr.ib(default=None, type=Optional[str])
 

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -218,18 +218,9 @@ class Schemas(object):
         "properties": {
             "error": {"type": "string"},
             "errcode": {"type": "string"},
-        },
-        "required": ["error", "errcode"],
-    }
-
-    limit_exceeded_error = {
-        "type": "object",
-        "properties": {
-            "error": {"type": "string"},
-            "errcode": {"type": "string", "enum": ["M_LIMIT_EXCEEDED"]},
             "retry_after_ms": {"type": "integer"},
         },
-        "required": ["error", "errcode", "retry_after_ms"],
+        "required": ["error", "errcode"],
     }
 
     room_timeline = {

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -222,6 +222,16 @@ class Schemas(object):
         "required": ["error", "errcode"],
     }
 
+    limit_exceeded_error = {
+        "type": "object",
+        "properties": {
+            "error": {"type": "string"},
+            "errcode": {"type": "string", "enum": ["M_LIMIT_EXCEEDED"]},
+            "retry_after_ms": {"type": "integer"},
+        },
+        "required": ["error", "errcode", "retry_after_ms"],
+    }
+
     room_timeline = {
         "type": "object",
         "properties": {

--- a/tests/data/limit_exceeded_error.json
+++ b/tests/data/limit_exceeded_error.json
@@ -1,5 +1,5 @@
 {
   "errcode": "M_LIMIT_EXCEEDED",
   "error": "Too many requests",
-  "retry_after_ms": 2000
+  "retry_after_ms": 500
 }

--- a/tests/data/limit_exceeded_error.json
+++ b/tests/data/limit_exceeded_error.json
@@ -1,0 +1,5 @@
+{
+  "errcode": "M_LIMIT_EXCEEDED",
+  "error": "Too many requests",
+  "retry_after_ms": 2000
+}

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -214,10 +214,10 @@ class TestClass(object):
 
         response = ErrorResponse.from_dict(parsed_dict)
         assert isinstance(response, ErrorResponse)
-        assert response.retry_after_ms == 2000
+        assert response.retry_after_ms == parsed_dict["retry_after_ms"]
 
         room_id = "!SVkFJHzfwvuaIEawgC:localhost"
         response2 = _ErrorWithRoomId.from_dict(parsed_dict, room_id)
         assert isinstance(response2, _ErrorWithRoomId)
-        assert response.retry_after_ms == 2000
+        assert response.retry_after_ms == parsed_dict["retry_after_ms"]
         assert response2.room_id == room_id

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -7,9 +7,9 @@ import json
 from nio.responses import (DeleteDevicesAuthResponse, DevicesResponse,
                            ErrorResponse, JoinedMembersError,
                            JoinedMembersResponse, KeysClaimResponse,
-                           KeysQueryResponse, KeysUploadResponse,
-                           LimitExceededError, LoginError, LoginResponse,
-                           PartialSyncResponse, ProfileGetAvatarResponse,
+                           KeysQueryResponse, KeysUploadResponse, LoginError,
+                           LoginResponse, PartialSyncResponse,
+                           ProfileGetAvatarResponse,
                            ProfileGetDisplayNameResponse, ProfileGetResponse,
                            RoomContextError, RoomContextResponse,
                            RoomKeyRequestError, RoomKeyRequestResponse,
@@ -115,7 +115,9 @@ class TestClass(object):
 
     def test_keyshare_request(self):
         parsed_dict = {
-            "errcode": "M_NOT_FOUND",
+            "errcode": "M_LIMIT_EXCEEDED",
+            "error": "Too many requests",
+            "retry_after_ms": 2000
         }
         response = RoomKeyRequestResponse.from_dict(
             parsed_dict, "1", "1", TEST_ROOM_ID, "megolm.v1"
@@ -211,10 +213,11 @@ class TestClass(object):
             "tests/data/limit_exceeded_error.json")
 
         response = ErrorResponse.from_dict(parsed_dict)
-        assert isinstance(response, LimitExceededError)
-        assert response.room_id is None
+        assert isinstance(response, ErrorResponse)
+        assert response.retry_after_ms == 2000
 
         room_id = "!SVkFJHzfwvuaIEawgC:localhost"
         response2 = _ErrorWithRoomId.from_dict(parsed_dict, room_id)
-        assert isinstance(response2, LimitExceededError)
+        assert isinstance(response2, _ErrorWithRoomId)
+        assert response.retry_after_ms == 2000
         assert response2.room_id == room_id


### PR DESCRIPTION
This adds a `LimitExceededError` class for this kind of response:
```json
{
  "errcode": "M_LIMIT_EXCEEDED",
  "error": "Too many requests",
  "retry_after_ms": 2000
}
 ```
and makes `AsyncClient._send` retry when getting this error response, after sleeping for the given time.

I wrote a test for the response, but I'm not too sure of how to write one for the `_send`. Can I get some indications, if this test is needed?