### PR TITLE
Import rooms module classes at root level

### DIFF
--- a/nio/__init__.py
+++ b/nio/__init__.py
@@ -3,4 +3,5 @@ from .client import *
 from .api import MessageDirection, Api
 from .responses import *
 from .events import *
+from .rooms import *
 from .exceptions import *

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -35,6 +35,12 @@ from .responses import RoomSummary, TypingNoticeEvent
 logger = Logger("nio.rooms")
 logger_group.add_logger(logger)
 
+__all__ = [
+    "MatrixRoom",
+    "MatrixInvitedRoom",
+    "MatrixUser",
+]
+
 
 class MatrixRoom(object):
     """Represents a Matrix room."""


### PR DESCRIPTION
For conveniance and consistency, since everything else is already available at root level. This avoids having to do:
```py
import nio
from nio.rooms import MatrixRoom, MatrixUser
``` 