### PR TITLE
M.tag 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 *.pyc
 .hypothesis/
 .tox/
+doc/build
+matrix_nio.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 .tox/
 doc/build
 matrix_nio.egg-info/
+*.swp

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -383,7 +383,7 @@ class AsyncClient(Client):
             except asyncio.CancelledError:
                 break
 
-            except ClientConnectionError:
+            except (ClientConnectionError, TimeoutError):
                 await self.run_response_callbacks(responses)
 
                 try:

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 import attr
 from logbook import Logger
+import warnings
 
 from ..crypto import ENCRYPTION_ENABLED
 from ..events import (BadEventType, Event, KeyVerificationEvent, MegolmEvent,
@@ -943,8 +944,10 @@ class Client(object):
         """
         Deprecated: typo in function name
         """
-        logger.warn(
-                "add_ephermeral_callback is deprecated. Use add_ephemeral_callback.")
+        warnings.warn(
+            "deprecated. Use add_ephemeral_callback.",
+            DeprecationWarning
+        )
         self.add_ephemeral_callback(callback, filter)
 
     def add_ephemeral_callback(self, callback, filter):

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -566,6 +566,10 @@ class Client(object):
             room = self.invited_rooms[room_id]
 
             for event in info.invite_state:
+                for cb in self.event_callbacks:
+                    if (cb.filter is None or isinstance(event, cb.filter)):
+                        cb.func(room, event)
+
                 room.handle_event(event)
 
         # Handle joined rooms

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -933,10 +933,14 @@ class Client(object):
         # type: (Callable[[MatrixRoom, Event], None], Tuple[Type]) -> None
         """Add a callback that will be executed on room events.
 
+        The callback can be used on joined rooms as well as on invited rooms.
+        The room parameter for the callback will have a different type
+        depending on if the room is joined or invited.
+
         Args:
-            callback (Callable[MatrixRoom, Event]): A function that will be
-                called if the event type in the filter argument is found in a
-                room timeline.
+            callback (Callable[Union[MatrixRoom, MatrixInvitedRoom, Event]): A
+                function that will be called if the event type in the filter
+                argument is found in a room timeline.
             filter (Type, Tuple[Type]): The event type or a tuple containing
                 multiple types for which the function will be called.
 
@@ -945,9 +949,7 @@ class Client(object):
         self.event_callbacks.append(cb)
 
     def add_ephermeral_callback(self, callback, filter):
-        """
-        Deprecated: typo in function name
-        """
+        """Deprecated: typo in function name."""
         warnings.warn(
             "deprecated. Use add_ephemeral_callback.",
             DeprecationWarning

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -940,6 +940,14 @@ class Client(object):
         self.event_callbacks.append(cb)
 
     def add_ephermeral_callback(self, callback, filter):
+        """
+        Deprecated: typo in function name
+        """
+        logger.warn(
+                "add_ephermeral_callback is deprecated. Use add_ephemeral_callback.")
+        self.add_ephemeral_callback(callback, filter)
+
+    def add_ephemeral_callback(self, callback, filter):
         # type: (Callable[[MatrixRoom, Event], None], Tuple[Type]) -> None
         """Add a callback that will be executed on ephemeral room events.
 

--- a/nio/crypto/olm_machine.py
+++ b/nio/crypto/olm_machine.py
@@ -1061,6 +1061,7 @@ class Olm(object):
         ignored_set = group_session.users_ignored
 
         user_map = []
+        mark_as_ignored = []
 
         for user_id in users:
             for device in self.device_store.active_user_devices(user_id):
@@ -1093,7 +1094,7 @@ class Olm(object):
                     if self.is_device_ignored(device):
                         pass
                     elif ignore_unverified_devices:
-                        self.ignore_device(device)
+                        mark_as_ignored.append(device)
                     else:
                         raise OlmTrustError("Device {} for user {} is not "
                                             "verified or blacklisted.".format(
@@ -1110,6 +1111,9 @@ class Olm(object):
                 break
 
         sharing_with = set()
+
+        if mark_as_ignored:
+            self.store.ignore_devices(mark_as_ignored)
 
         for user_id, device, session in user_map:
             # No need to share the session with our own device

--- a/nio/crypto/sessions.py
+++ b/nio/crypto/sessions.py
@@ -202,21 +202,27 @@ class OutboundGroupSession(olm.OutboundGroupSession):
         return super().encrypt(plaintext)
 
 
+@attr.s
 class OlmDevice(object):
-    def __init__(
-        self,
-        user_id,          # type: str
-        device_id,        # type: str
-        keys,             # type: Dict[str, str]
-        display_name="",  # type: str
-        deleted=False,    # type: bool
-    ):
-        # type: (...) -> None
-        self.user_id = user_id
-        self.id = device_id
-        self.keys = keys
-        self.display_name = display_name
-        self.deleted = deleted
+    """Class holding info about users Olm devices.
+
+    Attributes:
+        user_id (str): The id of the user that the device belongs to.
+        id (str): The device id that combined with the user id uniquely
+            identifies the device.
+        keys (Dict): A dictionary containing the type and the public part
+            of this devices encryption keys.
+        display_name (str): The human readable name of this device.
+        deleted (bool): A boolean signaling if this device has been deleted by
+            its owner.
+
+    """
+
+    user_id = attr.ib(type=str)
+    id = attr.ib(type=str)
+    keys = attr.ib(type=Dict[str, str])
+    display_name = attr.ib(type=str, default="")
+    deleted = attr.ib(type=bool, default=False)
 
     @property
     def ed25519(self):

--- a/nio/events/account_data.py
+++ b/nio/events/account_data.py
@@ -37,6 +37,8 @@ class AccountDataEvent(object):
 
         if event_dict["type"] == "m.fully_read":
             return FullyReadEvent.from_dict(event_dict)
+        if event_dict["type"] == "m.tag":
+            return TagEvent.from_dict(event_dict)
 
         return UnknownAccountDataEvent.from_dict(event_dict)
 
@@ -64,6 +66,28 @@ class FullyReadEvent(AccountDataEvent):
         content = event_dict.pop("content")
         return cls(
             content["event_id"],
+        )
+
+
+@attr.s
+class TagEvent(AccountDataEvent):
+    """Tag event.
+
+    Informs the client tags of a room.
+
+    Attributes:
+        tags (Dict): The tags of the room
+    """
+
+    tags = attr.ib()
+
+    @classmethod
+    @verify(Schemas.tags)
+    def from_dict(cls, event_dict):
+        """Construct a TagEvent from a dictionary."""
+        content = event_dict.pop("content")
+        return cls(
+            content["tags"]
         )
 
 

--- a/nio/events/account_data.py
+++ b/nio/events/account_data.py
@@ -71,12 +71,14 @@ class FullyReadEvent(AccountDataEvent):
 
 @attr.s
 class TagEvent(AccountDataEvent):
-    """Tag event.
-
-    Informs the client tags of a room.
+    """Informs the client tags of a room. Room tags may include
+        - m.favourite for favourite rooms
+        - m.lowpriority for low priority room
+       A tag may have an optinal order float 0 <= order <=1 for position
+       this room to other rooms.
 
     Attributes:
-        tags (Dict): The tags of the room
+        tags (Dict[string, Optional[Dict[string, float]]): The tag dictionary.
     """
 
     tags = attr.ib()

--- a/nio/events/account_data.py
+++ b/nio/events/account_data.py
@@ -37,7 +37,7 @@ class AccountDataEvent(object):
 
         if event_dict["type"] == "m.fully_read":
             return FullyReadEvent.from_dict(event_dict)
-        if event_dict["type"] == "m.tag":
+        elif event_dict["type"] == "m.tag":
             return TagEvent.from_dict(event_dict)
 
         return UnknownAccountDataEvent.from_dict(event_dict)

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -79,6 +79,8 @@ class Event(object):
             return RoomNameEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.topic":
             return RoomTopicEvent.from_dict(event_dict)
+        elif event_dict["type"] == "m.room.avatar":
+            return RoomAvatarEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.power_levels":
             return PowerLevelsEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.encryption":
@@ -341,6 +343,19 @@ class RoomTopicEvent(Event):
         canonical_alias = parsed_dict["content"]["topic"]
 
         return cls(parsed_dict, canonical_alias)
+
+
+@attr.s
+class RoomAvatarEvent(Event):
+    avatar_url = attr.ib()
+
+    @classmethod
+    @verify(Schemas.room_avatar)
+    def from_dict(cls, parsed_dict):
+        # type (Dict[Any, Any]) -> Union[RoomAvatarEvent, BadEventType]
+        room_avatar_url = parsed_dict["content"]["url"]
+
+        return cls(parsed_dict, room_avatar_url)
 
 
 @attr.s

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -154,7 +154,7 @@ class MatrixRoom(object):
         return self.users[user_id].avatar_url
 
     @property
-    def get_avatar_url(self):
+    def gen_avatar_url(self):
         """
         Calculate the room avatar_url
 
@@ -164,9 +164,12 @@ class MatrixRoom(object):
         if self.room_avatar_url:
             return self.room_avatar_url
         elif self.is_group:
-            for user in self.users:
-                if user != self.own_user_id:
-                    return self.avatar_url(user)
+            user = next(
+                (u for u in self.users if u != self.own_user_id),
+                None
+            )
+            return self.avatar_url(user)
+
         return None
 
     @property

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -28,7 +28,7 @@ from .events import (Event, InviteAliasEvent, InviteMemberEvent,
                      RoomAliasEvent, RoomCreateEvent, RoomEncryptionEvent,
                      RoomGuestAccessEvent, RoomHistoryVisibilityEvent,
                      RoomJoinRulesEvent, RoomMemberEvent, RoomNameEvent,
-                     RoomTopicEvent)
+                     RoomTopicEvent, RoomAvatarEvent)
 from .log import logger_group
 from .responses import RoomSummary, TypingNoticeEvent
 
@@ -60,6 +60,7 @@ class MatrixRoom(object):
         self.power_levels = PowerLevels()  # type: PowerLevels
         self.typing_users = []        # type: List[str]
         self.summary = None           # type: Optional[RoomSummary]
+        self.room_avatar_url = None        # type: Optional[str]
         # yapf: enable
 
     @property
@@ -151,6 +152,22 @@ class MatrixRoom(object):
             return None
 
         return self.users[user_id].avatar_url
+
+    @property
+    def get_avatar_url(self):
+        """
+        Calculate the room avatar_url
+
+        Either the room.avatar_url or the avatar_url of the first user
+        not myself
+        """
+        if self.room_avatar_url:
+            return self.room_avatar_url
+        elif self.is_group:
+            for user in self.users:
+                if user != self.own_user_id:
+                    return self.avatar_url(user)
+        return None
 
     @property
     def machine_name(self):
@@ -273,6 +290,9 @@ class MatrixRoom(object):
 
         elif isinstance(event, RoomTopicEvent):
             self.topic = event.topic
+
+        elif isinstance(event, RoomAvatarEvent):
+            self.room_avatar_url = event.avatar_url
 
         elif isinstance(event, RoomEncryptionEvent):
             self.encrypted = True

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -717,6 +717,25 @@ class Schemas(object):
         "required": ["type", "sender", "content"],
     }
 
+    room_avatar = {
+        type: "object",
+        "properties": {
+            "sender": {"type": "string", "format": "user_id"},
+            "type": {"type": "string"},
+            "content": {
+                "type": "object",
+                "info": {
+                    "h": {"type": "integer"},
+                    "w": {"type": "integer"},
+                    "mimetype": {"type", "string"},
+                    "size": {"type": "integer"},
+                },
+                "url": {"type": "string"},
+            },
+        },
+        "required": ["type", "sender", "content"]
+    }
+
     room_power_levels = {
         "type": "object",
         "properties": {

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1221,12 +1221,22 @@ class Schemas(object):
                 "type": "object",
                 "properties": {
                     "tags": {"type:": "object"},
+                    "properties": {
+                        "order": {"type": "float"}
+                    },
+                    "required": [
+                        "type"
+                    ],
                 },
                 "required": [
                     "tags",
                 ],
             }
-        }
+        },
+        "required": [
+            "type",
+            "content",
+        ],
     }
 
     upload = {

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1194,6 +1194,22 @@ class Schemas(object):
         ],
     }
 
+    tags = {
+        "type": "object",
+        "properties": {
+            "type": {"type": "string"},
+            "content": {
+                "type": "object",
+                "properties": {
+                    "tags": {"type:": "object"},
+                },
+                "required": [
+                    "tags",
+                ],
+            }
+        }
+    }
+
     upload = {
         "type": "object",
         "properties": {"content_uri": {"type": "string"}},

--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -1213,8 +1213,6 @@ class SqliteStore(MatrixStore):
         tuple_values = [(d.user_id, d.id) for d in devices]
         values = [item for sublist in tuple_values for item in sublist]
 
-        total_rows = []  # type: List[Dict[str, str]]
-
         for idx in range(0, len(values), 300):
             data = values[idx:idx + 300]
 

--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -396,6 +396,52 @@ class LegacyMatrixStore(object):
         # type: (OlmDevice) -> bool
         raise NotImplementedError
 
+    def ignore_device(self, device):
+        # type: (OlmDevice) -> bool
+        """Mark a device as ignored.
+
+        Args:
+            device (OlmDevice): The device that will be ignored.
+
+        Returns True if the device has been ignored, False if it already has
+        been ignored before.
+        """
+        raise NotImplementedError
+
+    def unignore_device(self, device):
+        # type: (OlmDevice) -> bool
+        """Unmark a device as ignored.
+
+        Args:
+            device (OlmDevice): The device that will be unignored.
+
+        Returns True if the device has been unignored, False if it wasn't
+        ignored in the first place.
+        """
+        raise NotImplementedError
+
+    def is_device_ignored(self, device):
+        # type: (OlmDevice) -> bool
+        """Check if a device is ignored.
+
+        Args:
+            device (OlmDevice): The device that will be checked if it is
+                ignored.
+
+        Returns True if the device is ignored, False otherwise.
+        """
+        raise NotImplementedError
+
+    def ignore_devices(self, devices):
+        # type: (List[OlmDevice]) -> None
+        """Mark multiple devices as ignored.
+
+        Args:
+            devices (List[OlmDevice]): The devices that will be makred as
+                ignored.
+        """
+        raise NotImplementedError
+
 
 @attr.s
 class MatrixStore(object):

--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -943,6 +943,10 @@ class MatrixStore(object):
         # type: (OlmDevice) -> bool
         raise NotImplementedError
 
+    def ignore_devices(self, devices):
+        # type: (List[OlmDevice]) -> None
+        raise NotImplementedError
+
     def is_device_ignored(self, device):
         # type: (OlmDevice) -> bool
         raise NotImplementedError

--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -989,7 +989,6 @@ class DefaultStore(MatrixStore):
 class SqliteStore(MatrixStore):
     models = MatrixStore.models + [DeviceTrustState]
 
-    @use_database
     def _get_device(self, device):
         acc = self._get_account()
 
@@ -1005,6 +1004,7 @@ class SqliteStore(MatrixStore):
         except DoesNotExist:
             return None
 
+    @use_database
     def verify_device(self, device):
         # type: (OlmDevice) -> bool
         if self.is_device_verified(device):
@@ -1020,6 +1020,7 @@ class SqliteStore(MatrixStore):
 
         return True
 
+    @use_database
     def unverify_device(self, device):
         # type: (OlmDevice) -> bool
         if not self.is_device_verified(device):
@@ -1035,6 +1036,7 @@ class SqliteStore(MatrixStore):
 
         return True
 
+    @use_database
     def is_device_verified(self, device):
         # type: (OlmDevice) -> bool
         d = self._get_device(device)
@@ -1049,6 +1051,7 @@ class SqliteStore(MatrixStore):
 
         return trust_state == TrustState.verified
 
+    @use_database
     def blacklist_device(self, device):
         # type: (OlmDevice) -> bool
         if self.is_device_blacklisted(device):
@@ -1064,6 +1067,7 @@ class SqliteStore(MatrixStore):
 
         return True
 
+    @use_database
     def unblacklist_device(self, device):
         # type: (OlmDevice) -> bool
         if not self.is_device_blacklisted(device):
@@ -1079,6 +1083,7 @@ class SqliteStore(MatrixStore):
 
         return True
 
+    @use_database
     def is_device_blacklisted(self, device):
         # type: (OlmDevice) -> bool
         d = self._get_device(device)
@@ -1093,6 +1098,7 @@ class SqliteStore(MatrixStore):
 
         return trust_state == TrustState.blacklisted
 
+    @use_database
     def ignore_device(self, device):
         # type: (OlmDevice) -> bool
         if self.is_device_ignored(device):
@@ -1108,6 +1114,7 @@ class SqliteStore(MatrixStore):
 
         return True
 
+    @use_database
     def unignore_device(self, device):
         # type: (OlmDevice) -> bool
         if not self.is_device_ignored(device):
@@ -1123,6 +1130,7 @@ class SqliteStore(MatrixStore):
 
         return True
 
+    @use_database
     def is_device_ignored(self, device):
         # type: (OlmDevice) -> bool
         d = self._get_device(device)

--- a/nio/store/file_trustdb.py
+++ b/nio/store/file_trustdb.py
@@ -158,7 +158,6 @@ class KeyStore(object):
                     raise OlmTrustError(message)
 
         self._entries.append(key)
-        self._save()
         return True
 
     @_save_store
@@ -166,7 +165,6 @@ class KeyStore(object):
         # type: (Key) -> bool
         if key in self._entries:
             self._entries.remove(key)
-            self._save()
             return True
 
         return False

--- a/nio/store/file_trustdb.py
+++ b/nio/store/file_trustdb.py
@@ -170,6 +170,13 @@ class KeyStore(object):
         return self._add_without_save(key)
 
     @_save_store
+    def remove_many(self, keys):
+        # type: (List[Key]) -> None
+        for key in keys:
+            if key in self._entries:
+                self._entries.remove(key)
+
+    @_save_store
     def remove(self, key):
         # type: (Key) -> bool
         if key in self._entries:

--- a/nio/store/file_trustdb.py
+++ b/nio/store/file_trustdb.py
@@ -137,8 +137,12 @@ class KeyStore(object):
                 f.write(line)
 
     @_save_store
-    def add(self, key):
-        # type: (Key) -> bool
+    def add_many(self, keys):
+        # type: (List[Key]) -> None
+        for key in keys:
+            self._add_without_save(key)
+
+    def _add_without_save(self, key):
         existing_key = self.get_key(key.user_id, key.device_id)
 
         if existing_key:
@@ -159,6 +163,11 @@ class KeyStore(object):
 
         self._entries.append(key)
         return True
+
+    @_save_store
+    def add(self, key):
+        # type: (Key) -> bool
+        return self._add_without_save(key)
 
     @_save_store
     def remove(self, key):

--- a/nio/store/models.py
+++ b/nio/store/models.py
@@ -249,6 +249,7 @@ class DeviceTrustState(Model):
         model=DeviceKeys,
         primary_key=True,
         backref="trust_state",
+        column_name="device_id",
     )
 
 

--- a/tests/data/events/room_avatar.json
+++ b/tests/data/events/room_avatar.json
@@ -1,0 +1,21 @@
+{
+    "content": {
+        "info": {
+            "h": 398,
+            "mimetype": "image/jpeg",
+            "size": 31037,
+            "w": 394
+        },
+        "url": "mxc://domain.com/JWEIFJgwEIhweiWJE"
+    },
+    "event_id": "$143273582443PhrSn:domain.com",
+    "origin_server_ts": 1432735824653,
+    "room_id": "!jEsUZKDJdhlrceRyVU:domain.com",
+    "sender": "@example:domain.com",
+    "state_key": "",
+    "type": "m.room.avatar",
+    "unsigned": {
+        "age": 1234
+    }
+}
+

--- a/tests/data/events/tag.json
+++ b/tests/data/events/tag.json
@@ -1,0 +1,10 @@
+{
+    "content": {
+        "tags": {
+            "u.work": {
+                "order": 0.9
+            }
+        }
+    },
+    "type": "m.tag"
+}

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -11,7 +11,7 @@ from nio.events import (BadEvent, OlmEvent, PowerLevelsEvent, RedactedEvent,
                         RoomJoinRulesEvent, RoomMemberEvent, RoomMessageEmote,
                         RoomMessageNotice, RoomMessageText, RoomNameEvent,
                         RoomTopicEvent, RoomAvatarEvent, TagEvent,
-                        ToDeviceEvent, UnknownBadEvent)
+                        AccountDataEvent, ToDeviceEvent, UnknownBadEvent)
 
 
 class TestClass(object):
@@ -72,7 +72,7 @@ class TestClass(object):
     def test_tag_event(self):
         parsed_dict = TestClass._load_response(
             "tests/data/events/tag.json")
-        event = TagEvent.from_dict(parsed_dict)
+        event = AccountDataEvent.parse_event(parsed_dict)
         assert isinstance(event, TagEvent)
 
     def test_name_event(self):

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -10,8 +10,8 @@ from nio.events import (BadEvent, OlmEvent, PowerLevelsEvent, RedactedEvent,
                         RoomGuestAccessEvent, RoomHistoryVisibilityEvent,
                         RoomJoinRulesEvent, RoomMemberEvent, RoomMessageEmote,
                         RoomMessageNotice, RoomMessageText, RoomNameEvent,
-                        RoomTopicEvent, RoomAvatarEvent, ToDeviceEvent,
-                        UnknownBadEvent)
+                        RoomTopicEvent, RoomAvatarEvent, TagEvent,
+                        ToDeviceEvent, UnknownBadEvent)
 
 
 class TestClass(object):
@@ -68,6 +68,12 @@ class TestClass(object):
             "tests/data/events/room_avatar.json")
         event = RoomAvatarEvent.from_dict(parsed_dict)
         assert isinstance(event, RoomAvatarEvent)
+
+    def test_tag_event(self):
+        parsed_dict = TestClass._load_response(
+            "tests/data/events/tag.json")
+        event = TagEvent.from_dict(parsed_dict)
+        assert isinstance(event, TagEvent)
 
     def test_name_event(self):
         parsed_dict = TestClass._load_response(

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -10,7 +10,8 @@ from nio.events import (BadEvent, OlmEvent, PowerLevelsEvent, RedactedEvent,
                         RoomGuestAccessEvent, RoomHistoryVisibilityEvent,
                         RoomJoinRulesEvent, RoomMemberEvent, RoomMessageEmote,
                         RoomMessageNotice, RoomMessageText, RoomNameEvent,
-                        RoomTopicEvent, ToDeviceEvent, UnknownBadEvent)
+                        RoomTopicEvent, RoomAvatarEvent, ToDeviceEvent,
+                        UnknownBadEvent)
 
 
 class TestClass(object):
@@ -61,6 +62,12 @@ class TestClass(object):
             "tests/data/events/topic.json")
         event = RoomTopicEvent.from_dict(parsed_dict)
         assert isinstance(event, RoomTopicEvent)
+
+    def test_room_avatar_event(self):
+        parsed_dict = TestClass._load_response(
+            "tests/data/events/room_avatar.json")
+        event = RoomAvatarEvent.from_dict(parsed_dict)
+        assert isinstance(event, RoomAvatarEvent)
 
     def test_name_event(self):
         parsed_dict = TestClass._load_response(

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -155,6 +155,24 @@ class TestClass(object):
         assert fake_key not in store
         assert key in store
 
+    def test_key_store_add_many(self, tempdir):
+        store_path = os.path.join(tempdir, "test_store")
+        store = KeyStore(os.path.join(tempdir, "test_store"))
+
+        keys = [
+            faker.ed25519_key(),
+            faker.ed25519_key(),
+            faker.ed25519_key(),
+            faker.ed25519_key(),
+        ]
+
+        store.add_many(keys)
+
+        store2 = KeyStore(os.path.join(tempdir, "test_store"))
+
+        for key in keys:
+            assert key in store2
+
     @ephemeral
     def test_store_opening(self):
         store = self.ephemeral_store

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -173,6 +173,27 @@ class TestClass(object):
         for key in keys:
             assert key in store2
 
+    def test_key_store_remove_many(self, tempdir):
+        store_path = os.path.join(tempdir, "test_store")
+        store = KeyStore(os.path.join(tempdir, "test_store"))
+
+        keys = [
+            faker.ed25519_key(),
+            faker.ed25519_key(),
+            faker.ed25519_key(),
+            faker.ed25519_key(),
+        ]
+        store.add_many(keys)
+
+        for key in keys:
+            assert key in store
+
+        store.remove_many(keys)
+        store2 = KeyStore(os.path.join(tempdir, "test_store"))
+
+        for key in keys:
+            assert key not in store2
+
     @ephemeral
     def test_store_opening(self):
         store = self.ephemeral_store


### PR DESCRIPTION
m.tag is used in room's account data e.g. for tagging m.favourite and m.lowpriority rooms. Because of the rebasing I need a new pull request.

Here you have:
- swp file out of the repo
- better description for TagEvent
- tests via AccountData.parse_events
- schema for tags has now better description, full required definition, better definition for tags-> order