### PR TITLE
Fix MatrixRoom profile change handling

### DIFF
--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -252,10 +252,11 @@ class MatrixRoom(object):
                 self.names[user.name].remove(user.user_id)
                 user.display_name = event.content["displayname"]
                 self.names[user.name].append(user.user_id)
-                return False
 
             if "avatar_url" in event.content:
                 user.avatar_url = event.content["avatar_url"]
+
+            return False
 
         elif event.content["membership"] in ["leave", "ban"]:
             return self.remove_member(event.state_key)


### PR DESCRIPTION
When a profile changed, `handle_membership` returned right after setting a new display name, before being able to set a new avatar.