### PR TITLE
Add upload method to async client

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -830,10 +830,10 @@ class Api(object):
     @staticmethod
     def upload(
         access_token,       # type: str
-        filename=None,      # type: str
+        filename=None,      # type: Optional[str]
     ):
         # type: (...) -> Tuple[str, str, str]
-        """Upload some content to the content repository.
+        """Upload a file's content to the content repository.
 
         Returns the HTTP method, HTTP path and empty data for the request.
         The real data should be read from the file that should be uploaded.

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -655,6 +655,7 @@ class TestClass(object):
             "?access_token=abc123&filename=test.png",
             status=200,
             payload=self.upload_response,
+            repeat=True
         )
 
         resp = await async_client.upload(
@@ -663,6 +664,14 @@ class TestClass(object):
             "test.png"
         )
         assert isinstance(resp, UploadResponse)
+
+        with open("tests/data/file_response", "rb") as file:
+            streaming_resp = await async_client.upload(
+                file,
+                "image/png",
+                "test.png"
+            )
+        assert isinstance(streaming_resp, UploadResponse)
 
 
     async def test_thumbnail(self, async_client, aioresponse):


### PR DESCRIPTION
https://matrix.org/docs/spec/client_server/latest#post-matrix-media-r0-upload

After your https://github.com/poljar/matrix-nio/pull/39#issuecomment-510170310, I looked into the aiohttp docs and found that it accepts a file-like object or async generator as data for a request (see [this](https://docs.aiohttp.org/en/stable/client_quickstart.html#streaming-uploads)).
I made `upload()` accept bytes or such objects, and added a `content_type` argument to `_send()`.

I haven't implemented the method for `HttpClient` (yet?), since I don't use it anymore and it requires more complicated changes to `_build_request()` and `HttpRequest`. Can this be merged like this?