### PR TITLE
Async timeouts handling

### DIFF
--- a/nio/client/__init__.py
+++ b/nio/client/__init__.py
@@ -3,4 +3,4 @@ import sys
 from .base_client import Client, ClientConfig
 from .http_client import HttpClient, TransportType, RequestInfo
 if sys.version_info >= (3, 5):
-    from .async_client import AsyncClient
+    from .async_client import AsyncClient, AsyncClientConfig

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -15,6 +15,7 @@
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import asyncio
+import warnings
 from asyncio import Event
 from functools import partial, wraps
 from json.decoder import JSONDecodeError
@@ -178,11 +179,16 @@ class AsyncClient(Client):
 
         self.sharing_session = dict()  # type: Dict[str, Event]
 
-        config = config or AsyncClientConfig()
+        if isinstance(config, ClientConfig):
+            warnings.warn(
+                "Pass an AsyncClientConfig instead of ClientConfig.",
+                DeprecationWarning
+            )
+            config = AsyncClientConfig(**config.__dict__)
 
-        super().__init__(user, device_id, store_path, config)
+        self.config = config or AsyncClientConfig()  # type: AsyncClientConfig
 
-        self.config = config  # type: AsyncClientConfig
+        super().__init__(user, device_id, store_path, self.config)
 
     def add_response_callback(
             self,

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -90,11 +90,11 @@ class ClientConfig(object):
     Attributes:
         store (MatrixStore, optional): The store that should be used for state
             storage.
-        store_name: (str, optional): Filename that should be used for the
+        store_name (str, optional): Filename that should be used for the
             store.
-        encryption_enabled(bool, optional): Should end to end encryption be
+        encryption_enabled (bool, optional): Should end to end encryption be
             used.
-        pickle_key: (str, optional): A passphrase that will be used to encrypt
+        pickle_key (str, optional): A passphrase that will be used to encrypt
             end to end encryption keys.
 
     Raises an ImportWarning if encryption_enabled is true but the dependencies
@@ -127,8 +127,8 @@ class Client(object):
            after logging in.
        user_id (str): The full mxid of the current user. This is set after
            logging in.
-       next_batch(str): The current sync token.
-       rooms(Dict[str, MatrixRoom)): A dictionary containing a mapping of room
+       next_batch (str): The current sync token.
+       rooms (Dict[str, MatrixRoom)): A dictionary containing a mapping of room
            ids to MatrixRoom objects. All the rooms a user is joined to will be
            here after a sync.
 

--- a/nio/events/to_device.py
+++ b/nio/events/to_device.py
@@ -368,7 +368,7 @@ class RoomKeyEvent(ToDeviceEvent):
         room_id (str): The room ID of the room to which the session key
             belongs to.
         session_id (str): The session id of the session key.
-        algorithm: (str): The algorithm of the session key.
+        algorithm (str): The algorithm of the session key.
 
     """
 
@@ -406,7 +406,7 @@ class ForwardedRoomKeyEvent(RoomKeyEvent):
         room_id (str): The room ID of the room to which the session key
             belongs to.
         session_id (str): The session id of the session key.
-        algorithm: (str): The algorithm of the session key.
+        algorithm (str): The algorithm of the session key.
 
     """
 

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -631,7 +631,7 @@ class ShareGroupSessionResponse(Response):
 
     Attributes:
         room_id (str): The room id of the group session.
-        users_shared_with: (Set[Tuple[str, str]]): A set containing a tuple of
+        users_shared_with (Set[Tuple[str, str]]): A set containing a tuple of
             user id device id pairs with whom we shared the group session in
             this request.
 
@@ -655,7 +655,7 @@ class ShareGroupSessionResponse(Response):
            parsed_dict (Dict): The dict containing the raw json response.
            room_id (str): The room id of the room to which the group session
                belongs to.
-           users_shared_with: (Set[Tuple[str, str]]): A set containing a tuple
+           users_shared_with (Set[Tuple[str, str]]): A set containing a tuple
                of user id device id pairs with whom we shared the group
                session in this request.
         """


### PR DESCRIPTION
This adds handling of `ClientConnectionError`, `TimeoutError` and `asyncio.TimeoutError` for all async client requests instead of just inside `sync_forever()`.

I added an `AsyncClientConfig` that allows setting the max timeouts before raising, max limit exceeded errors before retuning an `ErrorResponse`, an exponential backoff factor to control the wait time between retries (inspired from [urllib](https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry)), and a max total wait time.

Additionally, in `sync_forever()`: `sync()`, `send_to_device_messages()`, `keys_upload()` and `keys_query()` 
will now be run concurrently instead of waiting for each others, thus reducing initial delays with E2E rooms.