### PR TITLE
Fix FileResponse error parsing

### DIFF
--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -1053,7 +1053,7 @@ class HttpClient(Client):
 
         try:
             content_type = str(
-                transport_response.headers[b"content-type"], "utf-8",
+                transport_response.headers[b"content-type"], "utf-8"
             )
         except KeyError:
             content_type = None
@@ -1063,7 +1063,7 @@ class HttpClient(Client):
         if issubclass(request_class, FileResponse) and is_json:
             parsed_dict = self.parse_body(transport_response)
             response = request_class.from_data(
-                parsed_dict, content_type, *extra_data,
+                parsed_dict, content_type, *extra_data
             )
 
         elif issubclass(request_class, FileResponse):

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -779,7 +779,7 @@ class TestClass(object):
             ),
             status=429,
             content_type="application/json",
-            body=bytes(self.limit_exceeded_error_response, "utf-8"),
+            body = b'{"errcode": "M_LIMIT_EXCEEDED"}',
         )
         resp = await async_client.thumbnail(
             server_name, media_id, width, height, method

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -21,7 +21,8 @@ from nio import (DeviceList, DeviceOneTimeKeyCount, ErrorResponse,
                  RoomEncryptionEvent, RoomInfo, RoomLeaveResponse,
                  RoomMemberEvent, RoomMessagesResponse, Rooms,
                  RoomSendResponse, RoomSummary, ShareGroupSessionResponse,
-                 SyncResponse, ThumbnailResponse, Timeline, UploadResponse)
+                 SyncResponse, ThumbnailError, ThumbnailResponse,
+                 Timeline, UploadResponse)
 from nio.api import ResizingMethod
 from nio.crypto import OlmDevice, Session
 
@@ -765,6 +766,25 @@ class TestClass(object):
         )
         assert isinstance(resp, ThumbnailResponse)
         assert resp.body == self.file_response
+
+        aioresponse.get(
+            "https://example.org/_matrix/media/r0/thumbnail/{}/{}"
+            "?access_token=abc123&width={}&height={}&method={}"
+            "&allow_remote=true".format(
+                server_name,
+                media_id,
+                width,
+                height,
+                method.value,
+            ),
+            status=429,
+            content_type="application/json",
+            body=bytes(self.limit_exceeded_error_response, "utf-8"),
+        )
+        resp = await async_client.thumbnail(
+            server_name, media_id, width, height, method
+        )
+        assert isinstance(resp, ThumbnailError)
 
 
     async def test_event_callback(self, async_client):


### PR DESCRIPTION
If the returned content-type of the response is `application/json`, the body must be parsed as such instead of being passed as bytes.