### PR TITLE
Handle invited events before calling callbacks

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -308,11 +308,11 @@ class AsyncClient(Client):
             room = self._get_invited_room(room_id)
 
             for event in info.invite_state:
+                room.handle_event(event)
+
                 for cb in self.event_callbacks:
                     if (cb.filter is None or isinstance(event, cb.filter)):
                         await asyncio.coroutine(cb.func)(room, event)
-
-                room.handle_event(event)
 
     async def _handle_joined_rooms(self, response):
         encrypted_rooms = set()

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -608,11 +608,11 @@ class Client(object):
             room = self._get_invited_room(room_id)
 
             for event in info.invite_state:
+                room.handle_event(event)
+
                 for cb in self.event_callbacks:
                     if (cb.filter is None or isinstance(event, cb.filter)):
                         cb.func(room, event)
-
-                room.handle_event(event)
 
     def _handle_joined_state(self, room_id, join_info, encrypted_rooms):
         if room_id in self.invited_rooms:


### PR DESCRIPTION
Joined room events are handled by nio before calling user-registered callbacks. It should be the same for invited rooms, else the callback will receive an outdated `MatrixInvitedRoom`.