### PR TITLE
Expose unverified devices in errors

### DIFF
--- a/nio/crypto/olm_machine.py
+++ b/nio/crypto/olm_machine.py
@@ -620,12 +620,9 @@ class Olm(object):
                                   "{}".format(device.user_id, device.id))
 
         if not device.verified:
-            raise OlmUnverifiedDeviceError(
-                "Failed to reshare key {} with {}: Device {} is not "
-                "verified".format(event.session_id, event.sender,
-                                  event.requesting_device_id),
-                unverified_device=device
-            )
+            raise OlmUnverifiedDeviceError(device, "Failed to reshare key {} with {}: Device {} is not "
+                                                   "verified".format(event.session_id, event.sender,
+                                                                     event.requesting_device_id))
 
         logger.debug("Sucesfully shared a key {} with {}:{}".format(
             event.session_id,
@@ -1731,14 +1728,11 @@ class Olm(object):
                     elif ignore_unverified_devices:
                         mark_as_ignored.append(device)
                     else:
-                        raise OlmUnverifiedDeviceError(
-                            "Device {} for user {} is not "
-                            "verified or blacklisted.".format(
-                                device.id,
-                                device.user_id
-                            ),
-                            unverified_device=device
-                        )
+                        raise OlmUnverifiedDeviceError(device, "Device {} for user {} is not "
+                                                               "verified or blacklisted.".format(
+                            device.id,
+                            device.user_id
+                        ))
 
                 user_map.append((user_id, device, session))
 

--- a/nio/crypto/olm_machine.py
+++ b/nio/crypto/olm_machine.py
@@ -42,7 +42,8 @@ from ..events import (BadEvent, BadEventType, Event,
                       DummyEvent, validate_or_badevent, RoomKeyRequest,
                       RoomKeyRequestCancellation)
 from ..exceptions import (EncryptionError, GroupEncryptionError,
-                          LocalProtocolError, OlmTrustError, VerificationError)
+                          LocalProtocolError, OlmTrustError, OlmUnverifiedDeviceError,
+                          VerificationError)
 from ..responses import (KeysClaimResponse, KeysQueryResponse,
                          KeysUploadResponse, RoomKeyRequestResponse,
                          ToDeviceResponse)
@@ -619,10 +620,11 @@ class Olm(object):
                                   "{}".format(device.user_id, device.id))
 
         if not device.verified:
-            raise OlmTrustError(
+            raise OlmUnverifiedDeviceError(
                 "Failed to reshare key {} with {}: Device {} is not "
                 "verified".format(event.session_id, event.sender,
-                                  event.requesting_device_id)
+                                  event.requesting_device_id),
+                unverified_device=device
             )
 
         logger.debug("Sucesfully shared a key {} with {}:{}".format(
@@ -1729,11 +1731,14 @@ class Olm(object):
                     elif ignore_unverified_devices:
                         mark_as_ignored.append(device)
                     else:
-                        raise OlmTrustError("Device {} for user {} is not "
-                                            "verified or blacklisted.".format(
-                                                device.id,
-                                                device.user_id
-                                            ))
+                        raise OlmUnverifiedDeviceError(
+                            "Device {} for user {} is not "
+                            "verified or blacklisted.".format(
+                                device.id,
+                                device.user_id
+                            ),
+                            unverified_device=device
+                        )
 
                 user_map.append((user_id, device, session))
 

--- a/nio/exceptions.py
+++ b/nio/exceptions.py
@@ -14,8 +14,6 @@
 # CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from .crypto import OlmDevice
-
 
 class ProtocolError(Exception):
     pass
@@ -50,7 +48,7 @@ class OlmTrustError(Exception):
 
 
 class OlmUnverifiedDeviceError(OlmTrustError):
-    def __init__(self, *args: object, unverified_device: OlmDevice) -> None:
+    def __init__(self, *args: object, unverified_device: 'nio.OlmDevice') -> None:
         super().__init__(*args)
         self.device = unverified_device
 

--- a/nio/exceptions.py
+++ b/nio/exceptions.py
@@ -14,6 +14,8 @@
 # CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from .crypto import OlmDevice
+
 
 class ProtocolError(Exception):
     pass
@@ -45,6 +47,12 @@ class RemoteTransportError(ProtocolError):
 
 class OlmTrustError(Exception):
     pass
+
+
+class OlmUnverifiedDeviceError(OlmTrustError):
+    def __init__(self, *args: object, unverified_device: OlmDevice) -> None:
+        super().__init__(*args)
+        self.device = unverified_device
 
 
 class VerificationError(Exception):

--- a/nio/exceptions.py
+++ b/nio/exceptions.py
@@ -15,6 +15,9 @@
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
+from builtins import super
+
+
 class ProtocolError(Exception):
     pass
 
@@ -48,7 +51,7 @@ class OlmTrustError(Exception):
 
 
 class OlmUnverifiedDeviceError(OlmTrustError):
-    def __init__(self, *args, unverified_device=None):
+    def __init__(self, unverified_device, *args):
         super().__init__(*args)
         self.device = unverified_device
 

--- a/nio/exceptions.py
+++ b/nio/exceptions.py
@@ -48,7 +48,7 @@ class OlmTrustError(Exception):
 
 
 class OlmUnverifiedDeviceError(OlmTrustError):
-    def __init__(self, *args: object, unverified_device: 'nio.OlmDevice') -> None:
+    def __init__(self, *args, unverified_device) -> None:
         super().__init__(*args)
         self.device = unverified_device
 

--- a/nio/exceptions.py
+++ b/nio/exceptions.py
@@ -48,7 +48,7 @@ class OlmTrustError(Exception):
 
 
 class OlmUnverifiedDeviceError(OlmTrustError):
-    def __init__(self, *args, unverified_device=None) -> None:
+    def __init__(self, *args, unverified_device=None):
         super().__init__(*args)
         self.device = unverified_device
 

--- a/nio/exceptions.py
+++ b/nio/exceptions.py
@@ -48,7 +48,7 @@ class OlmTrustError(Exception):
 
 
 class OlmUnverifiedDeviceError(OlmTrustError):
-    def __init__(self, *args, unverified_device) -> None:
+    def __init__(self, *args, unverified_device=None) -> None:
         super().__init__(*args)
         self.device = unverified_device
 


### PR DESCRIPTION
#61 

Decided to subclass because `OlmTrustError` doesn't always mean unverified devices afaict.