### PR TITLE
Add download API

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -1040,7 +1040,6 @@ class Api(object):
 
     @staticmethod
     def download(
-        access_token,       # type: str
         server_name,        # type: str
         media_id,           # type: str
         filename=None,      # type: Optional[str]
@@ -1052,7 +1051,6 @@ class Api(object):
         Returns the HTTP method and HTTP path for the request.
 
         Args:
-            access_token (str): The access token to be used with the request.
             server_name (str): The server name from the mxc:// URI.
             media_id (str): The media ID from the mxc:// URI.
             filename (str, optional): A filename to be returned in the response
@@ -1064,7 +1062,6 @@ class Api(object):
                 itself.
         """
         query_parameters = {
-            "access_token": access_token,
             "allow_remote": "true" if allow_remote else "false",
         }
         end = "/{}".format(filename) if filename else ""

--- a/nio/api.py
+++ b/nio/api.py
@@ -1039,6 +1039,43 @@ class Api(object):
         )
 
     @staticmethod
+    def download(
+        access_token,       # type: str
+        server_name,        # type: str
+        media_id,           # type: str
+        filename=None,      # type: Optional[str]
+        allow_remote=True,  # type: bool
+    ):
+        # type: (...) -> Tuple[str, str]
+        """Get the content of a file from the content repository.
+
+        Returns the HTTP method and HTTP path for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+            server_name (str): The server name from the mxc:// URI.
+            media_id (str): The media ID from the mxc:// URI.
+            filename (str, optional): A filename to be returned in the response
+                by the server. If None (default), the original name of the
+                file will be returned instead, if there is one.
+            allow_remote (bool): Indicates to the server that it should not
+                attempt to fetch the media if it is deemed remote.
+                This is to prevent routing loops where the server contacts
+                itself.
+        """
+        query_parameters = {
+            "access_token": access_token,
+            "allow_remote": "true" if allow_remote else "false",
+        }
+        end = "/{}".format(filename) if filename else ""
+        path = "download/{}/{}{}".format(server_name, media_id, end)
+
+        return (
+            "GET",
+            Api._build_path(path, query_parameters, MATRIX_MEDIA_API_PATH)
+        )
+
+    @staticmethod
     def thumbnail(
         access_token,                 # type: str
         server_name,                  # type: str

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1553,7 +1553,7 @@ class AsyncClient(Client):
             content_type=content_type
         )
 
-    @logged_in
+    @client_session
     async def download(
         self,
         server_name,        # type: str
@@ -1579,7 +1579,6 @@ class AsyncClient(Client):
                 itself.
         """
         http_method, path = Api.download(
-            self.access_token,
             server_name,
             media_id,
             filename,

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -637,7 +637,6 @@ class HttpClient(Client):
         ))
 
     @connected
-    @logged_in
     def download(
         self,
         server_name,        # type: str
@@ -664,7 +663,6 @@ class HttpClient(Client):
         """
         request = self._build_request(
             Api.download(
-                self.access_token,
                 server_name,
                 media_id,
                 filename,

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -44,6 +44,8 @@ __all__ = [
     "DevicesResponse",
     "DevicesError",
     "DeviceOneTimeKeyCount",
+    "DownloadResponse",
+    "DownloadError",
     "ErrorResponse",
     "InviteInfo",
     "JoinResponse",
@@ -250,19 +252,22 @@ class FileResponse(Response):
         body (bytes): The file's content in bytes.
         content_type (str): The content MIME type of the file,
             e.g. "image/png".
+        filename (str, optional): The file's name returned by the server.
     """
 
     body = attr.ib(type=bytes)
     content_type = attr.ib(type=str)
+    filename = attr.ib(type=Optional[str])
 
     def __str__(self):
-        return "{} bytes, content type: {}".format(
+        return "{} bytes, content type: {}, filename: {}".format(
             len(self.body),
-            self.content_type
+            self.content_type,
+            self.filename
         )
 
     @classmethod
-    def from_data(cls, data, content_type):
+    def from_data(cls, data, content_type, filename=None):
         """Create a FileResponse from file content returned by the server.
 
         Args:
@@ -411,6 +416,12 @@ class KeysClaimError(_ErrorWithRoomId):
 
 class UploadError(ErrorResponse):
     """A response representing a unsuccessful upload request."""
+
+    pass
+
+
+class DownloadError(ErrorResponse):
+    """A response representing a unsuccessful download request."""
 
     pass
 
@@ -570,14 +581,40 @@ class UploadResponse(Response):
 
 
 @attr.s
+class DownloadResponse(FileResponse):
+    """A response representing a successful download request."""
+
+    @classmethod
+    def from_data(
+            cls,
+            data,          # type: bytes
+            content_type,  # type: str
+            filename=None  # type: Optional[str]
+    ):
+        # type: (...) -> Union[DownloadResponse, DownloadError]
+        if isinstance(data, bytes):
+            return cls(body=data, content_type=content_type, filename=filename)
+
+        if isinstance(data, dict):
+            return DownloadError.from_dict(data)
+
+        return DownloadError("invalid data")
+
+
+@attr.s
 class ThumbnailResponse(FileResponse):
     """A response representing a successful thumbnail request."""
 
     @classmethod
-    def from_data(cls, data, content_type):
-        # type: (bytes, str) -> Union[ThumbnailResponse, ThumbnailError]
+    def from_data(
+            cls,
+            data,          # type: bytes
+            content_type,  # type: str
+            filename=None  # type: Optional[str]
+    ):
+        # type: (...) -> Union[ThumbnailResponse, ThumbnailError]
         if isinstance(data, bytes):
-            return cls(body=data, content_type=content_type)
+            return cls(body=data, content_type=content_type, filename=filename)
 
         if isinstance(data, dict):
             return ThumbnailError.from_dict(data)

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -849,18 +849,13 @@ class TestClass(object):
         assert isinstance(streaming_resp, UploadResponse)
 
     async def test_download(self, async_client, aioresponse):
-        await async_client.receive_response(
-            LoginResponse.from_dict(self.login_response)
-        )
-        assert async_client.logged_in
-
         server_name = "example.org"
         media_id = "ascERGshawAWawugaAcauga"
         filename = "example.png"
 
         aioresponse.get(
             "https://example.org/_matrix/media/r0/download/{}/{}"
-            "?access_token=abc123&allow_remote=true".format(
+            "?allow_remote=true".format(
                 server_name,
                 media_id,
             ),
@@ -875,7 +870,7 @@ class TestClass(object):
 
         aioresponse.get(
             "https://example.org/_matrix/media/r0/download/{}/{}/{}"
-            "?access_token=abc123&allow_remote=true".format(
+            "?allow_remote=true".format(
                 server_name,
                 media_id,
                 filename,
@@ -894,7 +889,7 @@ class TestClass(object):
 
         aioresponse.get(
             "https://example.org/_matrix/media/r0/download/{}/{}"
-            "?access_token=abc123&allow_remote=true".format(
+            "?allow_remote=true".format(
                 server_name,
                 media_id,
             ),

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -4,6 +4,7 @@ import re
 import time
 from os import path
 from datetime import datetime, timedelta
+from urllib.parse import quote
 
 import pytest
 
@@ -851,7 +852,7 @@ class TestClass(object):
     async def test_download(self, async_client, aioresponse):
         server_name = "example.org"
         media_id = "ascERGshawAWawugaAcauga"
-        filename = "example.png"
+        filename = "example&.png"  # has unsafe character to test % encoding
 
         aioresponse.get(
             "https://example.org/_matrix/media/r0/download/{}/{}"
@@ -873,7 +874,7 @@ class TestClass(object):
             "?allow_remote=true".format(
                 server_name,
                 media_id,
-                filename,
+                quote(filename),
             ),
             status=200,
             content_type="image/png",

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -804,21 +804,13 @@ class TestClass(object):
     def test_http_client_download(self, http_client):
         http_client.connect(TransportType.HTTP2)
 
-        _, _ = http_client.login("1234")
-
-        http_client.receive(self.login_byte_response)
-        response = http_client.next_response()
-
-        assert isinstance(response, LoginResponse)
-        assert http_client.access_token == "ABCD"
-
         server_name = "example.og"
         media_id = "ascERGshawAWawugaAcauga",
         filename = "example.png"
 
         _, _ = http_client.download(server_name, media_id, allow_remote=False)
 
-        http_client.receive(self.file_byte_response(3))
+        http_client.receive(self.file_byte_response(1))
         response = http_client.next_response()
 
         assert isinstance(response, DownloadResponse)
@@ -830,7 +822,7 @@ class TestClass(object):
 
         _, _ = http_client.download(server_name, media_id, filename)
 
-        http_client.receive(self.file_byte_response(5, header_filename=True))
+        http_client.receive(self.file_byte_response(3, header_filename=True))
         response = http_client.next_response()
 
         assert isinstance(response, DownloadResponse)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -95,7 +95,7 @@ class TestClass(object):
 
         return f.serialize() + data.serialize()
 
-    def file_byte_response(self, stream_id=5, header_filename=False):
+    def file_byte_response(self, stream_id=5, header_filename=""):
         frame_factory = FrameFactory()
 
         headers = self.example_response_headers + [
@@ -104,7 +104,10 @@ class TestClass(object):
 
         if header_filename:
             headers.append(
-                ("content-disposition", 'inline; filename="example.png"')
+                (
+                    "content-disposition",
+                    'inline; filename="{}"'.format(header_filename),
+                ),
             )
 
         f = frame_factory.build_headers_frame(
@@ -806,7 +809,7 @@ class TestClass(object):
 
         server_name = "example.og"
         media_id = "ascERGshawAWawugaAcauga",
-        filename = "example.png"
+        filename = "example&.png"  # has unsafe character to test % encoding
 
         _, _ = http_client.download(server_name, media_id, allow_remote=False)
 
@@ -822,7 +825,7 @@ class TestClass(object):
 
         _, _ = http_client.download(server_name, media_id, filename)
 
-        http_client.receive(self.file_byte_response(3, header_filename=True))
+        http_client.receive(self.file_byte_response(3, filename))
         response = http_client.next_response()
 
         assert isinstance(response, DownloadResponse)

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import json
 
 from nio.responses import (DeleteDevicesAuthResponse, DevicesResponse,
+                           DownloadResponse, DownloadError,
                            ErrorResponse, JoinedMembersError,
                            JoinedMembersResponse, JoinResponse,
                            KeysClaimResponse,
@@ -116,6 +117,22 @@ class TestClass(object):
             "tests/data/upload_response.json")
         response = UploadResponse.from_dict(parsed_dict)
         assert isinstance(response, UploadResponse)
+
+    def test_download(self):
+        data = TestClass._load_bytes("tests/data/file_response")
+        response = DownloadResponse.from_data(data, "image/png", "example.png")
+        assert isinstance(response, DownloadResponse)
+        assert response.body == data
+        assert response.content_type == "image/png"
+        assert response.filename == "example.png"
+
+        data = TestClass._load_response("tests/data/limit_exceeded_error.json")
+        response = DownloadResponse.from_data(data, "image/png")
+        assert isinstance(response, DownloadError)
+        assert response.status_code == data["errcode"]
+
+        response = DownloadResponse.from_data("123", "image/png")
+        assert isinstance(response, DownloadError)
 
     def test_thumbnail(self):
         data = TestClass._load_bytes("tests/data/file_response")


### PR DESCRIPTION
This adds support in the http and async clients for the two download API: [normal](https://matrix.org/docs/spec/client_server/latest#get-matrix-media-r0-download-servername-mediaid) and [with filename](https://matrix.org/docs/spec/client_server/latest#get-matrix-media-r0-download-servername-mediaid-filename).