### PR TITLE
Add createRoom API 

### DIFF
--- a/nio/__init__.py
+++ b/nio/__init__.py
@@ -1,6 +1,8 @@
 from .log import logger_group
 from .client import *
-from .api import MessageDirection, Api
+from .api import (
+    MessageDirection, Api, ResizingMethod, RoomVisibility, RoomPreset
+)
 from .responses import *
 from .events import *
 from .rooms import *

--- a/nio/api.py
+++ b/nio/api.py
@@ -517,7 +517,7 @@ class Api(object):
 
             visibility (RoomVisibility): whether to have the room published in
                 the server's room directory or not.
-                Defaults to RoomVisibility.Private.
+                Defaults to ``RoomVisibility.Private``.
 
             alias (str, optional): The desired canonical alias local part.
                 For example, if set to "foo" and the room is created on the
@@ -531,36 +531,37 @@ class Api(object):
             room_version (str, optional): The room version to set.
                 If not specified, the homeserver will use its default setting.
                 If a version not supported by the homeserver is specified,
-                a 400 M_UNSUPPORTED_ROOM_VERSION error will be returned.
+                a 400 ``M_UNSUPPORTED_ROOM_VERSION`` error will be returned.
 
             federate (bool): Whether to allow users from other homeservers from
-                joining the room. Defaults to True. Cannot be changed later.
+                joining the room. Defaults to ``True``.
+                Cannot be changed later.
 
             is_direct (bool): If this should be considered a
                 direct messaging room.
-                If True, the server will set the is_direct flag on
-                m.room.member events sent to the users in
-                invite and invite_3pid.
-                Defaults to False.
+                If ``True``, the server will set the ``is_direct`` flag on
+                ``m.room.member events`` sent to the users in ``invite``.
+                Defaults to ``False``.
 
             preset (RoomPreset, optional): The selected preset will set various
                 rules for the room.
                 If unspecified, the server will choose a preset from the
-                visibility: RoomVisibility.public equates to
-                RoomPreset.public_chat, and RoomVisibility.private equates to a
-                RoomPreset.private_chat.
+                ``visibility``: ``RoomVisibility.public`` equates to
+                ``RoomPreset.public_chat``, and
+                ``RoomVisibility.private`` equates to a
+                ``RoomPreset.private_chat``.
 
             invite (list): A list of user id to invite to the room.
 
             initial_state (list): A list of state event dicts to send when
                 the room is created.
                 For example, a room could be made encrypted immediatly by
-                having a m.room.encryption event dict.
+                having a ``m.room.encryption`` event dict.
 
-            power_level_override (dict): A m.room.power_levels content dict to
-                override the default.
+            power_level_override (dict): A ``m.room.power_levels content`` dict
+                to override the default.
                 The dict will be applied on top of the generated
-                m.room.power_levels event before it is sent to the room.
+                ``m.room.power_levels`` event before it is sent to the room.
         """
         path = "createRoom"
         query_parameters = {"access_token": access_token}

--- a/nio/api.py
+++ b/nio/api.py
@@ -25,8 +25,8 @@ from __future__ import unicode_literals
 import json
 from collections import defaultdict
 from enum import Enum, unique
-from typing import (Any, Collection, DefaultDict, Dict, Iterable, List,
-                    Optional, Set, Tuple, Union)
+from typing import (Any, DefaultDict, Dict, Iterable, List,
+                    Optional, Set, Sequence, Tuple, Union)
 
 from .exceptions import LocalProtocolError
 from .http import Http2Request, HttpRequest, TransportRequest
@@ -503,8 +503,8 @@ class Api(object):
         federate=True,                      # type: bool
         is_direct=False,                    # type: bool
         preset=None,                        # type: Optional[RoomPreset]
-        invite=(),                          # type: Collection[str]
-        initial_state=(),                   # type: Collection[Dict[str, Any]]
+        invite=(),                          # type: Sequence[str]
+        initial_state=(),                   # type: Sequence[Dict[str, Any]]
         power_level_override=None,          # type: Optional[Dict[str, Any]]
     ):
         # type (...) -> Tuple[str, str, str]

--- a/nio/api.py
+++ b/nio/api.py
@@ -25,8 +25,8 @@ from __future__ import unicode_literals
 import json
 from collections import defaultdict
 from enum import Enum, unique
-from typing import (Any, DefaultDict, Dict, Iterable, List, Optional, Set,
-                    Tuple, Union)
+from typing import (Any, Collection, DefaultDict, Dict, Iterable, List,
+                    Optional, Set, Tuple, Union)
 
 from .exceptions import LocalProtocolError
 from .http import Http2Request, HttpRequest, TransportRequest
@@ -63,6 +63,36 @@ class ResizingMethod(Enum):
 
     scale = "scale"
     crop = "crop"
+
+
+@unique
+class RoomVisibility(Enum):
+    """Enum representing the desired visibility when creating a room.
+
+    "public" means the room will be shown in the server's room directory.
+    "private" will hide the room from the server's room directory.
+    """
+
+    private = "private"
+    public = "public"
+
+
+@unique
+class RoomPreset(Enum):
+    """Enum representing the available rule presets when creating a room.
+
+    "private_chat" makes the room invite-only and allows guests.
+
+    "trusted_private_chat" is the same as above, but also gives all invitees
+    the same power level as the room's creator.
+
+    "public_chat" makes the room joinable by anyone without invitations, and
+    forbid guests.
+    """
+
+    private_chat = "private_chat"
+    trusted_private_chat = "trusted_private_chat"
+    public_chat = "public_chat"
 
 
 class Api(object):
@@ -455,6 +485,115 @@ class Api(object):
         query_parameters = {"access_token": access_token}
         body = {"user_id": user_id}
         path = "rooms/{room}/invite".format(room=room_id)
+
+        return (
+            "POST",
+            Api._build_path(path, query_parameters),
+            Api.to_json(body)
+        )
+
+    @staticmethod
+    def room_create(
+        access_token,                       # type: str
+        visibility=RoomVisibility.private,  # type: RoomVisibility
+        alias=None,                         # type: Optional[str]
+        name=None,                          # type: Optional[str]
+        topic=None,                         # type: Optional[str]
+        room_version=None,                  # type: Optional[str]
+        federate=True,                      # type: bool
+        is_direct=False,                    # type: bool
+        preset=None,                        # type: Optional[RoomPreset]
+        invite=(),                          # type: Collection[str]
+        initial_state=(),                   # type: Collection[Dict[str, Any]]
+        power_level_override=None,          # type: Optional[Dict[str, Any]]
+    ):
+        # type (...) -> Tuple[str, str, str]
+        """Create a new room.
+
+        Returns the HTTP method, HTTP path and data for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+
+            visibility (RoomVisibility): whether to have the room published in
+                the server's room directory or not.
+                Defaults to RoomVisibility.Private.
+
+            alias (str, optional): The desired canonical alias local part.
+                For example, if set to "foo" and the room is created on the
+                "example.com" server, the room alias will be
+                "#foo:example.com".
+
+            name (str, optional): A name to set for the room.
+
+            topic (str, optional): A topic to set for the room.
+
+            room_version (str, optional): The room version to set.
+                If not specified, the homeserver will use its default setting.
+                If a version not supported by the homeserver is specified,
+                a 400 M_UNSUPPORTED_ROOM_VERSION error will be returned.
+
+            federate (bool): Whether to allow users from other homeservers from
+                joining the room. Defaults to True. Cannot be changed later.
+
+            is_direct (bool): If this should be considered a
+                direct messaging room.
+                If True, the server will set the is_direct flag on
+                m.room.member events sent to the users in
+                invite and invite_3pid.
+                Defaults to False.
+
+            preset (RoomPreset, optional): The selected preset will set various
+                rules for the room.
+                If unspecified, the server will choose a preset from the
+                visibility: RoomVisibility.public equates to
+                RoomPreset.public_chat, and RoomVisibility.private equates to a
+                RoomPreset.private_chat.
+
+            invite (list): A list of user id to invite to the room.
+
+            initial_state (list): A list of state event dicts to send when
+                the room is created.
+                For example, a room could be made encrypted immediatly by
+                having a m.room.encryption event dict.
+
+            power_level_override (dict): A m.room.power_levels content dict to
+                override the default.
+                The dict will be applied on top of the generated
+                m.room.power_levels event before it is sent to the room.
+        """
+        path = "createRoom"
+        query_parameters = {"access_token": access_token}
+
+        body = {
+            "visibility": visibility.value,
+            "creation_content": {"m.federate": federate},
+            "is_direct": is_direct,
+        }
+
+        if alias:
+            body["room_alias_name"] = alias
+
+        if name:
+            body["name"] = name
+
+        if topic:
+            body["topic"] = topic
+
+        if room_version:
+            body["room_version"] = room_version
+
+        if preset:
+            body["preset"] = preset.value
+
+        if invite:
+            body["invite"] = list(invite)
+
+        if initial_state:
+            body["initial_state"] = list(initial_state)
+
+        if power_level_override:
+            body["power_level_content_override"] = power_level_override
 
         return (
             "POST",

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1243,7 +1243,7 @@ class AsyncClient(Client):
             if self.olm.inbound_group_store.add(session):
                 self.store.save_inbound_group_session(session)
 
-    @store_loaded
+    @logged_in
     async def room_create(
         self,
         visibility:           RoomVisibility           = RoomVisibility.private,
@@ -1264,8 +1264,6 @@ class AsyncClient(Client):
         a `RoomCreateError` if there was an error with the request.
 
         Args:
-            access_token (str): The access token to be used with the request.
-
             visibility (RoomVisibility): whether to have the room published in
                 the server's room directory or not.
                 Defaults to ``RoomVisibility.Private``.
@@ -1331,7 +1329,6 @@ class AsyncClient(Client):
         )
 
         return await self._send(RoomCreateResponse, method, path, data)
-
 
     @logged_in
     async def join(self, room_id):

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1264,9 +1264,11 @@ class AsyncClient(Client):
         a `RoomCreateError` if there was an error with the request.
 
         Args:
+            access_token (str): The access token to be used with the request.
+
             visibility (RoomVisibility): whether to have the room published in
                 the server's room directory or not.
-                Defaults to RoomVisibility.Private.
+                Defaults to ``RoomVisibility.Private``.
 
             alias (str, optional): The desired canonical alias local part.
                 For example, if set to "foo" and the room is created on the
@@ -1280,36 +1282,37 @@ class AsyncClient(Client):
             room_version (str, optional): The room version to set.
                 If not specified, the homeserver will use its default setting.
                 If a version not supported by the homeserver is specified,
-                a 400 M_UNSUPPORTED_ROOM_VERSION error will be returned.
+                a 400 ``M_UNSUPPORTED_ROOM_VERSION`` error will be returned.
 
             federate (bool): Whether to allow users from other homeservers from
-                joining the room. Defaults to True. Cannot be changed later.
+                joining the room. Defaults to ``True``.
+                Cannot be changed later.
 
             is_direct (bool): If this should be considered a
                 direct messaging room.
-                If True, the server will set the is_direct flag on
-                m.room.member events sent to the users in
-                invite and invite_3pid.
-                Defaults to False.
+                If ``True``, the server will set the ``is_direct`` flag on
+                ``m.room.member events`` sent to the users in ``invite``.
+                Defaults to ``False``.
 
             preset (RoomPreset, optional): The selected preset will set various
                 rules for the room.
                 If unspecified, the server will choose a preset from the
-                visibility: RoomVisibility.public equates to
-                RoomPreset.public_chat, and RoomVisibility.private equates to a
-                RoomPreset.private_chat.
+                ``visibility``: ``RoomVisibility.public`` equates to
+                ``RoomPreset.public_chat``, and
+                ``RoomVisibility.private`` equates to a
+                ``RoomPreset.private_chat``.
 
             invite (list): A list of user id to invite to the room.
 
             initial_state (list): A list of state event dicts to send when
                 the room is created.
                 For example, a room could be made encrypted immediatly by
-                having a m.room.encryption event dict.
+                having a ``m.room.encryption`` event dict.
 
-            power_level_override (dict): A m.room.power_levels content dict to
-                override the default.
+            power_level_override (dict): A ``m.room.power_levels content`` dict
+                to override the default.
                 The dict will be applied on top of the generated
-                m.room.power_levels event before it is sent to the room.
+                ``m.room.power_levels`` event before it is sent to the room.
         """
 
         method, path, data = Api.room_create(

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -19,8 +19,8 @@ import warnings
 from asyncio import Event
 from functools import partial, wraps
 from json.decoder import JSONDecodeError
-from typing import (Any, AsyncIterable, BinaryIO, Collection, Coroutine, Dict,
-                    Iterable, List, Optional, Tuple, Type, Union)
+from typing import (Any, AsyncIterable, BinaryIO, Coroutine, Dict,
+                    Iterable, List, Optional, Sequence, Tuple, Type, Union)
 from uuid import uuid4
 
 import attr
@@ -1246,17 +1246,17 @@ class AsyncClient(Client):
     @store_loaded
     async def room_create(
         self,
-        visibility:           RoomVisibility             = RoomVisibility.private,
-        alias:                Optional[str]              = None,
-        name:                 Optional[str]              = None,
-        topic:                Optional[str]              = None,
-        room_version:         Optional[str]              = None,
-        federate:             bool                       = True,
-        is_direct:            bool                       = False,
-        preset:               Optional[RoomPreset]       = None,
-        invite:               Collection[str]            = (),
-        initial_state:        Collection[Dict[str, Any]] = (),
-        power_level_override: Optional[Dict[str, Any]]   = None,
+        visibility:           RoomVisibility           = RoomVisibility.private,
+        alias:                Optional[str]            = None,
+        name:                 Optional[str]            = None,
+        topic:                Optional[str]            = None,
+        room_version:         Optional[str]            = None,
+        federate:             bool                     = True,
+        is_direct:            bool                     = False,
+        preset:               Optional[RoomPreset]     = None,
+        invite:               Sequence[str]            = (),
+        initial_state:        Sequence[Dict[str, Any]] = (),
+        power_level_override: Optional[Dict[str, Any]] = None,
     ) -> Union[RoomCreateResponse, RoomCreateError]:
         """Create a new room.
 

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -400,9 +400,11 @@ class HttpClient(Client):
         should be sent to the socket.
 
         Args:
+            access_token (str): The access token to be used with the request.
+
             visibility (RoomVisibility): whether to have the room published in
                 the server's room directory or not.
-                Defaults to RoomVisibility.Private.
+                Defaults to ``RoomVisibility.Private``.
 
             alias (str, optional): The desired canonical alias local part.
                 For example, if set to "foo" and the room is created on the
@@ -416,36 +418,37 @@ class HttpClient(Client):
             room_version (str, optional): The room version to set.
                 If not specified, the homeserver will use its default setting.
                 If a version not supported by the homeserver is specified,
-                a 400 M_UNSUPPORTED_ROOM_VERSION error will be returned.
+                a 400 ``M_UNSUPPORTED_ROOM_VERSION`` error will be returned.
 
             federate (bool): Whether to allow users from other homeservers from
-                joining the room. Defaults to True. Cannot be changed later.
+                joining the room. Defaults to ``True``.
+                Cannot be changed later.
 
             is_direct (bool): If this should be considered a
                 direct messaging room.
-                If True, the server will set the is_direct flag on
-                m.room.member events sent to the users in
-                invite and invite_3pid.
-                Defaults to False.
+                If ``True``, the server will set the ``is_direct`` flag on
+                ``m.room.member events`` sent to the users in ``invite``.
+                Defaults to ``False``.
 
             preset (RoomPreset, optional): The selected preset will set various
                 rules for the room.
                 If unspecified, the server will choose a preset from the
-                visibility: RoomVisibility.public equates to
-                RoomPreset.public_chat, and RoomVisibility.private equates to a
-                RoomPreset.private_chat.
+                ``visibility``: ``RoomVisibility.public`` equates to
+                ``RoomPreset.public_chat``, and
+                ``RoomVisibility.private`` equates to a
+                ``RoomPreset.private_chat``.
 
             invite (list): A list of user id to invite to the room.
 
             initial_state (list): A list of state event dicts to send when
                 the room is created.
                 For example, a room could be made encrypted immediatly by
-                having a m.room.encryption event dict.
+                having a ``m.room.encryption`` event dict.
 
-            power_level_override (dict): A m.room.power_levels content dict to
-                override the default.
+            power_level_override (dict): A ``m.room.power_levels content`` dict
+                to override the default.
                 The dict will be applied on top of the generated
-                m.room.power_levels event before it is sent to the room.
+                ``m.room.power_levels`` event before it is sent to the room.
         """
 
         request = self._build_request(Api.room_create(

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -400,8 +400,6 @@ class HttpClient(Client):
         should be sent to the socket.
 
         Args:
-            access_token (str): The access token to be used with the request.
-
             visibility (RoomVisibility): whether to have the room published in
                 the server's room directory or not.
                 Defaults to ``RoomVisibility.Private``.
@@ -467,7 +465,6 @@ class HttpClient(Client):
         ))
 
         return self._send(request, RequestInfo(RoomCreateResponse))
-
 
     @connected
     @logged_in

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -19,7 +19,7 @@ import pprint
 from builtins import str, super
 from collections import deque
 from functools import wraps
-from typing import (Any, Collection, Deque, Dict, List, Tuple, Type,
+from typing import (Any, Deque, Dict, List, Sequence, Tuple, Type,
                     Union, Optional)
 from uuid import UUID, uuid4
 
@@ -389,8 +389,8 @@ class HttpClient(Client):
         federate=True,                      # type: bool
         is_direct=False,                    # type: bool
         preset=None,                        # type: Optional[RoomPreset]
-        invite=(),                          # type: Collection[str]
-        initial_state=(),                   # type: Collection[Dict[str, Any]]
+        invite=(),                          # type: Sequence[str]
+        initial_state=(),                   # type: Sequence[Dict[str, Any]]
         power_level_override=None,          # type: Optional[Dict[str, Any]]
     ):
         # type: (...) -> Tuple[UUID, bytes]

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -19,7 +19,8 @@ import pprint
 from builtins import str, super
 from collections import deque
 from functools import wraps
-from typing import Any, Deque, Dict, List, Optional, Tuple, Type, Union
+from typing import (Any, Collection, Deque, Dict, List, Tuple, Type,
+                    Union, Optional)
 from uuid import UUID, uuid4
 
 import attr
@@ -35,7 +36,8 @@ except ImportError:
 
 from . import Client, ClientConfig
 from .base_client import logged_in, store_loaded
-from ..api import Api, MessageDirection, ResizingMethod
+from ..api import (Api, MessageDirection, ResizingMethod, RoomVisibility,
+                   RoomPreset)
 from ..events import MegolmEvent
 from ..exceptions import LocalProtocolError, RemoteTransportError
 from ..http import (Http2Connection, Http2Request, HttpConnection, HttpRequest,
@@ -50,6 +52,7 @@ from ..responses import (DeleteDevicesAuthResponse, DeleteDevicesResponse,
                          ProfileGetDisplayNameResponse, ProfileGetResponse,
                          ProfileSetAvatarResponse,
                          ProfileSetDisplayNameResponse, Response,
+                         RoomCreateResponse,
                          RoomForgetResponse, RoomInviteResponse,
                          RoomKeyRequestResponse, RoomKickResponse,
                          RoomLeaveResponse, RoomMessagesResponse,
@@ -373,6 +376,95 @@ class HttpClient(Client):
         )
 
         return self._send(request, RequestInfo(RoomInviteResponse))
+
+    @connected
+    @logged_in
+    def room_create(
+        self,
+        visibility=RoomVisibility.private,  # type: RoomVisibility
+        alias=None,                         # type: Optional[str]
+        name=None,                          # type: Optional[str]
+        topic=None,                         # type: Optional[str]
+        room_version=None,                  # type: Optional[str]
+        federate=True,                      # type: bool
+        is_direct=False,                    # type: bool
+        preset=None,                        # type: Optional[RoomPreset]
+        invite=(),                          # type: Collection[str]
+        initial_state=(),                   # type: Collection[Dict[str, Any]]
+        power_level_override=None,          # type: Optional[Dict[str, Any]]
+    ):
+        # type: (...) -> Tuple[UUID, bytes]
+        """Create a new room.
+
+        Returns a unique uuid that identifies the request and the bytes that
+        should be sent to the socket.
+
+        Args:
+            visibility (RoomVisibility): whether to have the room published in
+                the server's room directory or not.
+                Defaults to RoomVisibility.Private.
+
+            alias (str, optional): The desired canonical alias local part.
+                For example, if set to "foo" and the room is created on the
+                "example.com" server, the room alias will be
+                "#foo:example.com".
+
+            name (str, optional): A name to set for the room.
+
+            topic (str, optional): A topic to set for the room.
+
+            room_version (str, optional): The room version to set.
+                If not specified, the homeserver will use its default setting.
+                If a version not supported by the homeserver is specified,
+                a 400 M_UNSUPPORTED_ROOM_VERSION error will be returned.
+
+            federate (bool): Whether to allow users from other homeservers from
+                joining the room. Defaults to True. Cannot be changed later.
+
+            is_direct (bool): If this should be considered a
+                direct messaging room.
+                If True, the server will set the is_direct flag on
+                m.room.member events sent to the users in
+                invite and invite_3pid.
+                Defaults to False.
+
+            preset (RoomPreset, optional): The selected preset will set various
+                rules for the room.
+                If unspecified, the server will choose a preset from the
+                visibility: RoomVisibility.public equates to
+                RoomPreset.public_chat, and RoomVisibility.private equates to a
+                RoomPreset.private_chat.
+
+            invite (list): A list of user id to invite to the room.
+
+            initial_state (list): A list of state event dicts to send when
+                the room is created.
+                For example, a room could be made encrypted immediatly by
+                having a m.room.encryption event dict.
+
+            power_level_override (dict): A m.room.power_levels content dict to
+                override the default.
+                The dict will be applied on top of the generated
+                m.room.power_levels event before it is sent to the room.
+        """
+
+        request = self._build_request(Api.room_create(
+            self.access_token,
+            visibility           = visibility,
+            alias                = alias,
+            name                 = name,
+            topic                = topic,
+            room_version         = room_version,
+            federate             = federate,
+            is_direct            = is_direct,
+            preset               = preset,
+            invite               = invite,
+            initial_state        = initial_state,
+            power_level_override = power_level_override,
+        ))
+
+        return self._send(request, RequestInfo(RoomCreateResponse))
+
 
     @connected
     @logged_in

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -63,6 +63,8 @@ __all__ = [
     "LogoutResponse",
     "LogoutError",
     "Response",
+    "RoomCreateResponse",
+    "RoomCreateError",
     "RoomInfo",
     "RoomInviteResponse",
     "RoomInviteError",
@@ -371,6 +373,11 @@ class RoomKickError(ErrorResponse):
 
 
 class RoomInviteError(ErrorResponse):
+    pass
+
+
+class RoomCreateError(ErrorResponse):
+    """A response representing a unsuccessful create room request."""
     pass
 
 
@@ -784,6 +791,13 @@ class RoomIdResponse(Response):
             return cls.create_error(parsed_dict)
 
         return cls(parsed_dict["room_id"])
+
+
+class RoomCreateResponse(RoomIdResponse):
+    """Response representing a successful create room request."""
+    @staticmethod
+    def create_error(parsed_dict):
+        return RoomCreateError.from_dict(parsed_dict)
 
 
 class JoinResponse(RoomIdResponse):

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -139,7 +139,7 @@ class TestClass(object):
             headers=self.example_response_headers, stream_id=stream_id
         )
 
-        body = bytes(json.dumps({"room_id": room_id}), "utf-8")
+        body = json.dumps({"room_id": room_id}).encode()
 
         data = frame_factory.build_data_frame(
             data=body,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -10,6 +10,7 @@ from nio import (Client, DeviceList, DeviceOneTimeKeyCount, EncryptionError,
                  LogoutResponse, MegolmEvent, ProfileGetAvatarResponse,
                  ProfileGetDisplayNameResponse, ProfileGetResponse,
                  ProfileSetAvatarResponse, ProfileSetDisplayNameResponse,
+                 RoomCreateResponse,
                  RoomEncryptionEvent, RoomForgetResponse, RoomInfo,
                  RoomKeyRequestResponse, RoomMember, RoomMemberEvent, Rooms,
                  RoomSummary, RoomTypingResponse,
@@ -122,6 +123,23 @@ class TestClass(object):
         )
 
         body = b"{}"
+
+        data = frame_factory.build_data_frame(
+            data=body,
+            stream_id=stream_id,
+            flags=['END_STREAM']
+        )
+
+        return f.serialize() + data.serialize()
+
+    def room_id_response(self, stream_id=5, room_id=TEST_ROOM_ID):
+        frame_factory = FrameFactory()
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers, stream_id=stream_id
+        )
+
+        body = bytes(json.dumps({"room_id": room_id}), "utf-8")
 
         data = frame_factory.build_data_frame(
             data=body,
@@ -692,6 +710,33 @@ class TestClass(object):
         assert isinstance(response, RoomKeyRequestResponse)
         assert ("X3lUlvLELLYxeTx4yOVu6UDpasGEVO0Jbu+QFnm0cKQ" in
                 http_client.outgoing_key_requests)
+
+    def test_http_client_room_create(self, http_client):
+        http_client.connect(TransportType.HTTP2)
+
+        _, _ = http_client.login("1234")
+
+        http_client.receive(self.login_byte_response)
+        response = http_client.next_response()
+
+        assert isinstance(response, LoginResponse)
+        assert http_client.access_token == "ABCD"
+
+        _, _ = http_client.sync()
+
+        http_client.receive(self.sync_byte_response)
+        response = http_client.next_response()
+
+        assert isinstance(response, SyncResponse)
+        assert http_client.access_token == "ABCD"
+
+        _, _ = http_client.room_create()
+
+        http_client.receive(self.room_id_response(5))
+        response = http_client.next_response()
+
+        assert isinstance(response, RoomCreateResponse)
+        assert response.room_id == TEST_ROOM_ID
 
     def test_http_client_room_forget(self, http_client):
         http_client.connect(TransportType.HTTP2)

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -13,7 +13,7 @@ from nio.responses import (DeleteDevicesAuthResponse, DevicesResponse,
                            PartialSyncResponse, ProfileGetAvatarResponse,
                            ProfileGetDisplayNameResponse, ProfileGetResponse,
                            RoomContextError, RoomContextResponse,
-                           RoomForgetResponse,
+                           RoomCreateResponse, RoomForgetResponse,
                            RoomKeyRequestError, RoomKeyRequestResponse,
                            RoomLeaveResponse, RoomMessagesResponse,
                            RoomTypingResponse, SyncError,
@@ -249,6 +249,12 @@ class TestClass(object):
         assert isinstance(response2, _ErrorWithRoomId)
         assert response.retry_after_ms == parsed_dict["retry_after_ms"]
         assert response2.room_id == room_id
+
+    def test_room_create(self):
+        parsed_dict = TestClass._load_response(
+            "tests/data/room_id.json")
+        response = RoomCreateResponse.from_dict(parsed_dict)
+        assert isinstance(response, RoomCreateResponse)
 
     def test_join(self):
         parsed_dict = TestClass._load_response(


### PR DESCRIPTION
This adds support for the [createRoom API](https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-createroom), with the exception of the `invite_3pid` key.