### PR TITLE
Add event builders

### DIFF
--- a/nio/__init__.py
+++ b/nio/__init__.py
@@ -5,3 +5,4 @@ from .responses import *
 from .events import *
 from .rooms import *
 from .exceptions import *
+from .event_builders import *

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -33,7 +33,7 @@ from ..api import Api, MessageDirection, ResizingMethod
 from ..exceptions import (GroupEncryptionError, LocalProtocolError,
                           MembersSyncError, SendRetryError)
 from ..events import RoomKeyRequest, RoomKeyRequestCancellation
-from ..messages import ToDeviceMessage
+from ..event_builders import ToDeviceMessage
 from ..responses import (ErrorResponse, FileResponse,
                          JoinResponse, JoinError,
                          JoinedMembersError, JoinedMembersResponse,

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -45,7 +45,7 @@ if ENCRYPTION_ENABLED:
 
 if False:
     from ..crypto import OlmDevice, OutgoingKeyRequest, Sas
-    from ..messages import ToDeviceMessage
+    from ..event_builders import ToDeviceMessage
 
 try:
     from json.decoder import JSONDecodeError

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -61,7 +61,7 @@ from ..responses import (DeleteDevicesAuthResponse, DeleteDevicesResponse,
                          LoginInfoResponse)
 
 if False:
-    from .messages import ToDeviceMessage
+    from .event_builders import ToDeviceMessage
     from .crypto import OlmDevice
 
 try:

--- a/nio/crypto/sas.py
+++ b/nio/crypto/sas.py
@@ -28,7 +28,7 @@ from future.moves.itertools import zip_longest
 from ..api import Api
 from ..events import KeyVerificationStart
 from ..exceptions import LocalProtocolError
-from ..messages import ToDeviceMessage
+from ..event_builders import ToDeviceMessage
 from .sessions import OlmDevice
 
 

--- a/nio/crypto/sessions.py
+++ b/nio/crypto/sessions.py
@@ -24,7 +24,7 @@ import attr
 import olm
 
 from ..exceptions import EncryptionError
-from ..messages import ToDeviceMessage
+from ..event_builders import ToDeviceMessage
 
 if False:
     from ..responses import RoomKeyRequestResponse

--- a/nio/event_builders/__init__.py
+++ b/nio/event_builders/__init__.py
@@ -1,0 +1,10 @@
+"""Nio Event Builders Module.
+
+This module provides classes to easily create content dictionaries that
+can be used with ``Api.room_send()``, ``HttpClient.room_send()`` or
+``AsyncClient.room_send()``.
+It also provides lasses for some direct events such as to-device messages.
+"""
+
+from .state_events import *
+from .direct_messages import *

--- a/nio/event_builders/__init__.py
+++ b/nio/event_builders/__init__.py
@@ -1,9 +1,9 @@
 """Nio Event Builders Module.
 
-This module provides classes to easily create content dictionaries that
-can be used with ``Api.room_send()``, ``HttpClient.room_send()`` or
-``AsyncClient.room_send()``.
-It also provides lasses for some direct events such as to-device messages.
+This module provides classes to easily create event dictionaries that
+can be used with the clients's ``room_send()`` method, or ``room_create()``'s
+``inital_state`` argument.
+It also provides classes for some direct events such as to-device messages.
 """
 
 from .state_events import *

--- a/nio/event_builders/direct_messages.py
+++ b/nio/event_builders/direct_messages.py
@@ -19,13 +19,10 @@ from typing import Dict
 import attr
 
 
-"""Matrix messages module.
+"""Matrix direct messages module.
 
-This module contains classes that can be used to send events to a Matrix
+This module contains classes that can be used to send direct events to a Matrix
 homeserver.
-
-They ease the creation of a propper message structure.
-
 """
 
 

--- a/nio/event_builders/state_events.py
+++ b/nio/event_builders/state_events.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright © 2018, 2019 Damir Jelić <poljar@termina.org.uk>
+# Copyright © 2019 miruka <miruka@disroot.org>
 #
 # Permission to use, copy, modify, and/or distribute this software for
 # any purpose with or without fee is hereby granted, provided that the

--- a/nio/event_builders/state_events.py
+++ b/nio/event_builders/state_events.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018, 2019 Damir Jelić <poljar@termina.org.uk>
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+# CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import attr
+
+
+"""Matrix state events module.
+
+This module contains classes that can be used to easily create
+content dicts for room state events.
+
+For example, to turn on encryption in a room with the ``AsyncClient``, the
+``EnableEncryptionBuilder`` class could be used:
+
+    >>> client.room_send(
+    ...     room_id      = "!test:example.com",
+    ...     message_type = "m.room.encryption",
+    ...     content      = EnableEncryptionBuilder().as_dict(),
+    ... )
+"""
+
+
+@attr.s
+class EnableEncryptionBuilder(object):
+    """A state event that can be sent to enable encryption in a room.
+
+    Attributes:
+        algorithm (str): The algorithm to use for encrypting messages.
+            The default ``m.megolm.v1.aes-sha2`` should not be changed.
+
+        rotation_ms (int): How long in milliseconds an encrypted session
+            should be used before changing it.
+            The default ``604800000`` (a week) is recommended.
+
+        rotation_msgs (int): How many messages can be received in a room before
+            changing the encrypted session.
+            The default ``100`` is recommended.
+
+    """
+
+    algorithm     = attr.ib(type=str, default="m.megolm.v1.aes-sha2")
+    rotation_ms   = attr.ib(type=int, default=604800000)
+    rotation_msgs = attr.ib(type=int, default=100)
+
+    def as_dict(self):
+        """Format the event as a content dictionary."""
+        return {
+            "algorithm":            self.algorithm,
+            "rotation_period_ms":   self.rotation_ms,
+            "rotation_period_msgs": self.rotation_msgs,
+        }

--- a/nio/event_builders/state_events.py
+++ b/nio/event_builders/state_events.py
@@ -20,15 +20,16 @@ import attr
 """Matrix state events module.
 
 This module contains classes that can be used to easily create
-content dicts for room state events.
+room state event dicts.
 
-For example, to turn on encryption in a room with the ``AsyncClient``, the
-``EnableEncryptionBuilder`` class could be used:
+For example, to turn on encryption in a room with the ``HttpClient`` or
+``AsyncClient``, the ``EnableEncryptionBuilder`` class can be used:
 
+    >>> event_dict = EnableEncryptionBuilder().as_dict()
     >>> client.room_send(
     ...     room_id      = "!test:example.com",
-    ...     message_type = "m.room.encryption",
-    ...     content      = EnableEncryptionBuilder().as_dict(),
+    ...     message_type = event_dict["type"],
+    ...     content      = event_dict["content"],
     ... )
 """
 
@@ -56,9 +57,13 @@ class EnableEncryptionBuilder(object):
     rotation_msgs = attr.ib(type=int, default=100)
 
     def as_dict(self):
-        """Format the event as a content dictionary."""
+        """Format the event as a dictionary."""
         return {
-            "algorithm":            self.algorithm,
-            "rotation_period_ms":   self.rotation_ms,
-            "rotation_period_msgs": self.rotation_msgs,
+            "type":      "m.room.encryption",
+            "state_key": "",
+            "content":   {
+                "algorithm":            self.algorithm,
+                "rotation_period_ms":   self.rotation_ms,
+                "rotation_period_msgs": self.rotation_msgs,
+            },
         }

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -24,7 +24,7 @@ import attr
 from ..schemas import Schemas
 from .misc import (BadEventType, UnknownBadEvent, validate_or_badevent, verify,
                    BadEvent)
-from ..messages import ToDeviceMessage
+from ..event_builders import ToDeviceMessage
 
 
 @attr.s

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -16,7 +16,7 @@ from nio import (Client, DeviceList, DeviceOneTimeKeyCount, EncryptionError,
                  ShareGroupSessionResponse, SyncResponse,
                  Timeline, ThumbnailResponse, TransportType, TypingNoticeEvent,
                  InviteMemberEvent, InviteInfo, ClientConfig)
-from nio.messages import ToDeviceMessage
+from nio.event_builders import ToDeviceMessage
 
 HOST = "example.org"
 USER = "example"

--- a/tests/event_builders_test.py
+++ b/tests/event_builders_test.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from nio.event_builders import EnableEncryptionBuilder
+
+
+class TestClass(object):
+    def test_enable_encryption(self):
+        event = EnableEncryptionBuilder(
+            algorithm="test", rotation_ms=9801, rotation_msgs=101
+        ).as_dict()
+
+        assert event["type"]                            == "m.room.encryption"
+        assert event["content"]["algorithm"]            == "test"
+        assert event["content"]["rotation_period_ms"]   == 9801
+        assert event["content"]["rotation_period_msgs"] == 101


### PR DESCRIPTION
This adds a new `event_builders` subpackage for classes that help easily creating event dicts to use for `room_create()` or `room_send()`. 

The already existing helper class `ToDeviceMessage` has been moved to the `nio.event_builders.direct_messages` module.

Included is a new `EnableEncryptionBuilder` class under the `nio.event_builders.state_events` module, to build [`m.room.encryption`](https://matrix.org/docs/spec/client_server/latest#m-room-encryption) events. 