### PR TITLE
Allow using thumbnails API without logging in

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -1074,7 +1074,6 @@ class Api(object):
 
     @staticmethod
     def thumbnail(
-        access_token,                 # type: str
         server_name,                  # type: str
         media_id,                     # type: str
         width,                        # type: int
@@ -1090,7 +1089,6 @@ class Api(object):
         Note: The actual thumbnail may be larger than the size specified.
 
         Args:
-            access_token (str): The access token to be used with the request.
             server_name (str): The server name from the mxc:// URI.
             media_id (str): The media ID from the mxc:// URI.
             width (int): The desired width of the thumbnail.
@@ -1102,7 +1100,6 @@ class Api(object):
                 itself.
         """
         query_parameters = {
-            "access_token": access_token,
             "width": width,
             "height": height,
             "method": method.value,

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1588,7 +1588,7 @@ class AsyncClient(Client):
         return await self._send(DownloadResponse, http_method, path)
 
 
-    @logged_in
+    @client_session
     async def thumbnail(
         self,
         server_name,                  # type: str
@@ -1618,7 +1618,6 @@ class AsyncClient(Client):
                 itself.
         """
         http_method, path = Api.thumbnail(
-            self.access_token,
             server_name,
             media_id,
             width,

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -673,7 +673,6 @@ class HttpClient(Client):
         return self._send(request, RequestInfo(DownloadResponse))
 
     @connected
-    @logged_in
     def thumbnail(
         self,
         server_name,                  # type: str
@@ -704,7 +703,6 @@ class HttpClient(Client):
         """
         request = self._build_request(
             Api.thumbnail(
-                self.access_token,
                 server_name,
                 media_id,
                 width,

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -902,11 +902,6 @@ class TestClass(object):
         assert isinstance(resp, DownloadError)
 
     async def test_thumbnail(self, async_client, aioresponse):
-        await async_client.receive_response(
-            LoginResponse.from_dict(self.login_response)
-        )
-        assert async_client.logged_in
-
         server_name = "example.org"
         media_id = "ascERGshawAWawugaAcauga"
         width = 32
@@ -915,8 +910,7 @@ class TestClass(object):
 
         aioresponse.get(
             "https://example.org/_matrix/media/r0/thumbnail/{}/{}"
-            "?access_token=abc123&width={}&height={}&method={}"
-            "&allow_remote=true".format(
+            "?width={}&height={}&method={}&allow_remote=true".format(
                 server_name,
                 media_id,
                 width,
@@ -935,8 +929,7 @@ class TestClass(object):
 
         aioresponse.get(
             "https://example.org/_matrix/media/r0/thumbnail/{}/{}"
-            "?access_token=abc123&width={}&height={}&method={}"
-            "&allow_remote=true".format(
+            "?width={}&height={}&method={}&allow_remote=true".format(
                 server_name,
                 media_id,
                 width,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -838,14 +838,6 @@ class TestClass(object):
     def test_http_client_thumbnail(self, http_client):
         http_client.connect(TransportType.HTTP2)
 
-        _, _ = http_client.login("1234")
-
-        http_client.receive(self.login_byte_response)
-        response = http_client.next_response()
-
-        assert isinstance(response, LoginResponse)
-        assert http_client.access_token == "ABCD"
-
         _, _ = http_client.thumbnail(
             "example.org",
             "ascERGshawAWawugaAcauga",
@@ -854,7 +846,7 @@ class TestClass(object):
             allow_remote=False
         )
 
-        http_client.receive(self.file_byte_response(3))
+        http_client.receive(self.file_byte_response(1))
         response = http_client.next_response()
 
         assert isinstance(response, ThumbnailResponse)


### PR DESCRIPTION
Like the download API, the [thumbnail API](https://matrix.org/docs/spec/client_server/latest#get-matrix-media-r0-thumbnail-servername-mediaid) doesn't require us to be logged in.