### PR TITLE
Allow getting profile/name/avatar without login

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -1082,36 +1082,32 @@ class Api(object):
         )
 
     @staticmethod
-    def profile_get(access_token, user_id):
+    def profile_get(user_id):
         # type (str, str) -> Tuple[str, str]
         """Get the combined profile information for a user.
 
         Returns the HTTP method and HTTP path for the request.
 
         Args:
-            access_token (str): The access token to be used with the request.
             user_id (str): User id to get the profile for.
         """
-        query_parameters = {"access_token": access_token}
         path = "profile/{user}".format(user=user_id)
 
-        return "GET", Api._build_path(path, query_parameters)
+        return "GET", Api._build_path(path)
 
     @staticmethod
-    def profile_get_displayname(access_token, user_id):
+    def profile_get_displayname(user_id):
         # type (str, str) -> Tuple[str, str]
         """Get display name.
 
         Returns the HTTP method and HTTP path for the request.
 
         Args:
-            access_token (str): The access token to be used with the request.
             user_id (str): User id to get display name for.
         """
-        query_parameters = {"access_token": access_token}
         path = "profile/{user}/displayname".format(user=user_id)
 
-        return "GET", Api._build_path(path, query_parameters)
+        return "GET", Api._build_path(path)
 
     @staticmethod
     def profile_set_displayname(access_token, user_id, display_name):
@@ -1136,20 +1132,18 @@ class Api(object):
         )
 
     @staticmethod
-    def profile_get_avatar(access_token, user_id):
+    def profile_get_avatar(user_id):
         # type (str, str) -> Tuple[str, str]
         """Get avatar URL.
 
         Returns the HTTP method and HTTP path for the request.
 
         Args:
-            access_token (str): The access token to be used with the request.
             user_id (str): User id to get avatar for.
         """
-        query_parameters = {"access_token": access_token}
         path = "profile/{user}/avatar_url".format(user=user_id)
 
-        return "GET", Api._build_path(path, query_parameters)
+        return "GET", Api._build_path(path)
 
     @staticmethod
     def profile_set_avatar(access_token, user_id, avatar_url):

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1589,7 +1589,7 @@ class AsyncClient(Client):
 
         return await self._send(ThumbnailResponse, http_method, path)
 
-    @logged_in
+    @client_session
     async def get_profile(self, user_id=None):
         # type: (Optional[str]) -> Union[ProfileGetResponse, ProfileGetError]
         """Get a user's combined profile information.
@@ -1605,10 +1605,7 @@ class AsyncClient(Client):
         Args:
             user_id (str): User id of the user to get the profile for.
         """
-        method, path = Api.profile_get(
-            self.access_token,
-            user_id or self.user_id
-        )
+        method, path = Api.profile_get(user_id or self.user_id)
 
         return await self._send(
             ProfileGetResponse,
@@ -1616,7 +1613,7 @@ class AsyncClient(Client):
             path,
         )
 
-    @logged_in
+    @client_session
     async def get_displayname(
             self,
             user_id=None  # type: Optional[str]
@@ -1634,10 +1631,7 @@ class AsyncClient(Client):
         Args:
             user_id (str): User id of the user to get the display name for.
         """
-        method, path = Api.profile_get_displayname(
-            self.access_token,
-            user_id or self.user_id
-        )
+        method, path = Api.profile_get_displayname(user_id or self.user_id)
 
         return await self._send(
             ProfileGetDisplayNameResponse,
@@ -1673,7 +1667,7 @@ class AsyncClient(Client):
             data,
         )
 
-    @logged_in
+    @client_session
     async def get_avatar(
             self,
             user_id=None  # type: Optional[str]
@@ -1691,10 +1685,7 @@ class AsyncClient(Client):
         Args:
             user_id (str): User id of the user to get the avatar for.
         """
-        method, path = Api.profile_get_avatar(
-            self.access_token,
-            user_id or self.user_id
-        )
+        method, path = Api.profile_get_avatar(user_id or self.user_id)
 
         return await self._send(
             ProfileGetAvatarResponse,

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -854,7 +854,6 @@ class HttpClient(Client):
         )
 
     @connected
-    @logged_in
     def get_profile(self, user_id=None):
         # type: (Optional[str]) -> Tuple[UUID, bytes]
         """Get a user's combined profile information.
@@ -869,17 +868,14 @@ class HttpClient(Client):
         Args:
             user_id (str): User id of the user to get the profile for.
         """
-        request = self._build_request(Api.profile_get(
-            self.access_token,
-            user_id or self.user_id
-        ))
+        request = self._build_request(Api.profile_get(user_id or self.user_id))
+
         return self._send(
             request,
             RequestInfo(ProfileGetResponse)
         )
 
     @connected
-    @logged_in
     def get_displayname(self, user_id=None):
         # type: (Optional[str]) -> Tuple[UUID, bytes]
         """Get a user's display name.
@@ -894,9 +890,9 @@ class HttpClient(Client):
             user_id (str): User id of the user to get the display name for.
         """
         request = self._build_request(Api.profile_get_displayname(
-            self.access_token,
             user_id or self.user_id
         ))
+
         return self._send(
             request,
             RequestInfo(ProfileGetDisplayNameResponse)
@@ -928,7 +924,6 @@ class HttpClient(Client):
         )
 
     @connected
-    @logged_in
     def get_avatar(self, user_id=None):
         # type: (Optional[str]) -> Tuple[UUID, bytes]
         """Get a user's avatar URL.
@@ -943,9 +938,9 @@ class HttpClient(Client):
             user_id (str): User id of the user to get the avatar for.
         """
         request = self._build_request(Api.profile_get_avatar(
-            self.access_token,
             user_id or self.user_id
         ))
+
         return self._send(
             request,
             RequestInfo(ProfileGetAvatarResponse)

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -921,19 +921,12 @@ class TestClass(object):
             await async_client.receive_response(self.encryption_sync_response)
 
     async def test_get_profile(self, async_client, aioresponse):
-        await async_client.receive_response(
-            LoginResponse.from_dict(self.login_response)
-        )
-        assert async_client.logged_in
-
         base_url = "https://example.org/_matrix/client/r0"
         name = faker.name()
         avatar = faker.avatar_url().replace("#auto", "")
 
         aioresponse.get(
-            "{}/profile/{}?access_token={}".format(
-                base_url, async_client.user_id, async_client.access_token
-            ),
+            "{}/profile/{}".format(base_url, async_client.user_id),
             status=200,
             payload=self.get_profile_response(name, avatar)
         )
@@ -951,9 +944,7 @@ class TestClass(object):
         base_url = "https://example.org/_matrix/client/r0"
 
         aioresponse.get(
-            "{}/profile/{}/displayname?access_token={}".format(
-                base_url, async_client.user_id, async_client.access_token
-            ),
+            "{}/profile/{}/displayname".format(base_url, async_client.user_id),
             status=200,
             payload=self.get_displayname_response(None)
         )
@@ -973,9 +964,7 @@ class TestClass(object):
         assert isinstance(resp2, ProfileSetDisplayNameResponse)
 
         aioresponse.get(
-            "{}/profile/{}/displayname?access_token={}".format(
-                base_url, async_client.user_id, async_client.access_token
-            ),
+            "{}/profile/{}/displayname".format(base_url, async_client.user_id),
             status=200,
             payload=self.get_displayname_response(new_name)
         )
@@ -992,9 +981,7 @@ class TestClass(object):
         base_url = "https://example.org/_matrix/client/r0"
 
         aioresponse.get(
-            "{}/profile/{}/avatar_url?access_token={}".format(
-                base_url, async_client.user_id, async_client.access_token
-            ),
+            "{}/profile/{}/avatar_url".format(base_url, async_client.user_id),
             status=200,
             payload=self.get_avatar_response(None)
         )
@@ -1014,9 +1001,7 @@ class TestClass(object):
         assert isinstance(resp2, ProfileSetAvatarResponse)
 
         aioresponse.get(
-            "{}/profile/{}/avatar_url?access_token={}".format(
-                base_url, async_client.user_id, async_client.access_token
-            ),
+            "{}/profile/{}/avatar_url".format(base_url, async_client.user_id),
             status=200,
             payload=self.get_avatar_response(new_avatar)
         )

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -827,24 +827,13 @@ class TestClass(object):
     def test_http_client_get_profile(self, http_client):
         http_client.connect(TransportType.HTTP2)
 
-        _, _ = http_client.login("1234")
-        http_client.receive(self.login_byte_response)
-        response = http_client.next_response()
-        assert isinstance(response, LoginResponse)
-        assert http_client.access_token == "ABCD"
-
-        _, _ = http_client.sync()
-        http_client.receive(self.sync_byte_response)
-        response = http_client.next_response()
-        assert isinstance(response, SyncResponse)
-        assert http_client.access_token == "ABCD"
-
         name = faker.name()
         avatar = faker.avatar_url().replace("#auto", "")
 
         _, _ = http_client.get_profile()
-        http_client.receive(self.get_profile_byte_response(name, avatar, 5))
+        http_client.receive(self.get_profile_byte_response(name, avatar, 1))
         response = http_client.next_response()
+
         assert isinstance(response, ProfileGetResponse)
         assert response.displayname == name
         assert response.avatar_url.replace("#auto", "") == avatar


### PR DESCRIPTION
The GET [profile](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-profile-userid), [displayname](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-profile-userid-displayname) and [avatar](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-profile-userid-avatar-url) API don't require to be logged in.