### PR TITLE
Async lazy encryption for uploads

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1520,7 +1520,7 @@ class AsyncClient(Client):
     async def upload(
         self,
         data:         AsyncDataT,
-        content_type: str,
+        content_type: str           = "application/octet-stream",
         filename:     Optional[str] = None,
         encrypt:      bool          = False,
     ) -> Tuple[Union[UploadResponse, UploadError], Optional[Dict[str, Any]]]:
@@ -1547,6 +1547,9 @@ class AsyncClient(Client):
 
             content_type (str): The content MIME type of the file,
                 e.g. "image/png".
+                Defaults to "application/octet-stream", corresponding to a
+                generic binary file.
+                Custom values are ignored if encrypt is ``True``.
 
             filename (str, optional): The file's original name.
 
@@ -1570,14 +1573,13 @@ class AsyncClient(Client):
         else:
             data = generator_from_data(data)
 
-        import remote_pdb; remote_pdb.RemotePdb("127.0.0.1", 4444).set_trace()
-
         response = await self._send(
             UploadResponse,
             http_method,
             path,
             data,
-            content_type=content_type,
+            content_type =
+                "application/octet-stream" if encrypt else content_type,
         )
 
         # After the upload finished and we get the response above, if encrypt

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -31,7 +31,8 @@ from . import Client, ClientConfig
 from .base_client import logged_in, store_loaded
 from ..api import (Api, MessageDirection, ResizingMethod, RoomVisibility,
                    RoomPreset)
-from ..crypto import AsyncDataT, async_encrypt_attachment, generator_from_data
+from ..crypto import (AsyncDataT, async_encrypt_attachment,
+                      async_generator_from_data)
 from ..exceptions import (GroupEncryptionError, LocalProtocolError,
                           MembersSyncError, SendRetryError)
 from ..events import RoomKeyRequest, RoomKeyRequestCancellation
@@ -1571,7 +1572,7 @@ class AsyncClient(Client):
 
             data = encrypted_data_generator(data)
         else:
-            data = generator_from_data(data)
+            data = async_generator_from_data(data)
 
         response = await self._send(
             UploadResponse,

--- a/nio/crypto/__init__.py
+++ b/nio/crypto/__init__.py
@@ -16,7 +16,8 @@ from .._compat import package_installed
 from .attachments import encrypt_attachment, decrypt_attachment
 
 if sys.version_info >= (3, 5):
-    from .async_attachments import async_encrypt_attachment, AsyncDataT
+    from .async_attachments import (AsyncDataT, async_encrypt_attachment,
+                                    generator_from_data,)
 
 if package_installed("olm"):
     from .sessions import (

--- a/nio/crypto/__init__.py
+++ b/nio/crypto/__init__.py
@@ -16,7 +16,7 @@ from .._compat import package_installed
 from .attachments import encrypt_attachment, decrypt_attachment
 
 if sys.version_info >= (3, 5):
-    from .async_attachments import async_encrypt_attachment
+    from .async_attachments import async_encrypt_attachment, AsyncDataT
 
 if package_installed("olm"):
     from .sessions import (

--- a/nio/crypto/__init__.py
+++ b/nio/crypto/__init__.py
@@ -10,8 +10,13 @@ documented here.
 
 """
 
+import sys
+
 from .._compat import package_installed
 from .attachments import encrypt_attachment, decrypt_attachment
+
+if sys.version_info >= (3, 5):
+    from .async_attachments import async_encrypt_attachment
 
 if package_installed("olm"):
     from .sessions import (

--- a/nio/crypto/__init__.py
+++ b/nio/crypto/__init__.py
@@ -17,7 +17,7 @@ from .attachments import encrypt_attachment, decrypt_attachment
 
 if sys.version_info >= (3, 5):
     from .async_attachments import (AsyncDataT, async_encrypt_attachment,
-                                    generator_from_data,)
+                                    async_generator_from_data,)
 
 if package_installed("olm"):
     from .sessions import (

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -52,7 +52,8 @@ async def async_encrypt_attachment(data: AsyncDataT) -> _EncryptedReturnT:
     or async iterable of bytes is passed as data.
 
     Args:
-        data (bytes/Iterable[bytes]/AsyncIterable[bytes]): The data to encrypt.
+        data (str/Path/bytes/Iterable[bytes]/AsyncIterable[bytes]/
+        io.BufferedIOBase/AsyncBufferedReader): The data to encrypt.
 
     Yields:
         The encrypted bytes for each chunk of data.

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -39,8 +39,7 @@ async def async_encrypt_attachment(data: _DataT) -> _EncryptedReturnT:
     or async iterable of bytes is passed as data.
 
     Args:
-        data (Union[bytes, Iterable[bytes]], AsyncIterable[bytes]): The data
-            to encrypt.
+        data (bytes/Iterable[bytes]/AsyncIterable[bytes]): The data to encrypt.
 
     Yields:
         The encrypted bytes for each chunk of data.

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -71,7 +71,6 @@ async def async_encrypt_attachment(data: AsyncDataT) -> _EncryptedReturnT:
         | hashes.sha256: Base64 encoded SHA-256 hash of the ciphertext.
     """
 
-
     key = Random.new().read(32)
     # 8 bytes IV
     iv = Random.new().read(8)

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -54,6 +54,13 @@ async def async_encrypt_attachment(data: AsyncDataT) -> _EncryptedReturnT:
     Args:
         data (str/Path/bytes/Iterable[bytes]/AsyncIterable[bytes]/
         io.BufferedIOBase/AsyncBufferedReader): The data to encrypt.
+            Passing a path string, Path, async iterable or aiofiles open
+            binary file object allows the file data to be read in an
+            asynchronous and lazy (without reading the entire file into
+            memory) way.
+            Passing a non-async iterable or standard open binary file
+            object will still allow the data to be read lazily, but
+            not asynchronously.
 
     Yields:
         The encrypted bytes for each chunk of data.

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -108,21 +108,7 @@ async def async_generator_from_data(
     if isinstance(data, bytes):
         yield data
 
-    elif isinstance(data, Iterable):
-        for chunk in data:
-            yield chunk  # type: ignore
-
-    elif isinstance(data, AsyncIterable):
-        async for chunk in data:
-            yield chunk
-
-    elif isinstance(data, io.BufferedIOBase):
-       while True:
-            chunk = data.read(4096)
-            if not chunk:
-                return
-            yield chunk
-
+    # Test if data is a file obj first, since it's considered Iterable too
     elif isinstance(data, io.BufferedIOBase):
        while True:
             chunk = data.read(4096)
@@ -139,6 +125,14 @@ async def async_generator_from_data(
 
         if aio_opened:
             await data.close()
+
+    elif isinstance(data, Iterable):
+        for chunk in data:  # type: ignore
+            yield chunk
+
+    elif isinstance(data, AsyncIterable):
+        async for chunk in data:
+            yield chunk
 
     else:
         raise TypeError(f"Unknown type for data: {data!r}")

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -116,7 +116,7 @@ async def async_generator_from_data(
                 return
             yield chunk
 
-    elif isinstance(data, aiofiles.base.AiofilesContextManager):
+    elif isinstance(data, AsyncBufferedReader):
         while True:
             chunk = await data.read(4096)
             if not chunk:

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -1,0 +1,89 @@
+# Copyright © 2018, 2019 Damir Jelić <poljar@termina.org.uk>
+# Copyright © 2019 miruka <miruka@disroot.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+# CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""Matrix async encryption/decryption functions for file uploads."""
+
+import asyncio
+from functools import partial
+from typing import Any, AsyncGenerator, AsyncIterable, Dict, Iterable, Union
+
+from Crypto import Random  # nosec
+from Crypto.Cipher import AES  # nosec
+from Crypto.Hash import SHA256  # nosec
+from Crypto.Util import Counter  # nosec
+
+from .attachments import _get_decryption_info_dict
+
+_DataT            = Union[bytes, Iterable[bytes], AsyncIterable[bytes]]
+_EncryptedReturnT = AsyncGenerator[Union[bytes, Dict[str, Any]], None]
+
+
+async def async_encrypt_attachment(data: _DataT) -> _EncryptedReturnT:
+    """Async generator to encrypt data in order to send it as an encrypted
+    attachment.
+
+    This function lazily encrypts and yields data, thus it can be used to
+    encrypt large files without fully loading them into memory if an iterable
+    or async iterable of bytes is passed as data.
+
+    Args:
+        data (Union[bytes, Iterable[bytes]], AsyncIterable[bytes]): The data
+            to encrypt.
+
+    Yields:
+        The encrypted bytes for each chunk of data.
+        The last yielded value will be a dict containing the info needed to
+        decrypt data. The keys are:
+        | key: AES-CTR JWK key object.
+        | iv: Base64 encoded 16 byte AES-CTR IV.
+        | hashes.sha256: Base64 encoded SHA-256 hash of the ciphertext.
+    """
+
+
+    key = Random.new().read(32)
+    # 8 bytes IV
+    iv = Random.new().read(8)
+    # 8 bytes counter, prefixed by the IV
+    ctr = Counter.new(64, prefix=iv, initial_value=0)
+
+    cipher = AES.new(key, AES.MODE_CTR, counter=ctr)
+    sha256 = SHA256.new()
+
+    loop = asyncio.get_event_loop()
+
+    adata: AsyncIterable[bytes]  # for mypy
+
+    if isinstance(data, bytes):
+        data = [data]
+
+    if isinstance(data, Iterable):
+        async def asyncify(iterable):
+            for item in iterable:
+                yield item
+
+        adata = asyncify(data)
+    else:
+        adata = data
+
+    async for chunk in adata:
+        update_crypt = partial(cipher.encrypt, chunk)
+        crypt_chunk  = await loop.run_in_executor(None, update_crypt)
+
+        update_hash = partial(sha256.update, crypt_chunk)
+        await loop.run_in_executor(None, update_hash)
+
+        yield crypt_chunk
+
+    yield _get_decryption_info_dict(key, iv, sha256)

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -82,7 +82,7 @@ async def async_encrypt_attachment(data: AsyncDataT) -> _EncryptedReturnT:
 
     loop = asyncio.get_event_loop()
 
-    async for chunk in generator_from_data(data):
+    async for chunk in async_generator_from_data(data):
         update_crypt = partial(cipher.encrypt, chunk)
         crypt_chunk  = await loop.run_in_executor(None, update_crypt)
 
@@ -94,7 +94,10 @@ async def async_encrypt_attachment(data: AsyncDataT) -> _EncryptedReturnT:
     yield _get_decryption_info_dict(key, iv, sha256)
 
 
-async def generator_from_data(data: AsyncDataT) -> AsyncGenerator[bytes, None]:
+async def async_generator_from_data(
+    data: AsyncDataT,
+) -> AsyncGenerator[bytes, None]:
+
     aio_opened = False
     if isinstance(data, (str, Path)):
         data       = await aiofiles.open(data, "rb")

--- a/nio/crypto/attachments.py
+++ b/nio/crypto/attachments.py
@@ -101,7 +101,7 @@ def encrypted_attachment_generator(data):
     into memory if an iterable of bytes is passed as data.
 
     Args:
-        data (Union[bytes, Iterable[bytes]]): The data to encrypt.
+        data (bytes/Iterable[bytes]): The data to encrypt.
 
     Yields:
         The encrypted bytes for each chunk of data.

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -13,4 +13,5 @@ pycrypto
 sphinx >= 1.8
 aiohttp; python_version >= '3.5'
 aioresponses; python_version >= '3.5'
+aiofiles; python_version >= '3.5'
 m2r

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "attrs",
         "future",
         "aiohttp;python_version>'3.5'",
+        "aiofiles;python_version>'3.5'",
         "typing;python_version<'3.5'",
         "h11",
         "h2",

--- a/tests/async_attachment_test.py
+++ b/tests/async_attachment_test.py
@@ -55,6 +55,10 @@ class TestClass:
     async def test_encrypt_async_file_object(self):
         await self.test_encrypt(await aiofiles.open(FILEPATH, "rb"))
 
+    async def test_encrypt_bad_argument_type(self):
+        with pytest.raises(TypeError):
+            await self.test_encrypt(123)
+
     async def test_hash_verification(self):
         data, cyphertext, keys = await self._get_data_cypher_keys()
 

--- a/tests/async_attachment_test.py
+++ b/tests/async_attachment_test.py
@@ -1,0 +1,99 @@
+import sys
+
+import pytest
+import unpaddedbase64
+from Crypto import Random  # nosec
+
+from nio import EncryptionError
+from nio.crypto import async_encrypt_attachment, decrypt_attachment
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 5), reason="Python 3 specific asyncio tests",
+)
+class TestClass:
+    async def _get_data_cypher_keys(self):
+        data          = b"Test bytes"
+        *chunks, keys = [i async for i in async_encrypt_attachment(data)]
+        return (data, b"".join(chunks), keys)
+
+
+    async def test_encrypt(self):
+        data, cyphertext, keys = await self._get_data_cypher_keys()
+
+        plaintext = decrypt_attachment(
+            cyphertext,
+            keys["key"]["k"],
+            keys["hashes"]["sha256"],
+            keys["iv"],
+        )
+
+        assert data == plaintext
+
+    async def test_hash_verification(self):
+        data, cyphertext, keys = await self._get_data_cypher_keys()
+
+        with pytest.raises(EncryptionError):
+            decrypt_attachment(
+                cyphertext,
+                keys["key"]["k"],
+                "Fake hash",
+                keys["iv"],
+            )
+
+    async def test_invalid_key(self):
+        data, cyphertext, keys = await self._get_data_cypher_keys()
+
+        with pytest.raises(EncryptionError):
+            decrypt_attachment(
+                cyphertext,
+                "Fake key",
+                keys["hashes"]["sha256"],
+                keys["iv"],
+            )
+
+    async def test_invalid_iv(self):
+        data, cyphertext, keys = await self._get_data_cypher_keys()
+
+        with pytest.raises(EncryptionError):
+            decrypt_attachment(
+                cyphertext,
+                keys["key"]["k"],
+                keys["hashes"]["sha256"],
+                "Fake iv",
+            )
+
+    async def test_short_key(self):
+        data, cyphertext, keys = await self._get_data_cypher_keys()
+
+        with pytest.raises(EncryptionError):
+            decrypt_attachment(
+                cyphertext,
+                unpaddedbase64.encode_base64(b"Fake key", urlsafe=True),
+                keys["hashes"]["sha256"],
+                keys["iv"],
+            )
+
+    async def test_short_iv(self):
+        data, cyphertext, keys = await self._get_data_cypher_keys()
+
+        plaintext = decrypt_attachment(
+            cyphertext,
+            keys["key"]["k"],
+            keys["hashes"]["sha256"],
+            unpaddedbase64.encode_base64(b"F" + b"\x00" * 8),
+        )
+        assert plaintext != data
+
+    async def test_fake_key(self):
+        data, cyphertext, keys = await self._get_data_cypher_keys()
+
+        fake_key = Random.new().read(32)
+
+        plaintext = decrypt_attachment(
+            cyphertext,
+            unpaddedbase64.encode_base64(fake_key, urlsafe=True),
+            keys["hashes"]["sha256"],
+            keys["iv"],
+        )
+        assert plaintext != data

--- a/tests/async_attachment_test.py
+++ b/tests/async_attachment_test.py
@@ -47,7 +47,7 @@ class TestClass:
             yield b"Test "
             yield b"bytes"
 
-        await self.test_encrypt([b async for b in async_gen()])
+        await self.test_encrypt(async_gen())
 
     async def test_encrypt_file_object(self):
         await self.test_encrypt(open(FILEPATH, "rb"))

--- a/tests/data/test_bytes
+++ b/tests/data/test_bytes
@@ -1,0 +1,1 @@
+Test bytes


### PR DESCRIPTION
- Added `nio.crypto.attachments.encrypted_attachment_generator()`, which takes bytes or an iterable of bytes. If an iterable is passed, the encrypted chunks will be lazily yielded without loading the entire data in memory. After yielding all the chunks, the decryption dictionary is the last yielded value.

- The preexisting `encrypt_attachment()` function is now a wrapper over `encrypted_attachment_generator()` and behaves the same as before (except for also accepting iterable of bytes).

- Added `nio.crypto.async_attachments.async_encrypt_attachment()`, which is an async version of `encrypted_attachment_generator()`. It accepts bytes, iterable of bytes, async iterable of bytes, path strings, `Path` objects, and opened binary file/aiofile objects as data.

- Added `encrypt` argument for `AsyncClient.upload()`, addressing https://github.com/poljar/matrix-nio/issues/75. It uses `async_encrypt_attachment()` under the hood, and now accepts all the data types mentioned above.