### PR TITLE
Parallel group sessions sharing

### DIFF
--- a/nio/crypto/olm_machine.py
+++ b/nio/crypto/olm_machine.py
@@ -1760,8 +1760,9 @@ class Olm(object):
         self,
         room_id,  # type: str
         users,    # type: List[str]
-        ignore_missing_sessions=False,   # type: bool
-        ignore_unverified_devices=False  # type: bool
+        ignore_missing_sessions=False,    # type: bool
+        ignore_unverified_devices=False,  # type: bool
+        already_shared_with=None  # type: Optional[Set[Tuple[str, str]]]
     ):
         # type: (...) -> Tuple[Set[Tuple[str, str]], Dict[str, Any]]
         logger.info("Sharing group session for room {}".format(room_id))
@@ -1783,7 +1784,9 @@ class Olm(object):
 
         to_device_dict = {"messages": {}}  # type: Dict[str, Any]
 
-        already_shared_set = group_session.users_shared_with
+        already_shared_set = (
+            group_session.users_shared_with | (already_shared_with or set())
+        )
         ignored_set = group_session.users_ignored
 
         user_map = []

--- a/nio/crypto/olm_machine.py
+++ b/nio/crypto/olm_machine.py
@@ -1855,6 +1855,9 @@ class Olm(object):
 
             to_device_dict["messages"][user_id][device.id] = olm_dict
 
+        if not sharing_with:
+            raise LocalProtocolError("No user to share group session with")
+
         return sharing_with, to_device_dict
 
     def load(self):

--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -720,7 +720,7 @@ class MatrixStore(object):
         if not rows:
             return
 
-        for batch in chunked(rows, 1000 / len(rows[0])):
+        for batch in chunked(rows, 1000 // len(rows[0])):
             OlmSessions.replace_many(batch).execute()
 
     @use_database

--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -712,16 +712,22 @@ class MatrixStore(object):
         account = self._get_account()
         assert account
 
-        rows = ({
-            "account": account,
-            "sender_key": sender_key,
-            "session": session.pickle(self.pickle_key),
-            "session_id": session.id,
-            "creation_time": session.creation_time,
-            "last_usage_date": session.use_time,
-        } for (sender_key, session) in sessions)
+        rows = [
+            {
+                "account": account,
+                "sender_key": sender_key,
+                "session": session.pickle(self.pickle_key),
+                "session_id": session.id,
+                "creation_time": session.creation_time,
+                "last_usage_date": session.use_time,
+            }
+            for (sender_key, session) in sessions
+        ]
 
-        for batch in chunked(rows, 20):
+        if not rows:
+            return
+
+        for batch in chunked(rows, 1000 / len(rows[0])):
             OlmSessions.replace_many(batch).execute()
 
     @use_database

--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -691,14 +691,7 @@ class MatrixStore(object):
         account = self._get_account()
         assert account
 
-        OlmSessions.replace(
-            account=account,
-            sender_key=sender_key,
-            session=session.pickle(self.pickle_key),
-            session_id=session.id,
-            creation_time=session.creation_time,
-            last_usage_date=session.use_time,
-        ).execute()
+        self.save_sessions((sender_key, session))
 
     @use_database_atomic
     def save_sessions(self, *sessions):

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -2592,7 +2592,6 @@ class TestClass(object):
         )
 
         def key_request_cb(event):
-            print(event)
             bob.verify_device(alice_device)
 
             for key_share in bob.get_active_key_requests(

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -678,11 +678,12 @@ class TestClass(object):
         with pytest.raises(EncryptionError):
             client.olm.share_group_session(TEST_ROOM_ID, room.users)
 
-        shared_with, to_device = client.olm.share_group_session(
-            TEST_ROOM_ID,
-            room.users,
-            True
-        )
+        with pytest.raises(LocalProtocolError):
+            client.olm.share_group_session(
+                TEST_ROOM_ID,
+                room.users,
+                ignore_missing_sessions=True,
+            )
 
         session = client.olm.outbound_group_sessions[TEST_ROOM_ID]
         assert (ALICE_ID, ALICE_DEVICE_ID) in session.users_ignored

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,8 @@ def alice_client(tempdir):
 
 
 if sys.version_info >= (3, 5):
-    from conftest_async import async_client, aioresponse, async_client_pair
+    from conftest_async import (async_client, aioresponse, async_client_pair,
+                                async_client_trio)
 
 if sys.version_info <= (3, 4):
     def pytest_ignore_collect(path, config):

--- a/tests/conftest_async.py
+++ b/tests/conftest_async.py
@@ -44,6 +44,32 @@ async def async_client_pair(tempdir, loop):
 
 
 @pytest.fixture
+async def async_client_trio(tempdir, loop):
+    ALICE_ID = "@alice:example.org"
+    ALICE_DEVICE = "JLAFKJWSCS"
+
+    BOB_ID = "@bob:example.org"
+    BOB_DEVICE = "ASDFOEAK"
+
+    CAROL_ID = "@alice:example.org"
+    CAROL_DEVICE = "JLAFKJWSCS"
+
+    alice = AsyncClient("https://example.org", ALICE_ID, ALICE_DEVICE, tempdir)
+    bob = AsyncClient("https://example.org", BOB_ID, BOB_DEVICE, tempdir)
+    carol = AsyncClient("https://example.org", CAROL_ID, CAROL_DEVICE, tempdir)
+
+    await alice.receive_response(LoginResponse(ALICE_ID, ALICE_DEVICE, "alice_1234"))
+    await bob.receive_response(LoginResponse(BOB_ID, BOB_DEVICE, "bob_1234"))
+    await carol.receive_response(LoginResponse(CAROL_ID, CAROL_DEVICE, "carol_1234"))
+
+    yield (alice, bob, carol)
+
+    await alice.close()
+    await bob.close()
+    await carol.close()
+
+
+@pytest.fixture
 def aioresponse():
     with aioresponses() as m:
         yield m

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -370,7 +370,11 @@ class TestClass(object):
         account = store.load_account()
 
         session = OutboundSession(account, BOB_CURVE, BOB_ONETIME)
-        store.save_session(BOB_CURVE, session)
+
+        # Nothing should happen if no sessions are passed
+        store.save_sessions()
+
+        store.save_sessions((BOB_CURVE, session))
 
         store2 = self.copy_store(store)
         session_store = store2.load_sessions()


### PR DESCRIPTION
This brings down the very long delay that occurs when sending a first message in an encrypted room with lots of devices. 

`share_group_session()` from `AsyncClient` and `Olm` now send all the batches of 20 devices concurrently instead of one-by-one.

The sessions are then saved to the DB in batch using  `Olm._olm_encrypt_batch()`, which calls the new `MatrixStore.save_sessions()` . The non-batch version of these methods now use the batch versions under-hood.