### PR TITLE
MatrixRoom.group_name(): return None for empty rooms

### DIFF
--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -101,6 +101,8 @@ class MatrixRoom(object):
 
         In other words, a display name based on the names of room members. This
         is used for ad-hoc groups of people (usually direct chats).
+
+        Returns None if there are no users.
         """
         # Sort user display names, excluding our own user and using the
         # mxid as the sorting key.
@@ -121,7 +123,7 @@ class MatrixRoom(object):
                 first_user=user_names[0], num=num_users - 1
             )
         else:
-            return "Empty room?"
+            return None
 
     def user_name(self, user_id):
         """Get disambiguated display name for a user.

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -52,8 +52,8 @@ class TestClass(object):
 
     def test_name_calculation_when_unnamed_with_no_members(self):
         room = self.test_room
-        assert room.display_name == "Empty room?"
-        assert room.named_room_name() == None
+        assert room.display_name is None
+        assert room.named_room_name() is None
 
     def test_name_calculation_when_unnamed_with_members(self):
         room = self.test_room


### PR DESCRIPTION
This changes the method (and subsequently the `MatrixRoom.display_name` property) to return `None`, instead of a hardcoded string that would make us have to jump through extra hoops to know if the room is actually empty or literally named "Empty room?".