### PR TITLE
RoomMessageNotice: support format/formatted_body

### DIFF
--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -957,29 +957,6 @@ class RoomMessageUnknown(RoomMessage):
 
 
 @attr.s
-class RoomMessageNotice(RoomMessage):
-    """A room message corresponding to the m.notice msgtype.
-
-    Room notices are primarily intended for responses from automated
-    clients.
-
-    Attributes:
-        body (str): The text of the notice.
-
-    """
-
-    body = attr.ib(type=str)
-
-    @classmethod
-    @verify(Schemas.room_message_notice)
-    def from_dict(cls, parsed_dict):
-        return cls(
-            parsed_dict,
-            parsed_dict["content"]["body"],
-        )
-
-
-@attr.s
 class RoomMessageFormatted(RoomMessage):
     """Base abstract class for room messages that can have formatted bodies.
 
@@ -1074,6 +1051,28 @@ class RoomMessageEmote(RoomMessageFormatted):
     def _validate(parsed_dict):
         # type: (Dict[Any, Any]) -> Optional[BadEventType]
         return validate_or_badevent(parsed_dict, Schemas.room_message_emote)
+
+
+@attr.s
+class RoomMessageNotice(RoomMessageFormatted):
+    """A room message corresponding to the m.notice msgtype.
+
+    Room notices are primarily intended for responses from automated
+    clients.
+
+    Attributes:
+        body (str): The textual body of the notice.
+        formatted_body (str, optional): The formatted version of the notice
+            body. Can be None if the message doesn't contain a formatted
+            version of the body.
+        format (str, optional): The format used in the formatted_body. This
+            specifies how the formatted_body should be interpreted.
+    """
+
+    @staticmethod
+    def _validate(parsed_dict):
+        # type: (Dict[Any, Any]) -> Optional[BadEventType]
+        return validate_or_badevent(parsed_dict, Schemas.room_message_notice)
 
 
 @attr.s

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -116,9 +116,11 @@ class Schemas(object):
                 "properties": {
                     "msgtype": {"type": "string", "const": "m.notice"},
                     "body": {"type": "string"},
+                    "formatted_body": {"type": "string"},
+                    "format": {"type": "string"},
                 },
                 "required": ["msgtype", "body"],
-            }
+            },
         },
     }
 

--- a/tests/data/events/message_notice.json
+++ b/tests/data/events/message_notice.json
@@ -7,6 +7,8 @@
   },
   "content": {
     "body": "https://github.com/matrix-org/matrix-python-sdk/issues/266 : Consider allowing MatrixClient.__init__ to take sync_token kwarg",
+    "format": "org.matrix.custom.html",
+    "formatted_body": "<a href='https://github.com/matrix-org/matrix-python-sdk/pull/313'>313: nio wins!</a>",
     "msgtype": "m.notice"
   },
   "type": "m.room.message",


### PR DESCRIPTION
This makes `RoomMessageNotice` a subclass of `RoomMessageFormatted`, since [`m.notice`](https://matrix.org/docs/spec/client_server/latest#m-notice) events can have `format` and `formatted_body` keys.