### PR TITLE
Room redaction for AsyncClient and other improvements

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -421,8 +421,9 @@ class Api(object):
             room_id (str): The room id of the room that contains the event that
                 will be redacted.
             event_id (str): The ID of the event that will be redacted.
-            tx_id (str): The transaction ID for this event.
-            reason(str): A description explaining why the event was redacted.
+            tx_id (str/UUID, optional): A transaction ID for this event.
+            reason(str, optional): A description explaining why the
+                event was redacted.
         """
         query_parameters = {"access_token": access_token}
 

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -212,7 +212,10 @@ class AsyncClient(Client):
 
         self.sharing_session = dict()  # type: Dict[str, Event]
 
-        if isinstance(config, ClientConfig):
+        is_config       = isinstance(config, ClientConfig)
+        is_async_config = isinstance(config, AsyncClientConfig)
+
+        if is_config and not is_async_config:
             warnings.warn(
                 "Pass an AsyncClientConfig instead of ClientConfig.",
                 DeprecationWarning

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1191,8 +1191,8 @@ class AsyncClient(Client):
         Raises a LocalProtocolError if the room key was already requested.
 
         Args:
-            event (str): An undecrypted MegolmEvent for which we would like to
-                request the decryption key.
+            event (MegolmEvent): An undecrypted MegolmEvent for which we would
+                like to request the decryption key.
         """
         uuid = tx_id or uuid4()
 

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -330,6 +330,19 @@ class HttpClient(Client):
     @connected
     @logged_in
     def room_redact(self, room_id, event_id, reason=None, tx_id=None):
+        """Strip information out of an event.
+
+        Returns a unique uuid that identifies the request and the bytes that
+        should be sent to the socket.
+
+        Args:
+            room_id (str): The room id of the room that contains the event that
+                will be redacted.
+            event_id (str): The ID of the event that will be redacted.
+            tx_id (str/UUID, optional): A transaction ID for this event.
+            reason(str, optional): A description explaining why the
+                event was redacted.
+        """
         uuid = tx_id or uuid4()
 
         request = self._build_request(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -5,6 +5,7 @@ import time
 from os import path
 from datetime import datetime, timedelta
 from urllib.parse import quote
+from uuid import uuid4
 
 import aiofiles
 import pytest
@@ -25,7 +26,8 @@ from nio import (DeviceList, DeviceOneTimeKeyCount, DownloadError,
                  RoomTypingResponse, RoomCreateResponse,
                  RoomEncryptionEvent, RoomInfo, RoomLeaveResponse,
                  RoomMemberEvent, RoomMessagesResponse, Rooms,
-                 RoomSendResponse, RoomSummary, ShareGroupSessionResponse,
+                 RoomRedactResponse, RoomSendResponse, RoomSummary,
+                 ShareGroupSessionResponse,
                  SyncResponse, ThumbnailError, ThumbnailResponse,
                  Timeline, UploadResponse, RoomMessageText, RoomKeyRequest)
 from nio.api import ResizingMethod, RoomPreset, RoomVisibility
@@ -744,7 +746,7 @@ class TestClass(object):
         assert async_client.logged_in
         await async_client.receive_response(self.encryption_sync_response)
 
-        room_id = list(async_client.rooms.keys())[0]
+        room_id = next(iter(async_client.rooms))
 
         aioresponse.post(
             "https://example.org/_matrix/client/r0/rooms/{}/forget"
@@ -757,6 +759,29 @@ class TestClass(object):
         resp = await async_client.room_forget(room_id)
         assert isinstance(resp, RoomForgetResponse)
         assert room_id not in async_client.rooms
+
+    async def test_room_redact(self, async_client, aioresponse):
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response)
+        )
+        assert async_client.logged_in
+        await async_client.receive_response(self.encryption_sync_response)
+
+        room_id  = next(iter(async_client.rooms))
+        event_id = "$15163622445EBvZJ:localhost"
+        tx_id    = uuid4()
+        reason   = "for no reason"
+
+        aioresponse.put(
+            "https://example.org/_matrix/client/r0/rooms/{}/redact/{}/{}"
+            "?access_token=abc123".format(
+                room_id, event_id, tx_id
+            ),
+            status=200,
+            payload={"event_id": "$90813622447EBvZJ:localhost"},
+        )
+        resp = await async_client.room_redact(room_id, event_id, reason, tx_id)
+        assert isinstance(resp, RoomRedactResponse)
 
     async def test_context(self, async_client, aioresponse):
         await async_client.receive_response(

--- a/tests/conftest_async.py
+++ b/tests/conftest_async.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nio import AsyncClient, LoginResponse
+from nio import AsyncClient, AsyncClientConfig, LoginResponse
 from aioresponses import aioresponses
 
 
@@ -10,7 +10,8 @@ async def async_client(tempdir, loop):
         "https://example.org",
         "ephemeral",
         "DEVICEID",
-        tempdir
+        tempdir,
+        config = AsyncClientConfig(max_timeouts=3),
     )
     yield client
 
@@ -25,8 +26,13 @@ async def async_client_pair(tempdir, loop):
     BOB_ID = "@bob:example.org"
     BOB_DEVICE = "ASDFOEAK"
 
-    alice = AsyncClient("https://example.org", ALICE_ID, ALICE_DEVICE, tempdir)
-    bob = AsyncClient("https://example.org", BOB_ID, BOB_DEVICE, tempdir)
+    config = AsyncClientConfig(max_timeouts=3)
+    alice = AsyncClient(
+        "https://example.org", ALICE_ID, ALICE_DEVICE, tempdir, config=config,
+    )
+    bob = AsyncClient(
+        "https://example.org", BOB_ID, BOB_DEVICE, tempdir, config=config,
+    )
 
     await alice.receive_response(LoginResponse(ALICE_ID, ALICE_DEVICE, "alice_1234"))
     await bob.receive_response(LoginResponse(BOB_ID, BOB_DEVICE, "bob_1234"))


### PR DESCRIPTION
- Add missing `room_redact()` to the `AsyncClient`, addresses https://github.com/poljar/matrix-nio/issues/83
- Add docstring and test for the already existing `HttpClient.room_redact()`
- Make some docstrings in *async_client.py* more consistent ("Arguments: ..." *after* "Returns ...") 
- Set a max number of timeouts for `AsyncClient` from test fixtures, to avoid having tests just silently hanging forever if something goes wrong with a request 
- Fix deprecation warnings being issued if an `AsyncClientConfig` is passed, they should only appear if a `ClientConfig` is passed 
- Add a new `synced_client` fixture that returns an already logged-in and synced `HttpClient`, to avoid having to copy-paste a large chunk of code for every new http client test