### PR TITLE
Uploads monitoring, pausing and cancelling

### DIFF
--- a/nio/__init__.py
+++ b/nio/__init__.py
@@ -8,3 +8,4 @@ from .events import *
 from .rooms import *
 from .exceptions import *
 from .event_builders import *
+from .monitors import *

--- a/nio/client/__init__.py
+++ b/nio/client/__init__.py
@@ -3,4 +3,4 @@ import sys
 from .base_client import Client, ClientConfig
 from .http_client import HttpClient, TransportType, RequestInfo
 if sys.version_info >= (3, 5):
-    from .async_client import AsyncClient, AsyncClientConfig
+    from .async_client import AsyncClient, AsyncClientConfig, DataProvider

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1655,6 +1655,9 @@ class AsyncClient(Client):
             if monitor:
                 monitor.transfered += len(value)
 
+                while monitor.pause:
+                    await asyncio.sleep(1 / monitor.update_rate)
+
             yield value
 
     @staticmethod
@@ -1665,6 +1668,9 @@ class AsyncClient(Client):
             else:
                 if monitor:
                     monitor.transfered += len(value)
+
+                    while monitor.pause:
+                        await asyncio.sleep(1 / monitor.update_rate)
 
                 yield value
 

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1651,7 +1651,7 @@ class AsyncClient(Client):
         )
 
     @staticmethod
-    async def _plain_data_generator(data, monitor):
+    async def _plain_data_generator(data, monitor=None):
         """Yield chunks of bytes from data.
 
         If a monitor is passed, update its ``transfered`` property and
@@ -1673,7 +1673,7 @@ class AsyncClient(Client):
             yield value
 
     @staticmethod
-    async def _encrypted_data_generator(data, decryption_dict, monitor):
+    async def _encrypted_data_generator(data, decryption_dict, monitor=None):
         """Yield encrypted chunks of bytes from data.
 
         If a monitor is passed, update its ``transfered`` property and

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -107,7 +107,7 @@ async def on_request_chunk_sent(session, context, params):
     context_obj = context.trace_request_ctx
 
     if isinstance(context_obj, TransferMonitor):
-        context_obj.transfered += len(params.chunk)
+        context_obj.transferred += len(params.chunk)
 
 
 def client_session(func):
@@ -1695,7 +1695,7 @@ class AsyncClient(Client):
     async def _plain_data_generator(self, data, monitor=None):
         """Yield chunks of bytes from data.
 
-        If a monitor is passed, update its ``transfered`` property and
+        If a monitor is passed, update its ``transferred`` property and
         suspend yielding chunks while its ``pause`` attribute is ``True``.
 
         Raise ``TransferCancelledError`` if ``monitor.cancel`` is ``True``.
@@ -1709,7 +1709,7 @@ class AsyncClient(Client):
     ):
         """Yield encrypted chunks of bytes from data.
 
-        If a monitor is passed, update its ``transfered`` property and
+        If a monitor is passed, update its ``transferred`` property and
         suspend yielding chunks while its ``pause`` attribute is ``True``.
 
         The last yielded value will be the decryption dict.
@@ -1780,7 +1780,7 @@ class AsyncClient(Client):
                 object is passed, it will be updated by this function while
                 uploading.
                 From this object, statistics such as currently
-                transfered bytes or estimated remaining time can be gathered
+                transferred bytes or estimated remaining time can be gathered
                 while the upload is running as a task; it also allows
                 for pausing and cancelling.
         """
@@ -1792,7 +1792,7 @@ class AsyncClient(Client):
         def provider(got_429, got_timeouts):
             if monitor and (got_429 or got_timeouts):
                 # We have to restart from scratch
-                monitor.transfered = 0
+                monitor.transferred = 0
 
             data = data_provider(got_429, got_timeouts)
 

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1781,10 +1781,10 @@ class AsyncClient(Client):
     @client_session
     async def download(
         self,
-        server_name,        # type: str
-        media_id,           # type: str
-        filename=None,      # type: Optional[str]
-        allow_remote=True,  # type: bool
+        server_name:  str,
+        media_id:     str,
+        filename:     Optional[str]             = None,
+        allow_remote: bool                      = True,
     ):
         # type: (...) -> Union[DownloadResponse, DownloadError]
         """Get the content of a file from the content repository.
@@ -1803,6 +1803,8 @@ class AsyncClient(Client):
                 This is to prevent routing loops where the server contacts
                 itself.
         """
+        # TODO: support TransferMonitor
+
         http_method, path = Api.download(
             server_name,
             media_id,

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1688,7 +1688,7 @@ class AsyncClient(Client):
                 raise TransferCancelledError()
 
             while monitor and monitor.pause:
-                await asyncio.sleep(1 / monitor.update_rate)
+                await asyncio.sleep(0.1)
 
             yield value
 
@@ -1712,7 +1712,7 @@ class AsyncClient(Client):
                     raise TransferCancelledError()
 
                 while monitor and monitor.pause:
-                    await asyncio.sleep(1 / monitor.update_rate)
+                    await asyncio.sleep(0.1)
 
                 yield value
 

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -106,7 +106,8 @@ async def async_generator_from_data(
     ###
 
     if isinstance(data, bytes):
-        yield data
+        for chunk in (data[i : i + 4096] for i in range(0, len(data), 4096)):
+            yield chunk
 
     # Test if data is a file obj first, since it's considered Iterable too
     elif isinstance(data, io.BufferedIOBase):

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -95,7 +95,8 @@ async def async_encrypt_attachment(data: AsyncDataT) -> _EncryptedReturnT:
 
 
 async def async_generator_from_data(
-    data: AsyncDataT,
+    data:       AsyncDataT,
+    chunk_size: int = 4 * 1024,
 ) -> AsyncGenerator[bytes, None]:
 
     aio_opened = False
@@ -106,20 +107,23 @@ async def async_generator_from_data(
     ###
 
     if isinstance(data, bytes):
-        for chunk in (data[i : i + 4096] for i in range(0, len(data), 4096)):
+        chunks = (
+            data[i : i + chunk_size] for i in range(0, len(data), chunk_size)
+        )
+        for chunk in chunks:
             yield chunk
 
     # Test if data is a file obj first, since it's considered Iterable too
     elif isinstance(data, io.BufferedIOBase):
        while True:
-            chunk = data.read(4096)
+            chunk = data.read(chunk_size)
             if not chunk:
                 return
             yield chunk
 
     elif isinstance(data, AsyncBufferedReader):
         while True:
-            chunk = await data.read(4096)
+            chunk = await data.read(chunk_size)
             if not chunk:
                 break
             yield chunk

--- a/nio/exceptions.py
+++ b/nio/exceptions.py
@@ -66,3 +66,7 @@ class EncryptionError(Exception):
 
 class GroupEncryptionError(Exception):
     pass
+
+
+class TransferCancelledError(Exception):
+    pass

--- a/nio/monitors.py
+++ b/nio/monitors.py
@@ -71,6 +71,10 @@ class TransferMonitor:
     def __post_init__(self) -> None:
         self.start_time   = datetime.now()
         self._past_speeds = Deque(maxlen=self.update_rate)
+        self._start_update_loop()
+
+    def _start_update_loop(self) -> None:
+        """Start a Thread running ``_update_loop()``."""
 
         self._updater = Thread(target=self._update_loop, daemon=True)
         self._updater.start()

--- a/nio/monitors.py
+++ b/nio/monitors.py
@@ -1,0 +1,100 @@
+# Copyright © 2018, 2019 Damir Jelić <poljar@termina.org.uk>
+# Copyright © 2019 miruka <miruka@disroot.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+# CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from threading import Thread
+from typing import Deque, Optional
+
+
+@dataclass
+class TransferMonitor:
+    total_size:  int  = field()
+    update_rate: int  = 10
+    pause:       bool = False
+    cancel:      bool = False
+
+    average_speed: float              = field(init=False, default=0.0)
+    start_time:    datetime           = field(init=False)
+    end_time:      Optional[datetime] = field(init=False, default=None)
+
+    _transfered:  int          = field(init=False, default=0)
+    _past_speeds: Deque[float] = field(init=False)
+    _updater:     Thread       = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.start_time   = datetime.now()
+        self._past_speeds = Deque(maxlen=self.update_rate)
+
+        self._updater = Thread(target=self._update_loop, daemon=True)
+        self._updater.start()
+
+    def _update_loop(self) -> None:
+        previous_transfered = 0
+        previous_date       = datetime.now()
+
+        while not self.done and not self.cancel:
+            transfered = self.transfered
+
+            self._past_speeds.append(
+                (transfered - previous_transfered) /
+                (datetime.now() - previous_date).total_seconds(),
+            )
+
+            self.average_speed = sum(self._past_speeds) / self.update_rate
+
+            previous_transfered = transfered
+            previous_date       = datetime.now()
+
+            time.sleep(1 / self.update_rate)
+
+        if self.done and not self.average_speed:
+            # Transfer was fast enough to end before we had time to calculate
+            self.average_speed = self.total_size
+
+    @property
+    def transfered(self) -> int:
+        return self._transfered
+
+    @transfered.setter
+    def transfered(self, size: int) -> None:
+        self._transfered = size
+
+        if size >= self.total_size:
+            self.end_time = datetime.now()
+
+    @property
+    def percent_done(self) -> float:
+        return self.transfered / self.total_size * 100
+
+    @property
+    def remaining(self) -> int:
+        return self.total_size - self.transfered
+
+    @property
+    def spent_time(self) -> timedelta:
+        return (self.end_time or datetime.now()) - self.start_time
+
+    @property
+    def remaining_time(self) -> Optional[timedelta]:
+        if not self.average_speed:
+            return None
+
+        return timedelta(seconds=self.remaining / self.average_speed)
+
+    @property
+    def done(self) -> bool:
+        return bool(self.end_time)

--- a/nio/monitors.py
+++ b/nio/monitors.py
@@ -57,6 +57,8 @@ class TransferMonitor:
 
         pause (bool): Indicates to methods using this object if the transfer
             should be paused. ``False`` by default.
+            At this time, servers don't handle pausing uploads well and
+            will end up dropping the connection after some time.
 
         cancel (bool): When set to True, stop updating statistics and
             indicate to methods using this object that they should raise

--- a/nio/monitors.py
+++ b/nio/monitors.py
@@ -65,7 +65,7 @@ class TransferMonitor:
     total_size:       int                               = field()
     on_transfered:    Optional[Callable[[int], None]]   = None
     on_speed_changed: Optional[Callable[[float], None]] = None
-    update_rate:      int                               = 4
+    update_rate:      int                               = 10
 
     average_speed: float              = field(init=False, default=0.0)
     start_time:    datetime           = field(init=False)

--- a/nio/monitors.py
+++ b/nio/monitors.py
@@ -162,12 +162,13 @@ class TransferMonitor:
     def remaining_time(self) -> Optional[timedelta]:
         """Estimated remaining time to complete the transfer.
 
-        Returns None (for infinity) if the current transfer speed is 0 bytes/s.
+        Returns None (for infinity) if the current transfer speed is 0 bytes/s,
+        or the remaining time is so long it would cause an OverflowError.
         """
-        if not self.average_speed:
+        try:
+            return timedelta(seconds=self.remaining / self.average_speed)
+        except (ZeroDivisionError, OverflowError):
             return None
-
-        return timedelta(seconds=self.remaining / self.average_speed)
 
     @property
     def done(self) -> bool:

--- a/nio/monitors.py
+++ b/nio/monitors.py
@@ -109,10 +109,11 @@ class TransferMonitor:
 
             consider_past_secs = min(times_we_got_data, self.speed_period) or 1
 
-            self.average_speed = (
+            self.average_speed = max(
+                0,
                 self.average_speed *
                 (consider_past_secs - 1) / consider_past_secs +
-                bytes_transfered_this_second / consider_past_secs
+                bytes_transfered_this_second / consider_past_secs,
             )
 
             if self.average_speed != previous_speed and self.on_speed_changed:

--- a/nio/monitors.py
+++ b/nio/monitors.py
@@ -34,8 +34,8 @@ class TransferMonitor:
     Args:
         total_size (int): Size in bytes of the data to transfer.
 
-        on_transfered (Callable[[int], None], optional): A callback to call
-            with the new value of ``transfered`` when it changes.
+        on_transferred (Callable[[int], None], optional): A callback to call
+            with the new value of ``transferred`` when it changes.
 
         on_speed_changed (Callable[[float], None], optional): A callback to
             call with the new value of ``average_speed`` when it changes.
@@ -47,7 +47,7 @@ class TransferMonitor:
 
     Attributes:
         average_speed (float): An average number of how many bytes
-            are being transfered per second.
+            are being transferred per second.
 
         start_time (datetime): The date when the ``TransferMonitor` object
             was created.
@@ -67,7 +67,7 @@ class TransferMonitor:
     # TODO: tell that this can be used for downloads too once implemented.
 
     total_size:       int                               = field()
-    on_transfered:    Optional[Callable[[int], None]]   = None
+    on_transferred:   Optional[Callable[[int], None]]   = None
     on_speed_changed: Optional[Callable[[float], None]] = None
     speed_period:     float                             = 10
 
@@ -77,13 +77,13 @@ class TransferMonitor:
     pause:         bool               = field(init=False, default=False)
     cancel:        bool               = field(init=False, default=False)
 
-    _transfered:            int       = field(init=False, default=0)
-    _updater:               Thread    = field(init=False)
-    _last_transfered_sizes: List[int] = field(init=False)
+    _transferred:            int       = field(init=False, default=0)
+    _updater:                Thread    = field(init=False)
+    _last_transferred_sizes: List[int] = field(init=False)
 
     def __post_init__(self) -> None:
-        self.start_time             = datetime.now()
-        self._last_transfered_sizes = []
+        self.start_time              = datetime.now()
+        self._last_transferred_sizes = []
         self._start_update_loop()
 
     def _start_update_loop(self) -> None:
@@ -102,8 +102,8 @@ class TransferMonitor:
                 time.sleep(0.1)
                 continue
 
-            bytes_transfered_this_second = sum(self._last_transfered_sizes)
-            self._last_transfered_sizes.clear()
+            bytes_transferred_this_second = sum(self._last_transferred_sizes)
+            self._last_transferred_sizes.clear()
 
             previous_speed = self.average_speed
 
@@ -113,13 +113,13 @@ class TransferMonitor:
                 0,
                 self.average_speed *
                 (consider_past_secs - 1) / consider_past_secs +
-                bytes_transfered_this_second / consider_past_secs,
+                bytes_transferred_this_second / consider_past_secs,
             )
 
             if self.average_speed != previous_speed and self.on_speed_changed:
                 self.on_speed_changed(self.average_speed)
 
-            if bytes_transfered_this_second:
+            if bytes_transferred_this_second:
                 times_we_got_data += 1
 
             time.sleep(1)
@@ -129,32 +129,32 @@ class TransferMonitor:
             self.average_speed = self.total_size
 
     @property
-    def transfered(self) -> int:
-        """Number of currently transfered bytes."""
-        return self._transfered
+    def transferred(self) -> int:
+        """Number of currently transferred bytes."""
+        return self._transferred
 
-    @transfered.setter
-    def transfered(self, size: int) -> None:
-        old_value        = self._transfered
-        self._transfered = size
+    @transferred.setter
+    def transferred(self, size: int) -> None:
+        old_value        = self._transferred
+        self._transferred = size
 
-        self._last_transfered_sizes.append(size - old_value)
+        self._last_transferred_sizes.append(size - old_value)
 
         if size >= self.total_size:
             self.end_time = datetime.now()
 
-        if size != old_value and self.on_transfered:
-            self.on_transfered(size)
+        if size != old_value and self.on_transferred:
+            self.on_transferred(size)
 
     @property
     def percent_done(self) -> float:
         """Percentage of completion for the transfer."""
-        return self.transfered / self.total_size * 100
+        return self.transferred / self.total_size * 100
 
     @property
     def remaining(self) -> int:
         """Number of remaining bytes to transfer."""
-        return self.total_size - self.transfered
+        return self.total_size - self.transferred
 
     @property
     def spent_time(self) -> timedelta:

--- a/nio/monitors.py
+++ b/nio/monitors.py
@@ -19,13 +19,12 @@ from datetime import datetime, timedelta
 from threading import Thread
 from typing import Deque, Optional
 
-
 @dataclass
 class TransferMonitor:
-    """Get statistics, pause or cancel a running upload or download.
+    """Get statistics, pause or cancel a running upload.
 
     A ``TransferMonitor`` object can be passed to the
-    ``AsyncClient.upload()`` and ``AsyncClient.download()`` methods;
+    ``AsyncClient.upload()`` methods;
     the methods will then update the object's statistics while the transfer
     is running.
 
@@ -54,6 +53,7 @@ class TransferMonitor:
             indicate to methods using this object that they should raise
             a ``TransferCancelledError``.
     """
+    # TODO: tell that this can be used for downloads too once implemented.
 
     total_size:  int  = field()
     update_rate: int  = 10

--- a/nio/monitors.py
+++ b/nio/monitors.py
@@ -81,6 +81,8 @@ class TransferMonitor:
     _updater:                Thread    = field(init=False)
     _last_transferred_sizes: List[int] = field(init=False)
 
+    _update_loop_sleep_time: float = field(default=1)
+
     def __post_init__(self) -> None:
         self.start_time              = datetime.now()
         self._last_transferred_sizes = []
@@ -99,7 +101,7 @@ class TransferMonitor:
 
         while not self.done and not self.cancel:
             if self.pause:
-                time.sleep(0.1)
+                time.sleep(self._update_loop_sleep_time / 10)
                 continue
 
             bytes_transferred_this_second = sum(self._last_transferred_sizes)
@@ -122,7 +124,7 @@ class TransferMonitor:
             if bytes_transferred_this_second:
                 times_we_got_data += 1
 
-            time.sleep(1)
+            time.sleep(self._update_loop_sleep_time)
 
         if self.done and not self.average_speed:
             # Transfer was fast enough to end before we had time to calculate

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -14,4 +14,5 @@ sphinx >= 1.8
 aiohttp; python_version >= '3.5'
 aioresponses; python_version >= '3.5'
 aiofiles; python_version >= '3.5'
+dataclasses; python_version < '3.7'
 m2r

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "aiohttp;python_version>'3.5'",
         "aiofiles;python_version>'3.5'",
         "typing;python_version<'3.5'",
+        "dataclasses;python_version<'3.7'",
         "h11",
         "h2",
         "logbook",

--- a/tests/async_attachment_test.py
+++ b/tests/async_attachment_test.py
@@ -21,8 +21,8 @@ class TestClass:
         return (data, b"".join(chunks), keys)
 
 
-    async def test_encrypt(self, data=b"Test bytes"):
-        data, cyphertext, keys = await self._get_data_cypher_keys(data)
+    async def test_encrypt(self, data=b"Test bytes", large=False):
+        _, cyphertext, keys = await self._get_data_cypher_keys(data)
 
         plaintext = decrypt_attachment(
             cyphertext,
@@ -31,7 +31,12 @@ class TestClass:
             keys["iv"],
         )
 
-        assert plaintext == b"Test bytes"
+        assert plaintext == b"Test bytes" * (16384 if large else 1)
+
+    async def test_encrypt_large_bytes(self):
+        # Makes sure our bytes chunking in async_generator_from_data
+        # is working correctly
+        await self.test_encrypt(b"Test bytes" * 16384, large=True)
 
     async def test_encrypt_str(self):
         await self.test_encrypt(FILEPATH)

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -964,7 +964,7 @@ class TestClass(object):
         params  = TraceRequestChunkSentParams(chunk=b"x")
 
         await on_request_chunk_sent(session, context, params)
-        assert monitor.transfered == 1
+        assert monitor.transferred == 1
         self._verify_monitor_state_for_finished_transfer(monitor, 1)
 
     async def test_plain_data_generator(self, async_client):
@@ -998,8 +998,8 @@ class TestClass(object):
         with pytest.raises(TransferCancelledError):
             await gen.__anext__()
 
-        monitor.transfered += len(b"".join(data))
-        assert monitor.transfered == len(b"".join(data))
+        monitor.transferred += len(b"".join(data))
+        assert monitor.transferred == len(b"".join(data))
         self._wait_monitor_thread_exited(monitor)
 
         left      = original_data[len(data):]
@@ -1012,7 +1012,7 @@ class TestClass(object):
         data += [chunk async for chunk in gen]
 
         assert data == original_data
-        monitor.transfered = monitor.total_size
+        monitor.transferred = monitor.total_size
         self._verify_monitor_state_for_finished_transfer(monitor, left_size)
 
     async def test_encrypted_data_generator(self, async_client):
@@ -1049,8 +1049,8 @@ class TestClass(object):
         with pytest.raises(TransferCancelledError):
             await gen.__anext__()
 
-        monitor.transfered += len(encrypted_data)
-        assert monitor.transfered == len(encrypted_data)
+        monitor.transferred += len(encrypted_data)
+        assert monitor.transferred == len(encrypted_data)
         self._wait_monitor_thread_exited(monitor)
 
         # Restart from scratch (avoid encrypted data SHA mismatch)
@@ -1078,34 +1078,34 @@ class TestClass(object):
         )
 
         assert decrypted_data == original_data
-        monitor.transfered = monitor.total_size
+        monitor.transferred = monitor.total_size
         self._verify_monitor_state_for_finished_transfer(monitor, data_size)
 
     def test_transfer_monitor_callbacks(self):
-        called = {"transfered": (0, 0), "speed_changed": 0}
+        called = {"transferred": (0, 0), "speed_changed": 0}
 
-        def on_transfered(transfered: int):
-            called["transfered"] = (called["transfered"][0] + 1, transfered)
+        def on_transferred(transferred: int):
+            called["transferred"] = (called["transferred"][0] + 1, transferred)
 
         def on_speed_changed(speed: float):
             called["speed_changed"] += 1
 
-        monitor = TransferMonitor(100, on_transfered, on_speed_changed)
-        monitor.transfered += 50
+        monitor = TransferMonitor(100, on_transferred, on_speed_changed)
+        monitor.transferred += 50
 
         slept = 0
 
-        while not called["transfered"] or not called["speed_changed"]:
+        while not called["transferred"] or not called["speed_changed"]:
             time.sleep(0.1)
             slept += 0.1
 
             if slept >= 1:
                 raise RuntimeError("1+ callback not called after 1s", called)
 
-        assert called["transfered"] == (1, 50)
+        assert called["transferred"] == (1, 50)
         assert called["speed_changed"] == 1
 
-        monitor.transfered += 50
+        monitor.transferred += 50
         self._verify_monitor_state_for_finished_transfer(monitor, 100)
 
 
@@ -1123,7 +1123,7 @@ class TestClass(object):
         assert monitor.total_size == data_size
         assert monitor.start_time and monitor.end_time
         assert monitor.average_speed > 0
-        assert monitor.transfered == data_size
+        assert monitor.transferred == data_size
         assert monitor.percent_done == 100
         assert monitor.remaining == 0
         assert monitor.spent_time.microseconds > 0

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -916,7 +916,7 @@ class TestClass(object):
         monitor  = TransferMonitor(filesize)
 
         resp, decryption_info = await async_client.upload(
-            path, "image/png", "test.png", monitor=monitor,
+            lambda *_: path, "image/png", "test.png", monitor=monitor,
         )
         assert isinstance(resp, UploadResponse)
         assert decryption_info is None
@@ -942,7 +942,7 @@ class TestClass(object):
 
         async with aiofiles.open("tests/data/file_response", "rb") as file:
             resp, decryption_info = await async_client.upload(
-                file, "image/png", "test.png", encrypt=True,
+                lambda *_: file, "image/png", "test.png", encrypt=True,
             )
 
         assert isinstance(resp, UploadResponse)

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1,4 +1,5 @@
 import json
+import math
 import sys
 import re
 import time
@@ -1108,6 +1109,13 @@ class TestClass(object):
         monitor.transferred += 50
         self._verify_monitor_state_for_finished_transfer(monitor, 100)
 
+    def test_transfer_monitor_bad_remaining_time(self):
+        monitor = TransferMonitor(100)
+        assert monitor.average_speed == 0.0
+        assert monitor.remaining_time is None
+
+        monitor.total_size = math.inf
+        assert monitor.remaining_time is None
 
     @staticmethod
     def _wait_monitor_thread_exited(monitor):


### PR DESCRIPTION
This adds a `TransferMonitor` class that users can instantiate and pass to `AsyncClient.upload()`. While the method is processing data chunks to send, it will suspend or cancel the processing if the monitor's attributes are set to do so. By leveraging aiohttp's `TraceConfig`, the monitor's `transferred` (bytes sent) property is updated, which are the basis for other provided statistics such as average speed or estimated remaining time. 

Pausing is currently not well supported across homeservers, with the connection timing out after a certain time depending of the HTTP server's config (for example, `client_body_timeout 300s;` in nginx). When this happens, the upload process has to restart from 0.

I plan to make `download()` also able to use the monitor later. 