### PR TITLE
Use Py2.7 compatible typing for access_token

### DIFF
--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -164,7 +164,7 @@ class Client(object):
 
         self.user_id = ""
         # TODO Turn this into a optional string.
-        self.access_token: str = ""
+        self.access_token = ""  # type: str
         self.next_batch = ""
         self.loaded_sync_token = ""
 


### PR DESCRIPTION
Hey @poljar :wave: 

I was trying to run the tests for weechat-matrix and it looks like this is the only typing that's not Python2.7 compatible. Is 2.7 still officially supported? What I see in the README is that
> nio on the other hand works with older python versions as well.

Thanks for reviewing!