### PR TITLE
Add the ability to login using a custom auth string

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -299,6 +299,19 @@ class Api(object):
         Args:
             auth_dict (Dict[str, Any): The authentication dictionary
                 containing the elements for the logon.
+            For example :
+                auth_dict = {
+                    "type": "m.login.password",
+                    "identifier": {
+                        "type": "m.id.thirdparty",
+                        "medium": "email",
+                        "address": "testemail@mail.org"
+                    },
+                    "password": "PASSWORDABCD",
+                    "initial_device_display_name": "Test user"
+                }
+            See https://matrix.org/docs/spec/client_server/r0.6.0#authentication-types
+            for detailed documentation.
         """
         if auth_dict is None or auth_dict == {}:
             raise ValueError("Auth dictionary shall not be empty")

--- a/nio/api.py
+++ b/nio/api.py
@@ -288,21 +288,24 @@ class Api(object):
         return "POST", path, Api.to_json(content_dict)
 
     @staticmethod
-    def login_with_auth_string(
-        auth_string      # type: str
+    def login_raw(
+        auth_dict      # type: Dict[str, Any]
     ):
-        # type: (...) -> Tuple[str, str, str]
-        """Authenticate the user.
+        # type: (Dict[str, Any]) -> Tuple[str, str, str]
+        """Login to the homeserver using a raw dictionary.
 
         Returns the HTTP method, HTTP path and data for the request.
 
         Args:
-            auth_string (str): The authentication string containing the
-                elements for the logon
+            auth_dict (Dict[str, Any): The authentication dictionary
+                containing the elements for the logon.
         """
+        if auth_dict is None or auth_dict == {}:
+            raise ValueError("Auth dictionary shall not be empty")
+
         path = Api._build_path("login")
 
-        return "POST", path, Api.to_json(auth_string)
+        return "POST", path, Api.to_json(auth_dict)
 
 
     @staticmethod

--- a/nio/api.py
+++ b/nio/api.py
@@ -299,19 +299,21 @@ class Api(object):
         Args:
             auth_dict (Dict[str, Any): The authentication dictionary
                 containing the elements for the logon.
-            For example :
-                auth_dict = {
-                    "type": "m.login.password",
-                    "identifier": {
-                        "type": "m.id.thirdparty",
-                        "medium": "email",
-                        "address": "testemail@mail.org"
-                    },
-                    "password": "PASSWORDABCD",
-                    "initial_device_display_name": "Test user"
-                }
-            See https://matrix.org/docs/spec/client_server/r0.6.0#authentication-types
-            for detailed documentation.
+                See the example below and here
+                 https://matrix.org/docs/spec/client_server/r0.6.0#authentication-types
+                for detailed documentation
+
+        Example:
+                >>> auth_dict = {
+                >>>     "type": "m.login.password",
+                >>>     "identifier": {
+                >>>         "type": "m.id.thirdparty",
+                >>>         "medium": "email",
+                >>>         "address": "testemail@mail.org"
+                >>>     },
+                >>>     "password": "PASSWORDABCD",
+                >>>     "initial_device_display_name": "Test user"
+                >>> }
         """
         if auth_dict is None or auth_dict == {}:
             raise ValueError("Auth dictionary shall not be empty")

--- a/nio/api.py
+++ b/nio/api.py
@@ -288,6 +288,24 @@ class Api(object):
         return "POST", path, Api.to_json(content_dict)
 
     @staticmethod
+    def login_with_auth_string(
+        auth_string      # type: str
+    ):
+        # type: (...) -> Tuple[str, str, str]
+        """Authenticate the user.
+
+        Returns the HTTP method, HTTP path and data for the request.
+
+        Args:
+            auth_string (str): The authentication string containing the
+                elements for the logon
+        """
+        path = Api._build_path("login")
+
+        return "POST", path, Api.to_json(auth_string)
+
+
+    @staticmethod
     def logout(
         access_token,     # type: str
         all_devices=False         # type: bool

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -602,19 +602,22 @@ class AsyncClient(Client):
 
         Args:
             auth_dict (Dict[str, Any]): The auth dictionary.
-            For example :
-                auth_dict = {
-                    "type": "m.login.password",
-                    "identifier": {
-                        "type": "m.id.thirdparty",
-                        "medium": "email",
-                        "address": "testemail@mail.org"
-                    },
-                    "password": "PASSWORDABCD",
-                    "initial_device_display_name": "Test user"
-                }
-            See https://matrix.org/docs/spec/client_server/r0.6.0#authentication-types
-            for detailed documentation.
+                See the example below and here
+                 https://matrix.org/docs/spec/client_server/r0.6.0#authentication-types
+                for detailed documentation
+
+        Example:
+                >>> auth_dict = {
+                >>>     "type": "m.login.password",
+                >>>     "identifier": {
+                >>>         "type": "m.id.thirdparty",
+                >>>         "medium": "email",
+                >>>         "address": "testemail@mail.org"
+                >>>     },
+                >>>     "password": "PASSWORDABCD",
+                >>>     "initial_device_display_name": "Test user"
+                >>> }
+
         Returns either a `LoginResponse` if the request was successful or
         a `LoginError` if there was an error with the request.
         """

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -596,19 +596,21 @@ class AsyncClient(Client):
         """Convert a matrix content URI to a HTTP URI."""
         return Api.mxc_to_http(mxc, homeserver or self.homeserver)
 
-    async def login_with_auth_string(self, auth_string):
-        # type: (str) -> Union[LoginResponse, LoginError]
-        """Login to the homeserver.
+    async def login_raw(self, auth_dict):
+        # type: (Dict[str, Any]) -> Union[LoginResponse, LoginError]
+        """Login to the homeserver using a raw dictionary.
 
         Args:
-            auth_string (str): The auth string.
-
+            auth_dict (Dict[str, Any]): The auth dictionary.
+            See https://matrix.org/docs/spec/client_server/r0.6.0#authentication-types
+            for valid authentication dictionaries.
         Returns either a `LoginResponse` if the request was successful or
         a `LoginError` if there was an error with the request.
         """
-        method, path, data = Api.login_with_auth_string(
-            auth_string
-        )
+        if auth_dict is None or auth_dict == {}:
+            raise ValueError("Auth dictionary shall not be empty")
+
+        method, path, data = Api.login_raw(auth_dict)
 
         return await self._send(LoginResponse, method, path, data)
 

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -596,6 +596,22 @@ class AsyncClient(Client):
         """Convert a matrix content URI to a HTTP URI."""
         return Api.mxc_to_http(mxc, homeserver or self.homeserver)
 
+    async def login_with_auth_string(self, auth_string):
+        # type: (str) -> Union[LoginResponse, LoginError]
+        """Login to the homeserver.
+
+        Args:
+            auth_string (str): The auth string.
+
+        Returns either a `LoginResponse` if the request was successful or
+        a `LoginError` if there was an error with the request.
+        """
+        method, path, data = Api.login_with_auth_string(
+            auth_string
+        )
+
+        return await self._send(LoginResponse, method, path, data)
+
     async def login(self, password, device_name=""):
         # type: (str, str) -> Union[LoginResponse, LoginError]
         """Login to the homeserver.

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -602,8 +602,19 @@ class AsyncClient(Client):
 
         Args:
             auth_dict (Dict[str, Any]): The auth dictionary.
+            For example :
+                auth_dict = {
+                    "type": "m.login.password",
+                    "identifier": {
+                        "type": "m.id.thirdparty",
+                        "medium": "email",
+                        "address": "testemail@mail.org"
+                    },
+                    "password": "PASSWORDABCD",
+                    "initial_device_display_name": "Test user"
+                }
             See https://matrix.org/docs/spec/client_server/r0.6.0#authentication-types
-            for valid authentication dictionaries.
+            for detailed documentation.
         Returns either a `LoginResponse` if the request was successful or
         a `LoginError` if there was an error with the request.
         """

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -261,6 +261,20 @@ class HttpClient(Client):
         return self._send(request, RequestInfo(LoginResponse))
 
     @connected
+    def login_with_auth_string(self, auth_string):
+        # type: (str) -> Tuple[UUID, bytes]
+        if auth_string is None and auth_string == "":
+            raise ValueError("Auth string shall not be empty")
+
+        request = self._build_request(
+            Api.login_with_auth_string(
+                auth_string
+            )
+        )
+
+        return self._send(request, RequestInfo(LoginResponse))
+
+    @connected
     @logged_in
     def logout(self, all_devices=False):
         request = self._build_request(

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -263,7 +263,7 @@ class HttpClient(Client):
     @connected
     def login_with_auth_string(self, auth_string):
         # type: (str) -> Tuple[UUID, bytes]
-        if auth_string is None and auth_string == "":
+        if auth_string is None or auth_string == "":
             raise ValueError("Auth string shall not be empty")
 
         request = self._build_request(

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -261,16 +261,12 @@ class HttpClient(Client):
         return self._send(request, RequestInfo(LoginResponse))
 
     @connected
-    def login_with_auth_string(self, auth_string):
-        # type: (str) -> Tuple[UUID, bytes]
-        if auth_string is None or auth_string == "":
-            raise ValueError("Auth string shall not be empty")
+    def login_raw(self, auth_dict):
+        # type: (Dict[str, Any]) -> Tuple[UUID, bytes]
+        if auth_dict is None or auth_dict == {}:
+            raise ValueError("Auth dictionary shall not be empty")
 
-        request = self._build_request(
-            Api.login_with_auth_string(
-                auth_string
-            )
-        )
+        request = self._build_request(Api.login_raw(auth_dict))
 
         return self._send(request, RequestInfo(LoginResponse))
 

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -380,7 +380,7 @@ class TestClass(object):
         loop.run_until_complete(async_client.close())
         assert not async_client.client_session
 
-    def test_login_with_auth_string(self, async_client, aioresponse):
+    def test_login_raw(self, async_client, aioresponse):
         loop = asyncio.get_event_loop()
 
         assert not async_client.access_token
@@ -391,7 +391,7 @@ class TestClass(object):
             status=200,
             payload=self.login_response
         )
-        auth_string = {
+        auth_dict = {
             "type": "m.login.password",
             "identifier": {
                 "type": "m.id.thirdparty",
@@ -402,8 +402,8 @@ class TestClass(object):
             "initial_device_display_name": "Test user"
         }
         resp = loop.run_until_complete(
-            async_client.login_with_auth_string(
-                auth_string
+            async_client.login_raw(
+                auth_dict
             )
         )
 
@@ -411,7 +411,7 @@ class TestClass(object):
         assert async_client.access_token
         assert async_client.logged_in
 
-    def test_failed_login_with_auth_string(self, async_client, aioresponse):
+    def test_failed_login_raw(self, async_client, aioresponse):
         loop = asyncio.get_event_loop()
 
         assert not async_client.access_token
@@ -423,7 +423,7 @@ class TestClass(object):
             body=""
         )
 
-        auth_string = {
+        auth_dict = {
             "type": "m.login.password",
             "identifier": {
                 "type": "m.id.thirdparty",
@@ -435,14 +435,55 @@ class TestClass(object):
         }
 
         resp = loop.run_until_complete(
-            async_client.login_with_auth_string(
-                auth_string
-            )
+            async_client.login_raw(auth_dict)
         )
+
         assert isinstance(resp, LoginError)
         assert not async_client.logged_in
 
         assert async_client.client_session
+        loop.run_until_complete(async_client.close())
+        assert not async_client.client_session
+
+    def test_login_raw_with_empty_dict(self, async_client, aioresponse):
+        loop = asyncio.get_event_loop()
+
+        assert not async_client.access_token
+        assert not async_client.logged_in
+
+        auth_dict = {}
+        resp = None
+
+        with pytest.raises(ValueError):
+            resp = loop.run_until_complete(
+                async_client.login_raw(auth_dict)
+            )
+
+        assert not resp
+        assert not async_client.logged_in
+
+        assert not async_client.client_session
+        loop.run_until_complete(async_client.close())
+        assert not async_client.client_session
+
+    def test_login_raw_with_none_dict(self, async_client, aioresponse):
+        loop = asyncio.get_event_loop()
+
+        assert not async_client.access_token
+        assert not async_client.logged_in
+
+        auth_dict = None
+        resp = None
+
+        with pytest.raises(ValueError):
+            resp = loop.run_until_complete(
+                async_client.login_raw(auth_dict)
+            )
+
+        assert not resp
+        assert not async_client.logged_in
+
+        assert not async_client.client_session
         loop.run_until_complete(async_client.close())
         assert not async_client.client_session
 

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -344,6 +344,37 @@ class TestClass(object):
         expected     = f"{other_server}{url_path}"
         assert await async_client.mxc_to_http(mxc, other_server) == expected
 
+    def test_login_with_auth_string(self, async_client, aioresponse):
+        loop = asyncio.get_event_loop()
+
+        assert not async_client.access_token
+        assert not async_client.logged_in
+
+        aioresponse.post(
+            "https://example.org/_matrix/client/r0/login",
+            status=200,
+            payload=self.login_response
+        )
+        auth_string = {
+            "type": "m.login.password",
+            "identifier": {
+                "type": "m.id.thirdparty",
+                "medium": "email",
+                "address": "testemail@mail.org"
+            },
+            "password": "PASSWORDABCD",
+            "initial_device_display_name": "Citadel bot"
+        }
+        resp = loop.run_until_complete(
+            async_client.login_with_auth_string(
+                auth_string
+            )
+        )
+
+        assert isinstance(resp, LoginResponse)
+        assert async_client.access_token
+        assert async_client.logged_in
+
     def test_login(self, async_client, aioresponse):
         loop = asyncio.get_event_loop()
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -722,9 +722,9 @@ class TestClass(object):
         assert isinstance(response, LoginResponse)
         assert http_client.access_token == "ABCD"
 
-    def test_http_client_login_with_auth_string(self, http_client):
+    def test_http_client_login_raw(self, http_client):
         http_client.connect(TransportType.HTTP2)
-        auth_string = {
+        auth_dict = {
             "type": "m.login.password",
             "identifier": {
                 "type": "m.id.thirdparty",
@@ -734,9 +734,7 @@ class TestClass(object):
             "password": "PASSWORDABCD",
             "initial_device_display_name": "Citadel bot"
         }
-        _, _ = http_client.login_with_auth_string(
-            auth_string
-        )
+        _, _ = http_client.login_raw(auth_dict)
 
         http_client.receive(self.login_byte_response)
         response = http_client.next_response()
@@ -744,24 +742,22 @@ class TestClass(object):
         assert isinstance(response, LoginResponse)
         assert http_client.access_token == "ABCD"
 
-    def test_http_client_login_with_empty_auth_string(self, http_client):
+    def test_http_client_login_raw_with_empty_dict(self, http_client):
         http_client.connect(TransportType.HTTP2)
-        auth_string = ""
+        auth_dict = {}
 
         with pytest.raises(ValueError):
-            _, _ = http_client.login_with_auth_string(
-                auth_string
-            )
+            _, _ = http_client.login_raw(auth_dict)
 
         assert not http_client.access_token == "ABCD"
 
-    def test_http_client_login_with_none_auth_string(self, http_client):
+    def test_http_client_login_raw_with_none_dict(self, http_client):
         http_client.connect(TransportType.HTTP2)
-        auth_string = None
+        auth_dict = None
 
         with pytest.raises(ValueError):
-            _, _ = http_client.login_with_auth_string(
-                auth_string
+            _, _ = http_client.login_raw(
+                auth_dict
             )
 
         assert not http_client.access_token == "ABCD"

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -744,6 +744,27 @@ class TestClass(object):
         assert isinstance(response, LoginResponse)
         assert http_client.access_token == "ABCD"
 
+    def test_http_client_login_with_empty_auth_string(self, http_client):
+        http_client.connect(TransportType.HTTP2)
+        auth_string = ""
+
+        with pytest.raises(ValueError):
+            _, _ = http_client.login_with_auth_string(
+                auth_string
+            )
+
+        assert not http_client.access_token == "ABCD"
+
+    def test_http_client_login_with_none_auth_string(self, http_client):
+        http_client.connect(TransportType.HTTP2)
+        auth_string = None
+
+        with pytest.raises(ValueError):
+            _, _ = http_client.login_with_auth_string(
+                auth_string
+            )
+
+        assert not http_client.access_token == "ABCD"
 
     def test_http_client_sync(self, http_client):
         http_client.connect(TransportType.HTTP2)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -722,6 +722,29 @@ class TestClass(object):
         assert isinstance(response, LoginResponse)
         assert http_client.access_token == "ABCD"
 
+    def test_http_client_login_with_auth_string(self, http_client):
+        http_client.connect(TransportType.HTTP2)
+        auth_string = {
+            "type": "m.login.password",
+            "identifier": {
+                "type": "m.id.thirdparty",
+                "medium": "email",
+                "address": "testemail@mail.org"
+            },
+            "password": "PASSWORDABCD",
+            "initial_device_display_name": "Citadel bot"
+        }
+        _, _ = http_client.login_with_auth_string(
+            auth_string
+        )
+
+        http_client.receive(self.login_byte_response)
+        response = http_client.next_response()
+
+        assert isinstance(response, LoginResponse)
+        assert http_client.access_token == "ABCD"
+
+
     def test_http_client_sync(self, http_client):
         http_client.connect(TransportType.HTTP2)
 


### PR DESCRIPTION
For some deployments of matrix.org (namely Citadel by Thalès) the provided methods do not allow to use the standard auth string. This commit for allowing logging in using a custom formed auth_string. 

I defined specific methods for logging in, rather than overloading the existing ones, but I find the overloading solution to be more elegant.

Please let me know if additional changes are required.

Signed-off-by: Benoît Clouet <benoit.clouet@gmail.com>