### PR TITLE
Improve TransferMonitor statistics accuracy

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -31,6 +31,7 @@ from aiofiles.threadpool.binary import AsyncBufferedReader
 from aiohttp import (ClientResponse, ClientSession, ContentTypeError,
                      TraceConfig)
 from aiohttp.client_exceptions import ClientConnectionError
+from aiohttp.connector import Connection
 
 from . import Client, ClientConfig
 from .base_client import logged_in, store_loaded
@@ -116,6 +117,12 @@ async def on_request_chunk_sent(session, context, params):
         context_obj.transferred += len(params.chunk)
 
 
+async def connect_wrapper(self, *args, **kwargs) -> Connection:
+    connection = await type(self).connect(self, *args, **kwargs)
+    connection.transport.set_write_buffer_limits(16 * 1024)
+    return connection
+
+
 def client_session(func):
     """Ensure that the Async client has a valid client session."""
 
@@ -126,6 +133,9 @@ def client_session(func):
             trace.on_request_chunk_sent.append(on_request_chunk_sent)
 
             self.client_session = ClientSession(trace_configs=[trace])
+            self.client_session.connector.connect = partial(
+                connect_wrapper, self.client_session.connector,
+            )
 
         return await func(self, *args, **kwargs)
 


### PR DESCRIPTION
The default transport used by `Connection` objects (which are returned by `ClientSession.connector.connect()`) has an inappropriate default write buffer limit ranging from 64 to 512KiB depending on the implementation (tested with normal asyncio and uvloop).

If the user's connection isn't fast enough to fill the buffer at least once per second, this causes the callback for the client's trace config `on_request_chunk_sent` to fire too fast without waiting for the server to actually receive chunks, and the `TransferMonitor` is left hanging at the end waiting for the server to catch up and buffers to be drained.

I haven't found a direct or clean way to change the transport buffer size in aiohttp, so I'm patching `connect()` to set it to 16KiB max. 