### PR TITLE
ThumbnailResponse: ensure content type is image/*

### DIFF
--- a/nio/responses.py
+++ b/nio/responses.py
@@ -684,6 +684,9 @@ class ThumbnailResponse(FileResponse):
             filename=None  # type: Optional[str]
     ):
         # type: (...) -> Union[ThumbnailResponse, ThumbnailError]
+        if not content_type.startswith("image/"):
+            return ThumbnailError(f"invalid content type: {content_type}")
+
         if isinstance(data, bytes):
             return cls(body=data, content_type=content_type, filename=filename)
 

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -148,6 +148,9 @@ class TestClass(object):
         response = ThumbnailResponse.from_data("123", "image/png")
         assert isinstance(response, ThumbnailError)
 
+        response = ThumbnailResponse.from_data(b"5xx error", "text/html")
+        assert isinstance(response, ThumbnailError)
+
     def test_sync_fail(self):
         parsed_dict = {}
         response = SyncResponse.from_dict(parsed_dict, 0)


### PR DESCRIPTION
A server could return something unexpected instead of an image, for example an HTML error page. In these cases we need to return a ThumbnailError.