### PR TITLE
Adds ReadReceiptEvent for m.receipt events

### DIFF
--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -28,7 +28,8 @@ from .events import (Event, InviteAliasEvent, InviteMemberEvent,
                      RoomAliasEvent, RoomCreateEvent, RoomEncryptionEvent,
                      RoomGuestAccessEvent, RoomHistoryVisibilityEvent,
                      RoomJoinRulesEvent, RoomMemberEvent, RoomNameEvent,
-                     RoomTopicEvent, RoomAvatarEvent, TypingNoticeEvent)
+                     RoomTopicEvent, RoomAvatarEvent, TypingNoticeEvent,
+                     ReceiptEvent, Receipt)
 from .log import logger_group
 from .responses import RoomSummary
 
@@ -66,6 +67,7 @@ class MatrixRoom(object):
         self.encrypted = encrypted    # type: bool
         self.power_levels = PowerLevels()  # type: PowerLevels
         self.typing_users = []        # type: List[str]
+        self.read_receipts = {}       # type: Dict[str, Receipt]
         self.summary = None           # type: Optional[RoomSummary]
         self.room_avatar_url = None        # type: Optional[str]
         # yapf: enable
@@ -293,6 +295,14 @@ class MatrixRoom(object):
     def handle_ephemeral_event(self, event):
         if isinstance(event, TypingNoticeEvent):
             self.typing_users = event.users
+
+        if isinstance(event, ReceiptEvent):
+            read_receipts = filter(
+                lambda x: x.receipt_type == "m.read", event.receipts
+            )
+
+            for read_receipt in read_receipts:
+                self.read_receipts[read_receipt.user_id] = read_receipt
 
     def handle_event(self, event: Event):
         logger.info(

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1130,7 +1130,8 @@ class Schemas(object):
                                         "type": "object",
                                         "properties": {
                                             "ts": {"type" : "integer"}
-                                        }
+                                        },
+                                        "required": ["ts"]
                                     }
                                 }
                             }

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -22,6 +22,7 @@ from jsonschema import Draft4Validator, FormatChecker, validators
 RoomRegex = "^!.+:.+$"
 UserIdRegex = "^@.*:.+$"
 EventTypeRegex = r"^.+\..+"
+EventIdRegex = r"^\$.+:.+$"
 Base64Regex = r"[^-A-Za-z0-9+/=]|=[^=]|={3,}$"
 KeyRegex = r"(ed25519|curve25519):.+"
 SignedCurveRegex = r"(signed_curve25519|curve25519):.+"
@@ -1106,6 +1107,37 @@ class Schemas(object):
                     }
                 },
                 "required": ["user_ids"]
+            },
+            "type": {"type": "string"},
+            "room_id": {"type": "string"}
+        },
+        "required": ["content", "type"],
+        "additionalProperties": False,
+    }
+
+    m_read = {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "object",
+                "patternProperties": {
+                    EventIdRegex: {
+                        "type": "object",
+                        "properties": {
+                            "m.read": {
+                                "type": "object",
+                                "patternProperties": {
+                                    UserIdRegex: {
+                                        "type": "object",
+                                        "properties": {
+                                            "ts": {"type" : "integer"}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             },
             "type": {"type": "string"},
             "room_id": {"type": "string"}

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -22,7 +22,6 @@ from jsonschema import Draft4Validator, FormatChecker, validators
 RoomRegex = "^!.+:.+$"
 UserIdRegex = "^@.*:.+$"
 EventTypeRegex = r"^.+\..+"
-EventIdRegex = r"^\$.+:.+$"
 Base64Regex = r"[^-A-Za-z0-9+/=]|=[^=]|={3,}$"
 KeyRegex = r"(ed25519|curve25519):.+"
 SignedCurveRegex = r"(signed_curve25519|curve25519):.+"
@@ -1115,13 +1114,13 @@ class Schemas(object):
         "additionalProperties": False,
     }
 
-    m_read = {
+    m_receipt = {
         "type": "object",
         "properties": {
             "content": {
                 "type": "object",
                 "patternProperties": {
-                    EventIdRegex: {
+                    r".*": {
                         "type": "object",
                         "properties": {
                             "m.read": {
@@ -1143,7 +1142,7 @@ class Schemas(object):
             "room_id": {"type": "string"}
         },
         "required": ["content", "type"],
-        "additionalProperties": False,
+        "additionalProperties": True,
     }
 
     keys_upload = {

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -19,7 +19,8 @@ from nio import (Client, DeviceList, DeviceOneTimeKeyCount, DownloadResponse,
                  RoomSummary, RoomTypingResponse, RoomRedactResponse,
                  ShareGroupSessionResponse, SyncResponse,
                  Timeline, ThumbnailResponse, TransportType, TypingNoticeEvent,
-                 InviteMemberEvent, InviteInfo, ClientConfig, ReadReceiptEvent)
+                 InviteMemberEvent, InviteInfo, ClientConfig, ReceiptEvent,
+                 Receipt)
 from nio.event_builders import ToDeviceMessage
 
 HOST = "example.org"
@@ -289,13 +290,19 @@ class TestClass(object):
         test_room_info = RoomInfo(
             timeline,
             [],
-            [TypingNoticeEvent([ALICE_ID]), ReadReceiptEvent({
-                "event_id_3": [{
-                    "receipt_type": "m.read",
-                    "user_id": ALICE_ID,
-                    "timestamp": 1516809890615
-                }]
-            })],
+            [
+                TypingNoticeEvent([ALICE_ID]),
+                ReceiptEvent(
+                    [
+                        Receipt(
+                            event_id="event_id_3",
+                            receipt_type="m.read",
+                            user_id=ALICE_ID,
+                            timestamp=1516809890615
+                        )
+                    ]
+                )
+            ],
             [],
             RoomSummary(invited_member_count=1, joined_member_count=2),
         )
@@ -1095,7 +1102,7 @@ class TestClass(object):
         are called, including for duplicate events.
         """
         client.receive_response(self.login_response)
-        ephemeral_events = [TypingNoticeEvent, ReadReceiptEvent]
+        ephemeral_events = [TypingNoticeEvent, ReceiptEvent]
 
         event_selection = random.choices(
             population=ephemeral_events,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import random
 from uuid import uuid4
 
 import pytest
@@ -18,7 +19,7 @@ from nio import (Client, DeviceList, DeviceOneTimeKeyCount, DownloadResponse,
                  RoomSummary, RoomTypingResponse, RoomRedactResponse,
                  ShareGroupSessionResponse, SyncResponse,
                  Timeline, ThumbnailResponse, TransportType, TypingNoticeEvent,
-                 InviteMemberEvent, InviteInfo, ClientConfig)
+                 InviteMemberEvent, InviteInfo, ClientConfig, ReadReceiptEvent)
 from nio.event_builders import ToDeviceMessage
 
 HOST = "example.org"
@@ -288,7 +289,13 @@ class TestClass(object):
         test_room_info = RoomInfo(
             timeline,
             [],
-            [TypingNoticeEvent([ALICE_ID])],
+            [TypingNoticeEvent([ALICE_ID]), ReadReceiptEvent({
+                "event_id_3": [{
+                    "receipt_type": "m.read",
+                    "user_id": ALICE_ID,
+                    "timestamp": 1516809890615
+                }]
+            })],
             [],
             RoomSummary(invited_member_count=1, joined_member_count=2),
         )
@@ -1078,6 +1085,41 @@ class TestClass(object):
         client.add_ephemeral_callback(cb, TypingNoticeEvent)
 
         with pytest.raises(CallbackException):
+            client.receive_response(self.sync_response)
+
+    def test_many_ephemeral_cb(self, client):
+        """Test that callbacks for multiple ephemeral events are properly handled.
+
+        Generates a random selection of ephemeral events and produces unique
+        callbacks and exceptions for each. Verifies that all of the callbacks
+        are called, including for duplicate events.
+        """
+        client.receive_response(self.login_response)
+        ephemeral_events = [TypingNoticeEvent, ReadReceiptEvent]
+
+        event_selection = random.choices(
+            population=ephemeral_events,
+            # By the pigeonhole princple, we'll have at least one duplicate Event
+            k=len(ephemeral_events) + 1
+        ) 
+        # This will only print during a failure, at which point we want to know
+        # what event selection caused an error.
+        print(f"Random selection of EphemeralEvents: {event_selection}")
+
+        exceptions = []
+        for index, event in enumerate(event_selection):
+            exception_class = type(
+                f"CbException{event.__name__}_{index}",
+                (Exception,), {}
+            )
+            exceptions.append(exception_class)
+
+            def callback(_, event):
+                raise exception_class()
+
+            client.add_ephemeral_callback(callback, event)
+        
+        with pytest.raises(tuple(exceptions)):
             client.receive_response(self.sync_response)
 
     def test_no_encryption(self, client_no_e2e):

--- a/tests/data/events/receipt.json
+++ b/tests/data/events/receipt.json
@@ -1,0 +1,13 @@
+{
+    "content": {
+        "$152037280074GZeOm:localhost": {
+            "m.read": {
+                "@bob:example.com": {
+                    "ts": 1520372804619
+                }
+            }
+        }
+    },
+    "type":"m.receipt"
+}
+    

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -37,6 +37,7 @@ from nio.events import (
     InviteNameEvent,
     EphemeralEvent,
     TypingNoticeEvent,
+    ReadReceiptEvent,
     AccountDataEvent,
     UnknownAccountDataEvent,
     FullyReadEvent,
@@ -315,6 +316,16 @@ class TestClass(object):
         assert isinstance(event, TypingNoticeEvent)
 
         assert "@bob:example.com" in event.users
+    
+    def test_read_receipt_event(self):
+        parsed_dict = TestClass._load_response("tests/data/events/receipt.json")
+        event = EphemeralEvent.parse_event(parsed_dict)
+
+        assert isinstance(event, ReadReceiptEvent)
+
+        assert "$152037280074GZeOm:localhost" in event.receipts
+        assert "@bob:example.com" == \
+            event.receipts["$152037280074GZeOm:localhost"][0]["user_id"]
 
     def test_account_data_event(self):
         event = AccountDataEvent.parse_event({})

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -37,7 +37,8 @@ from nio.events import (
     InviteNameEvent,
     EphemeralEvent,
     TypingNoticeEvent,
-    ReadReceiptEvent,
+    Receipt,
+    ReceiptEvent,
     AccountDataEvent,
     UnknownAccountDataEvent,
     FullyReadEvent,
@@ -321,12 +322,18 @@ class TestClass(object):
         parsed_dict = TestClass._load_response("tests/data/events/receipt.json")
         event = EphemeralEvent.parse_event(parsed_dict)
 
-        assert isinstance(event, ReadReceiptEvent)
+        # Warning: this is directly tied to the above file; any changes below
+        # need to be reflected there too.
+        receipt = Receipt(
+            "$152037280074GZeOm:localhost",
+            "m.read",
+            "@bob:example.com",
+            1520372804619
+        )
 
-        assert "$152037280074GZeOm:localhost" in event.receipts
-        assert "@bob:example.com" == \
-            event.receipts["$152037280074GZeOm:localhost"][0]["user_id"]
-
+        assert isinstance(event, ReceiptEvent)
+        assert receipt in event.receipts
+        
     def test_account_data_event(self):
         event = AccountDataEvent.parse_event({})
 


### PR DESCRIPTION
Closes #111 

ReadReceiptEvent handles notifying the client when users change their
most recently read message.

@poljar We discussed on #nio:matrix.org storing receipts in the `Room`, but I wasn't sure exactly what you meant (and I figured people in the room might not appreciate continued discussion). I'm not concerned about merging this right away but I figured this way you can see what I have and we can talk about how to track read receipts events in `Room`s.

The `from_dict()` method is a bit hairy, but that's unfortunately part
of the spec.  "m.receipt" events have four parts; the `event_id`,
`receipt_type`, `user_id`, and timestamp.  There may be only a single
(`user_id`, `receipt_type`) pair associated with a single `event_id`,
but each "m.receipt" event can have multiple `receipt_type`s,
`user_id`s, or `event_id`s.  So we have to control for that here.

The test that is added, `test_many_ephemeral_cb()` selects a random
assortment of (defined) ephemeral events, verifying that all of their
callbacks are properly called and that having multiple callbacks for the
same ephemeral event is handled properly (i.e. that they all execute).
Since it is a random assortment, it's vital to log the failing test
case, which we do here.