### PR TITLE
api: URI encode device_id in update_device

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -1017,7 +1017,7 @@ class Api(object):
                 updated for the device.
         """
         query_parameters = {"access_token": access_token}
-        path = "devices/{}".format(device_id)
+        path = "devices/{}".format(quote(device_id))
 
         return (
             "PUT",


### PR DESCRIPTION
The grammar for device IDs is not documented (matrix-org/matrix-doc#1257).  In the meantime we should not assume that device IDs will not contain reserved characters.