### PR TITLE
Improve group rooms display name and avatar calculation

### DIFF
--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -52,6 +52,28 @@ class TestClass(object):
         assert member.display_name == name
         assert member.avatar_url == avatar
 
+    def test_summary_details(self):
+        room = self.test_room
+
+        room.summary = None
+        with pytest.raises(ValueError):
+            assert room._summary_details()
+
+        room.summary = RoomSummary(None, None, [])
+        with pytest.raises(ValueError):
+            assert room._summary_details()
+
+        room.summary = RoomSummary(0, None, [])
+        with pytest.raises(ValueError):
+            assert room._summary_details()
+
+        room.summary = RoomSummary(None, 0, [])
+        with pytest.raises(ValueError):
+            assert room._summary_details()
+
+        room.summary = RoomSummary(0, 0, [])
+        assert room._summary_details() == ([], 0, 0)
+
     def test_named_checks(self):
         room = self.test_room
         assert not room.is_named
@@ -137,7 +159,7 @@ class TestClass(object):
 
     def test_name_calculation_when_unnamed_no_summary(self):
         room = self.test_room
-        room.summary = None
+        room.summary = RoomSummary()
         assert room.named_room_name() is None
         assert room.display_name == "Empty Room"
 
@@ -158,22 +180,22 @@ class TestClass(object):
         room.add_member("@dave:example.org", "Dave", None)
         assert (room.display_name ==
                 "Alice (@alice:example.org), Alice (@malory:example.org), "
-                "Steve, Carol and Dave")
+                "Carol, Dave and Steve")
 
         room.add_member("@erin:example.org", "Eirin", None)
         assert (room.display_name ==
                 "Alice (@alice:example.org), Alice (@malory:example.org), "
-                "Steve, Carol, Dave and 1 other")
+                "Carol, Dave, Eirin and 1 other")
 
         room.add_member("@frank:example.org", "Frank", None)
         assert (room.display_name ==
                 "Alice (@alice:example.org), Alice (@malory:example.org), "
-                "Steve, Carol, Dave and 2 others")
+                "Carol, Dave, Eirin and 2 others")
 
         room.add_member("@gregor:example.org", "Gregor", None)
         assert (room.display_name ==
                 "Alice (@alice:example.org), Alice (@malory:example.org), "
-                "Steve, Carol, Dave and 3 others")
+                "Carol, Dave, Eirin and 3 others")
 
         # Members leave
 

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -57,7 +57,7 @@ class TestClass(object):
         assert room.is_named
         assert not room.is_group
 
-    def _test_name_calculation_when_unnamed(self):
+    def test_name_calculation_when_unnamed(self):
         room = self.test_room
         assert room.named_room_name() is None
         assert room.display_name == "Empty Room"


### PR DESCRIPTION
- Conform to the [r0.6.0 spec](https://matrix.org/docs/spec/client_server/r0.6.0#id342)
- Use the room summary to calculate group display names and avatars,
  making it work properly with member lazy loading and smarter with
  how many names to list vs how many "x others" to show
- Provide a `MatrixRoom.group_name_structure` property that returns a
  `(is_empty, user_names, x_others)` tuple suitable for clients
  that want to show custom strings from the data
- Support "Empty Room (was Alice, User2, ...)" - note that I used "had" instead of "was", I think it makes more sense ("Alice" wasn't a room but a user part of that room) and the spec allows custom forms
- Use the `users` list as fallback if the room doesn't have a `summary`, and raise the maximum of names listed vs "x others" to 5, to match how many heroes we can have

Also:

- Add/convert type hints everywhere for `rooms.py`
- Reach 100% test coverage for `rooms.py`
- Shorten/simplify some functions