### PR TITLE
Added deactivation of users

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -278,6 +278,24 @@ class Api(object):
         return "POST", path, Api.to_json(content_dict)
 
     @staticmethod
+    def deactivate(
+            user,           # type: str
+            admin_token,    # type: str
+    ):
+        """Deactivate a user.
+
+        Args:
+            user (str): The fully qualified user ID to deactivate
+            admin_token (str): The user token (received during login) of a user with admin powers.
+        """
+
+        path = Api._build_path("/admin/deactivate/"+user, {"access_token": admin_token})
+
+        content_dict = {}
+
+        return "POST", path, Api.to_json(content_dict)
+
+    @staticmethod
     def login(
         user,            # type: str
         password=None,   # type: str

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -57,7 +57,8 @@ from ..responses import (ContentRepositoryConfigError,
                          JoinedRoomsError, JoinedRoomsResponse,
                          KeysClaimError, KeysClaimResponse, KeysQueryResponse,
                          KeysUploadResponse,
-                         RegisterResponse, LoginError, LoginResponse,
+                         RegisterResponse, DeactivateResponse, RegisterErrorResponse, DeactivateErrorResponse,
+                         LoginError, LoginResponse,
                          LogoutError, LogoutResponse,
                          ProfileGetAvatarResponse, ProfileGetAvatarError,
                          ProfileGetDisplayNameResponse,
@@ -686,6 +687,19 @@ class AsyncClient(Client):
         )
 
         return await self._send(RegisterResponse, method, path, data)
+
+    async def deactivate(self, username, admin_token):
+        """Deactivate a user.
+
+        Args:
+            username (str): The fully qualified user ID to deactivate
+            admin_token (str): The user token (received during login) of a user with admin powers.
+
+        Returns a 'DeactivateResponse' if successful.
+        """
+        method, path, data = Api.deactivate(user=username, admin_token=admin_token)
+
+        return await self._send(DeactivateResponse, method, path, data)
 
     async def login(self, password, device_name=""):
         # type: (str, str) -> Union[LoginResponse, LoginError]

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -32,7 +32,7 @@ from ..log import logger_group
 from ..responses import (ErrorResponse, JoinedMembersResponse,
                          KeysClaimResponse, KeysQueryResponse,
                          KeysUploadResponse, LoginResponse, LogoutResponse,
-                         PartialSyncResponse, RegisterResponse, Response, RoomContextResponse,
+                         PartialSyncResponse, DeactivateResponse, RegisterResponse, Response, RoomContextResponse,
                          RoomForgetResponse, RoomKeyRequestResponse,
                          RoomMessagesResponse, ShareGroupSessionResponse,
                          SyncResponse, SyncType, ToDeviceResponse)
@@ -539,6 +539,16 @@ class Client(object):
         self.access_token = response.access_token
         self.user_id = response.user_id
         self.device_id = response.device_id
+
+        if self.store_path and not (self.store and self.olm):
+            self.load_store()
+
+    def _handle_deactivate(self, response):
+        # type: (Union[DeactivateResponse, ErrorResponse]) -> None
+        if isinstance(response, ErrorResponse):
+            return
+
+        self.id_server_unbind_result = response.id_server_unbind_result
 
         if self.store_path and not (self.store and self.olm):
             self.load_store()

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -65,6 +65,8 @@ __all__ = [
     "KeysUploadResponse",
     "KeysUploadError",
     "RegisterResponse",
+    "DeactivateResponse",
+    "DeactivateErrorResponse",
     "LoginResponse",
     "LoginError",
     "LoginInfoResponse",
@@ -523,6 +525,11 @@ class RegisterErrorResponse(ErrorResponse):
 
 
 @attr.s
+class DeactivateErrorResponse(ErrorResponse):
+    pass
+
+
+@attr.s
 class RegisterResponse(Response):
     user_id = attr.ib(type=str)
     device_id = attr.ib(type=str)
@@ -539,6 +546,22 @@ class RegisterResponse(Response):
             parsed_dict["user_id"],
             parsed_dict["device_id"],
             parsed_dict["access_token"],
+        )
+
+
+@attr.s
+class DeactivateResponse(Response):
+    id_server_unbind_result = attr.ib(type=str)
+
+    def __str__(self):
+        # type () -> str
+        return "id_server_unbind_result {}".format(self.id_server_unbind_result)
+
+    @classmethod
+    @verify(Schemas.deactivate, DeactivateErrorResponse)
+    def from_dict(cls, parsed_dict):
+        return cls(
+            parsed_dict["id_server_unbind_result"]
         )
 
 

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -244,6 +244,14 @@ class Schemas(object):
         "required": ["user_id", "device_id", "access_token"],
     }
 
+    deactivate = {
+        "type": "object",
+        "properties":  {
+            "id_server_unbind_result": {"type": "string"}
+        },
+        "required": ["id_server_unbind_result"]
+    }
+
     login = {
         "type": "object",
         "properties": {

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -26,7 +26,7 @@ from nio import (ContentRepositoryConfigResponse,
                  JoinedMembersResponse, KeysClaimResponse, KeysQueryResponse,
                  KeysUploadResponse, LocalProtocolError, LoginError,
                  LoginResponse, LogoutError, LogoutResponse,
-                 MegolmEvent, MembersSyncError, OlmTrustError, RegisterResponse,
+                 MegolmEvent, MembersSyncError, OlmTrustError, RegisterResponse, DeactivateResponse,
                  RoomContextResponse, RoomForgetResponse,
                  ProfileGetAvatarResponse,
                  ProfileGetDisplayNameResponse, ProfileGetResponse,
@@ -365,6 +365,21 @@ class TestClass(object):
 
         assert isinstance(resp, RegisterResponse)
         assert async_client.access_token
+
+    def test_deactivate(self, async_client, aioresponse):
+        loop = asyncio.get_event_loop()
+
+        assert not async_client.access_token
+
+        aioresponse.post(
+            "https://example.org/_matrix/client/r0/admin/deactivate",
+            status=200,
+            payload=self.deactivate_response
+        )
+        resp = loop.run_until_complete(async_client.deactivate("user", "admin_token"))
+
+        assert isinstance(resp, DeactivateResponse)
+        assert async_client.id_server_unbind_result
 
     def test_login(self, async_client, aioresponse):
         loop = asyncio.get_event_loop()

--- a/tests/data/deactivate_response.json
+++ b/tests/data/deactivate_response.json
@@ -1,0 +1,3 @@
+{
+    "id_server_unbind_result": "success"
+  }


### PR DESCRIPTION
Tested that it works with the following code (anonymized my username/password):

```python
async def main():
    client = AsyncClient(myserver", myaccount)
    response = await client.login(password=mypassword)
    print(response)
    print(client.access_token)
    deactivate_response = await client.deactivate("@testy2:myserver", client.access_token)
    print(deactivate_response)
    await client.close()

asyncio.get_event_loop().run_until_complete(main())

```

and got the responses:
Logged in as myaccount, device id: an id.
my access token
the correct url
and, finally,

id_server_unbind_result success

So, as long as Travis is OK with my code, I think we're good.