### PR TITLE
Add Content-Length to headers when uploading

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -612,6 +612,9 @@ class AsyncClient(Client):
             else {"Content-Type": "application/json"}
         )
 
+        if content_length is not None:
+            headers["Content-Length"] = str(content_length)
+
         got_429 = 0
         max_429 = self.config.max_limit_exceeded
 
@@ -621,14 +624,6 @@ class AsyncClient(Client):
         while True:
             if data_provider:
                 data = data_provider(got_429, got_timeouts)
-
-                if content_length is None and isinstance(data, (str, Path)):
-                    content_length = Path(data).stat().st_size
-                elif content_length is None and isinstance(data, bytes):
-                    content_length = len(data)
-
-                if content_length is not None:
-                    headers["Content-Length"] = str(content_length)
 
             try:
                 transport_resp = await self.send(
@@ -2073,11 +2068,7 @@ class AsyncClient(Client):
                 for pausing and cancelling.
 
             filesize (int, optional): Size in bytes for the file to transfer.
-                If the passed ``data_provider`` returns a path string, Path
-                object or bytes, the size can be determined automatically
-                and there is no need to specify this argument.
-                If it can't be determined and no ``filesize`` is
-                explicitely passed, some servers might refuse the upload.
+                If left as ``None``, some servers might refuse the upload.
         """
 
         http_method, path, _ = Api.upload(self.access_token, filename)

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1267,6 +1267,10 @@ class TestClass(object):
         )
         assert async_client.logged_in
 
+        path     = Path("tests/data/file_response")
+        filesize = path.stat().st_size
+        monitor  = TransferMonitor(filesize)
+
         aioresponse.post(
             "https://example.org/_matrix/media/r0/upload"
             "?access_token=abc123&filename=test.png",
@@ -1274,10 +1278,6 @@ class TestClass(object):
             payload=self.upload_response,
             repeat=True,
         )
-
-        path     = Path("tests/data/file_response")
-        filesize = path.stat().st_size
-        monitor  = TransferMonitor(filesize)
 
         resp, decryption_info = await async_client.upload(
             lambda *_: path, "image/png", "test.png", monitor=monitor,
@@ -1296,6 +1296,10 @@ class TestClass(object):
         )
         assert async_client.logged_in
 
+        path     = Path("tests/data/file_response")
+        filesize = path.stat().st_size
+        monitor  = TransferMonitor(filesize)
+
         aioresponse.post(
             "https://example.org/_matrix/media/r0/upload"
             "?access_token=abc123&filename=test.png",
@@ -1311,16 +1315,14 @@ class TestClass(object):
             repeat  = True,
         )
 
-        path    = Path("tests/data/file_response")
-        monitor = TransferMonitor(path.stat().st_size)
-
         async with aiofiles.open(path, "rb") as file:
             resp, decryption_info = await async_client.upload(
                 lambda *_: file,
                 "image/png",
                 "test.png",
-                encrypt = True,
-                monitor = monitor,
+                encrypt  = True,
+                monitor  = monitor,
+                filesize = filesize,
             )
 
         assert isinstance(resp, UploadResponse)


### PR DESCRIPTION
For `upload()`, accept an optional `filesize` argument.