### PR TITLE
Improve PowerLevels.can_user_kick/ban()

### DIFF
--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -1239,20 +1239,42 @@ class PowerLevels(object):
         required_level = self.get_message_event_required_level(event_type)
         return self.get_user_level(user_id) >= required_level
 
-    def can_user_ban(self, user_id):
-        # type: (str) -> bool
-        """Return whether a user has enough power to ban others."""
-        return self.get_user_level(user_id) >= self.defaults.ban
-
     def can_user_invite(self, user_id):
         # type: (str) -> bool
         """Return whether a user has enough power to invite others."""
         return self.get_user_level(user_id) >= self.defaults.invite
 
-    def can_user_kick(self, user_id):
-        # type: (str) -> bool
-        """Return whether a user has enough power to kick others."""
-        return self.get_user_level(user_id) >= self.defaults.kick
+    def can_user_kick(
+        self, user_id: str, target_user_id: Optional[str] = None,
+    ) -> bool:
+        """Return whether a user has enough power to kick another.
+
+        If ``target_user_id`` is ``None``, returns whether ``user_id`` has
+        enough power to kick anyone with a lower power level than that user.
+        """
+        level = self.get_user_level(user_id)
+        can_kick_lower = level >= self.defaults.kick
+
+        if target_user_id is None:
+            return can_kick_lower
+
+        return can_kick_lower and level > self.get_user_level(target_user_id)
+
+    def can_user_ban(
+        self, user_id: str, target_user_id: Optional[str] = None,
+    ) -> bool:
+        """Return whether a user has enough power to ban another.
+
+        If ``target_user_id`` is ``None``, returns whether ``user_id`` has
+        enough power to ban anyone with a lower power level than that user.
+        """
+        level = self.get_user_level(user_id)
+        can_ban_lower = level >= self.defaults.ban
+
+        if target_user_id is None:
+            return can_ban_lower
+
+        return can_ban_lower and level > self.get_user_level(target_user_id)
 
     def can_user_redact(self, user_id):
         # type: (str) -> bool

--- a/tests/data/events/power_levels.json
+++ b/tests/data/events/power_levels.json
@@ -16,6 +16,8 @@
         "state_default": 50,
         "users": {
             "@example:localhost": 100,
+            "@alice:localhost": 50,
+            "@carol:localhost": 25,
             "@bob:localhost": 0
         },
         "users_default": 0

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -153,6 +153,8 @@ class TestClass(object):
 
         levels = event.power_levels
         admin = "@example:localhost"
+        mod = "@alice:localhost"
+        higher_user = "@carol:localhost"
         user = "@bob:localhost"
 
         assert levels.get_state_event_required_level("m.room.name") == 50
@@ -168,14 +170,24 @@ class TestClass(object):
         assert levels.can_user_send_message(admin) is True
         assert levels.can_user_send_message(user, "m.room.message") is False
 
-        assert levels.can_user_ban(admin) is True
-        assert levels.can_user_ban(user) is False
-
         assert levels.can_user_invite(admin) is True
         assert levels.can_user_invite(user) is True
 
         assert levels.can_user_kick(admin) is True
         assert levels.can_user_kick(user) is False
+        assert levels.can_user_kick(admin, admin) is False
+        assert levels.can_user_kick(admin, mod) is True
+        assert levels.can_user_kick(mod, admin) is False
+        assert levels.can_user_kick(mod, higher_user) is True
+        assert levels.can_user_kick(higher_user, user) is False
+
+        assert levels.can_user_ban(admin) is True
+        assert levels.can_user_ban(user) is False
+        assert levels.can_user_ban(admin, admin) is False
+        assert levels.can_user_ban(admin, mod) is True
+        assert levels.can_user_ban(mod, admin) is False
+        assert levels.can_user_ban(mod, higher_user) is True
+        assert levels.can_user_ban(higher_user, user) is False
 
         assert levels.can_user_redact(admin) is True
         assert levels.can_user_redact(user) is False
@@ -317,7 +329,7 @@ class TestClass(object):
         assert isinstance(event, TypingNoticeEvent)
 
         assert "@bob:example.com" in event.users
-    
+
     def test_read_receipt_event(self):
         parsed_dict = TestClass._load_response("tests/data/events/receipt.json")
         event = EphemeralEvent.parse_event(parsed_dict)
@@ -333,7 +345,7 @@ class TestClass(object):
 
         assert isinstance(event, ReceiptEvent)
         assert receipt in event.receipts
-        
+
     def test_account_data_event(self):
         event = AccountDataEvent.parse_event({})
 


### PR DESCRIPTION
Accept a `target_user_id` parameter to check if a user can kick or ban
another one, depending on if the user's power level >= minimum kick/ban
power level and > target's power level