### PR TITLE
m_receipt schema requires m.read

### DIFF
--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1135,7 +1135,8 @@ class Schemas:
                                     }
                                 }
                             }
-                        }
+                        },
+                        "required": ["m.read"]
                     }
                 }
             },


### PR DESCRIPTION
This change should make the m_receipt schema more restrictive in what it matches.

The way we've done this (requiring m.read) isn't really ideal as we'd like alternative receipts in the future, but as there's nothing else to check for this'll have to do for now.

@mirukana If you have a chance pull this branch and see if your issues go away (or just add the change into your local branch).