### PR TITLE
Fix handling of m.receipts with invalid ts values

### DIFF
--- a/nio/events/ephemeral.py
+++ b/nio/events/ephemeral.py
@@ -128,8 +128,11 @@ class ReceiptEvent(EphemeralEvent):
         for event_id, event in parsed_dict["content"].items():
             for receipt_type, receipt in event.items():
                 for user_id, user in receipt.items():
-                    event_receipts.append(
-                        Receipt(event_id, receipt_type, user_id, user["ts"])
-                    )
+                    # Synapse pre-0.99.3 has a bug where it sends invalid
+                    # ts values. https://github.com/matrix-org/synapse/issues/4898
+                    if isinstance(user, dict) and "ts" in user:
+                        event_receipts.append(
+                            Receipt(event_id, receipt_type, user_id, user["ts"])
+                        )
 
         return cls(event_receipts)

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1127,7 +1127,7 @@ class Schemas:
                                 "type": "object",
                                 "patternProperties": {
                                     UserIdRegex: {
-                                        "type": "object",
+                                        "type": ["object", "string"],
                                         "properties": {
                                             "ts": {"type" : "integer"}
                                         },

--- a/tests/data/events/receipt_invalid.json
+++ b/tests/data/events/receipt_invalid.json
@@ -1,0 +1,14 @@
+{
+    "content": {
+        "$152037280074GZeOm:localhost": {
+            "m.read": {
+                "@bob:example.com": {
+                    "ts": 1520372804619
+                },
+                "@alice:example.com": "\"ts\": 1520372804619"
+            }
+        }
+    },
+    "type":"m.receipt"
+}
+    

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -346,6 +346,29 @@ class TestClass:
         assert isinstance(event, ReceiptEvent)
         assert receipt in event.receipts
 
+    def test_read_receipt_event_bad_ts(self):
+        """Test reading an m_receipt event that has malformed data for one user.
+
+        @alice:example.com is a user using Synapse pre 0.99.3 with a
+        timestamp bug. We want to ignore her malformed value without losing
+        the receipt data from @bob:example.com
+        """
+        parsed_dict = TestClass._load_response("tests/data/events/receipt_invalid.json")
+        event = EphemeralEvent.parse_event(parsed_dict)
+
+        # Warning: this is directly tied to the above file; any changes below
+        # need to be reflected there too.
+        receipt = Receipt(
+            "$152037280074GZeOm:localhost",
+            "m.read",
+            "@bob:example.com",
+            1520372804619
+        )
+
+        assert isinstance(event, ReceiptEvent)
+        assert receipt in event.receipts
+
+
     def test_account_data_event(self):
         event = AccountDataEvent.parse_event({})
 


### PR DESCRIPTION
Synapse pre-0.99.3 has a [bug](https://github.com/matrix-org/synapse/issues/4898) where timestamp values are sent as a JSON string instead of as an object. Since m.receipts can have a number of m.read receipts inside, we don't want to throw away the whole event just for a couple bad timestamps.

This commit makes the schema accept those bad values and then ignores them in the `ReceiptEvent.from_dict()` method.