### PR TITLE
Add room_read_markers() to AsyncClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ matrix_nio.egg-info/
 dist
 doc/html
 *.swp
+build

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -157,6 +157,8 @@ from ..responses import (
     RoomSendResponse,
     RoomTypingResponse,
     RoomTypingError,
+    RoomReadMarkersResponse,
+    RoomReadMarkersError,
     RoomUnbanError,
     RoomUnbanResponse,
     ShareGroupSessionError,
@@ -2043,6 +2045,44 @@ class AsyncClient(Client):
         return await self._send(
             RoomTypingResponse, method, path, data, response_data=(room_id,)
         )
+    
+    @logged_in
+    async def room_read_markers(
+        self,
+        room_id: str,
+        fully_read_event: str,
+        read_event: Optional[str] = None
+    ):
+        """Update read markers for a room.
+
+        Returns either a `RoomReadResponse` if the request was successful or
+        a `RoomReadError` if there was an error with the request.
+
+        This sets the position of the read markers. `fully_read_event` is the
+        latest event in the set of events that the user has either fully read
+        or indicated they aren't intersted in, while `read_event` is the most
+        recent message in the set of messages that the user may or may not have
+        read, as in when a user comes back to a room after hundreds of messages
+        has been sent and _only_ reads the most recent message.
+
+        If you want to set the read receipt, you _must_ set `read_event`.
+
+        Args:
+            room_id (str): The room ID of the room where the read markers should
+                be updated.
+            fully_read_event (str): The event ID that the user has fully read up
+                to.
+            read_event (Optional[str]): The event ID to set the read receipt
+                location at.
+        """
+        method, path, data = Api.room_read_markers(
+            self.access_token, room_id, fully_read_event, read_event
+        )
+
+        return await self._send(
+            RoomReadMarkersResponse, method, path, data, response_data=(room_id,)
+        )
+
 
     @logged_in
     async def content_repository_config(


### PR DESCRIPTION
Affects #85 

Adds the `room_read_markers()` method to the AsyncClient, allowing users to set the fully_read position and (more importantly, imo) the read receipt position. This is almost exactly what was in place for `AsyncClient.room_typing()` but modified for read receipts. Tested working with Synapse 1.12.3.

This PR also modifies the .gitignore to ignore the build folder, because I keep building to test with Synapse and then git thinks I have 40+ files to commit...