### PR TITLE
Add update_device() to AsyncClient

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -1066,7 +1066,7 @@ class Api:
 
     @staticmethod
     def update_device(access_token, device_id, content):
-        # type: (str, Dict[str, str]) -> Tuple[str, str, str]
+        # type: (str, str, Dict[str, str]) -> Tuple[str, str, str]
         """Update the metadata of the given device.
 
         Returns the HTTP method, HTTP path and data for the request.

--- a/nio/api.py
+++ b/nio/api.py
@@ -1065,8 +1065,7 @@ class Api:
         return "GET", Api._build_path(path, query_parameters)
 
     @staticmethod
-    def update_device(access_token, device_id, content):
-        # type: (str, str, Dict[str, str]) -> Tuple[str, str, str]
+    def update_device(access_token: str, device_id: str, content: Dict[str, str]) -> Tuple[str, str, str]:
         """Update the metadata of the given device.
 
         Returns the HTTP method, HTTP path and data for the request.

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1248,7 +1248,7 @@ class AsyncClient(Client):
 
         Args:
             device_id (str): The device for which the metadata will be updated.
-            content (Dict): A dictionary of metadata values that will be
+            content (Dict[str, str]): A dictionary of metadata values that will be
                 updated for the device.
 
         Example:

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -172,6 +172,8 @@ from ..responses import (
     ToDeviceResponse,
     UploadError,
     UploadResponse,
+    UpdateDeviceResponse,
+    UpdateDeviceError,
 )
 
 _ShareGroupSessionT = Union[ShareGroupSessionError, ShareGroupSessionResponse]
@@ -1232,6 +1234,34 @@ class AsyncClient(Client):
         method, path = Api.devices(self.access_token)
 
         return await self._send(DevicesResponse, method, path)
+
+    @logged_in
+    async def update_device(
+            self,
+            device_id: str,
+            content: Dict[str, str]
+    ) -> Union[UpdateDeviceResponse, UpdateDeviceError]:
+        """Update the metadata of the given device.
+
+        Returns either a `UpdateDeviceResponse` if the request was successful or
+        a `UpdateDeviceError` if there was an error with the request.
+
+        Args:
+            device_id (str): The device for which the metadata will be updated.
+            content (Dict): A dictionary of metadata values that will be
+                updated for the device.
+
+        Example:
+            >>> device_id = "QBUAZIFURK"
+            >>> content = {"display_name": "My new device"}
+            >>> await client.update_device(device_id, content)
+
+        """
+        method, path, data = Api.update_device(
+            self.access_token, device_id, content
+        )
+
+        return await self._send(UpdateDeviceResponse, method, path, data)
 
     @logged_in
     async def delete_devices(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -46,7 +46,7 @@ from nio import (ContentRepositoryConfigResponse,
                  ShareGroupSessionResponse,
                  SyncResponse, ThumbnailError, ThumbnailResponse,
                  Timeline, TransferMonitor, TransferCancelledError,
-                 UploadResponse,
+                 UploadResponse, UpdateDeviceResponse,
                  RoomMessageText, RoomKeyRequest)
 from nio.api import ResizingMethod, RoomPreset, RoomVisibility
 from nio.crypto import OlmDevice, Session, decrypt_attachment
@@ -1804,6 +1804,28 @@ class TestClass:
         assert isinstance(resp, DeleteDevicesAuthResponse)
         resp = await async_client.delete_devices(devices)
         assert isinstance(resp, DeleteDevicesResponse)
+
+    async def test_update_device(self, async_client: AsyncClient, aioresponse: aioresponses):
+        """Test that we can update a device
+        """
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response)
+        )
+        assert async_client.logged_in
+
+        device_id = "QBUAZIFURK"
+        content = {"display_name": "My new device"}
+
+        aioresponse.get(
+            "https://example.org/_matrix/client/r0/devices/{}".format(device_id),
+            status=200,
+            payload={}
+        )
+
+        resp = await async_client.update_device(device_id, content)
+
+        assert isinstance(resp, UpdateDeviceResponse)
+
 
     async def test_get_set_displayname(self, async_client, aioresponse):
         await async_client.receive_response(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1816,8 +1816,11 @@ class TestClass:
         device_id = "QBUAZIFURK"
         content = {"display_name": "My new device"}
 
-        aioresponse.post(
-            "https://example.org/_matrix/client/r0/devices/{}?access_token=abc123".format(device_id),
+        aioresponse.put(
+            "https://example.org/_matrix/client/r0/devices/{}?access_token={}".format(
+                device_id,
+                async_client.access_token
+            ),
             status=200,
             payload={}
         )

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1816,8 +1816,8 @@ class TestClass:
         device_id = "QBUAZIFURK"
         content = {"display_name": "My new device"}
 
-        aioresponse.get(
-            "https://example.org/_matrix/client/r0/devices/{}".format(device_id),
+        aioresponse.post(
+            "https://example.org/_matrix/client/r0/devices/{}?access_token=abc123".format(device_id),
             status=200,
             payload={}
         )


### PR DESCRIPTION
As mentioned in #85.
Adds the `update_device()` method to the AsyncClient.
I also corrected the type hints for the `update_device()` method in api


First PR and new to python, i tried my best to include a test.
Feedback is more then welcome :)