### PR TITLE
Use file objects directly in upload()

### DIFF
--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1390,6 +1390,82 @@ class TestClass:
         monitor.cancel = True
         self._wait_monitor_thread_exited(monitor)
 
+
+    async def test_upload_binary_file_object(self, async_client: AsyncClient, aioresponse):
+        """Test uploading binary files using file objects.
+        """
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response),
+        )
+        assert async_client.logged_in
+
+        path     = Path("tests/data/file_response")
+        filesize = path.stat().st_size
+        monitor  = TransferMonitor(filesize)
+
+        aioresponse.post(
+            "https://example.org/_matrix/media/r0/upload"
+            "?access_token=abc123&filename=test.png",
+            status=200,
+            payload=self.upload_response,
+            repeat=True,
+        )
+
+        # Upload binary file using a standard file object
+        with open("tests/data/file_response", "r+b") as f:
+            resp, decryption_info = await async_client.upload(
+                f, "image/png", "test.png", monitor=monitor,
+            )
+
+        assert isinstance(resp, UploadResponse)
+        assert decryption_info is None
+
+        # Upload binary file using an async file object
+        async with aiofiles.open("tests/data/file_response", "r+b") as f:
+            resp, decryption_info = await async_client.upload(
+                f, "image/png", "test.png", monitor=monitor,
+            )
+
+        assert isinstance(resp, UploadResponse)
+        assert decryption_info is None
+
+        monitor.cancel = True
+        self._wait_monitor_thread_exited(monitor)
+
+
+    async def test_upload_text_file_object(self, async_client: AsyncClient, aioresponse):
+        """Test uploading text files using file objects.
+        """
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response),
+        )
+        assert async_client.logged_in
+
+        path     = Path("tests/data/sample_text_file.py")
+        filesize = path.stat().st_size
+        monitor  = TransferMonitor(filesize)
+
+        aioresponse.post(
+            "https://example.org/_matrix/media/r0/upload"
+            "?access_token=abc123&filename=test.py",
+            status=200,
+            payload=self.upload_response,
+            repeat=True,
+        ) 
+
+        # Upload text file using a async file object
+        async with aiofiles.open("tests/data/sample_text_file.py") as f:
+            resp, decryption_info = await async_client.upload(
+                f, "text/plain", "test.py", monitor=monitor,
+            )
+
+        assert isinstance(resp, UploadResponse)
+        assert decryption_info is None
+
+        monitor.cancel = True
+        self._wait_monitor_thread_exited(monitor)
+
+
     async def test_encrypted_upload(self, async_client, aioresponse):
         await async_client.receive_response(
             LoginResponse.from_dict(self.login_response),

--- a/tests/data/sample_text_file.py
+++ b/tests/data/sample_text_file.py
@@ -1,0 +1,4 @@
+def main():
+    print("Some code you might want to send using Matrix!")
+
+main()


### PR DESCRIPTION
Closes #133.

Tracks Sync and Async files separately so that later, if required, we can handle those cases separately. At this point `upload()` doesn't require files to be opened in binary format but I believe `_send()` fails if the file is in a text format.

Tested uploading plain text files and images to Synapse.