### PR TITLE
Add login_info() to AsyncClient

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -234,8 +234,7 @@ class Api:
         return path
 
     @staticmethod
-    def login_info():
-        # type: (...) -> Tuple[str, str]
+    def login_info() -> Tuple[str, str]:
         """Get the homeserver's supported login types
 
         Returns the HTTP method and HTTP path for the request.

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -113,6 +113,8 @@ from ..responses import (
     RegisterResponse,
     LoginError,
     LoginResponse,
+    LoginInfoResponse,
+    LoginInfoError,
     LogoutError,
     LogoutResponse,
     ProfileGetAvatarResponse,
@@ -789,6 +791,17 @@ class AsyncClient(Client):
         )
 
         return await self._send(RegisterResponse, method, path, data)
+
+    async def login_info(self) -> Union[LoginInfoResponse, LoginInfoError]:
+        """Get the available login methods from the server
+
+        Returns either a `UpdateDeviceResponse` if the request was successful or
+        a `UpdateDeviceError` if there was an error with the request.
+
+        """
+        method, path = Api.login_info()
+
+        return await self._send(LoginInfoResponse, method, path)
 
     async def login(
         self,

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -795,8 +795,8 @@ class AsyncClient(Client):
     async def login_info(self) -> Union[LoginInfoResponse, LoginInfoError]:
         """Get the available login methods from the server
 
-        Returns either a `UpdateDeviceResponse` if the request was successful or
-        a `UpdateDeviceError` if there was an error with the request.
+        Returns either a `LoginInfoResponse` if the request was successful or
+        a `LoginInfoError` if there was an error with the request.
 
         """
         method, path = Api.login_info()

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -379,7 +379,7 @@ class TestClass:
         assert isinstance(resp, RegisterResponse)
         assert async_client.access_token
 
-    def test_login_info(self, async_client, aioresponse):
+    async def test_login_info(self, async_client, aioresponse):
         """Test that we can get login info"""
 
         aioresponse.get(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -24,7 +24,7 @@ from nio import (ContentRepositoryConfigResponse,
                  GroupEncryptionError,
                  JoinResponse, JoinedRoomsResponse,
                  JoinedMembersResponse, KeysClaimResponse, KeysQueryResponse,
-                 KeysUploadResponse, LocalProtocolError, LoginError,
+                 KeysUploadResponse, LocalProtocolError, LoginError, LoginInfoResponse,
                  LoginResponse, LogoutError, LogoutResponse,
                  MegolmEvent, MembersSyncError, OlmTrustError,
                  RegisterResponse,
@@ -378,6 +378,25 @@ class TestClass:
 
         assert isinstance(resp, RegisterResponse)
         assert async_client.access_token
+
+    def test_login_info(self, async_client, aioresponse):
+        """Test that we can get login info"""
+
+        aioresponse.get(
+            "https://example.org/_matrix/client/r0/login",
+            status=200,
+            payload={
+                "flows": [
+                    {
+                        "type": "m.login.password"
+                    }
+                ]
+            }
+        )
+        resp = await async_client.login_info()
+
+        assert isinstance(resp, LoginInfoResponse)
+
 
     def test_login(self, async_client, aioresponse):
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
Affects #85

Adds the `login_info()` method to the AsyncClient.
I also changed the type hints for the `login_info()` method in api to python3 syntax