### PR TITLE
Add mxc URI to download method

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -2379,9 +2379,9 @@ class AsyncClient(Client):
     @client_session
     async def download(
         self,
-        server_name: Optional[str],
-        media_id: Optional[str],
-        mxc: Optional[str],
+        server_name: Optional[str] = None,
+        media_id: Optional[str] = None,
+        mxc: Optional[str] = None,
         filename: Optional[str] = None,
         allow_remote: bool = True,
     ) -> Union[DownloadResponse, DownloadError]:

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -2413,7 +2413,7 @@ class AsyncClient(Client):
         if mxc:
             url = urlparse(mxc)
             server_name = url.netloc
-            media_id = url.path
+            media_id = url.path.replace('/', '')
 
         http_method, path = Api.download(
             server_name, media_id, filename, allow_remote

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -38,6 +38,7 @@ from typing import (
     Type,
     Union,
 )
+from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
 from dataclasses import dataclass, field
@@ -2378,12 +2379,15 @@ class AsyncClient(Client):
     @client_session
     async def download(
         self,
-        server_name: str,
-        media_id: str,
+        server_name: Optional[str],
+        media_id: Optional[str],
+        mxc: Optional[str],
         filename: Optional[str] = None,
         allow_remote: bool = True,
     ) -> Union[DownloadResponse, DownloadError]:
         """Get the content of a file from the content repository.
+
+        Either `server_name` and `media_id` or `mxc` must be given.
 
         This method ignores `AsyncClient.config.request_timeout` and uses `0`.
 
@@ -2393,8 +2397,9 @@ class AsyncClient(Client):
         a `DownloadError` if there was an error with the request.
 
         Args:
-            server_name (str): The server name from the mxc:// URI.
-            media_id (str): The media ID from the mxc:// URI.
+            server_name (str, optional): The server name from the mxc:// URI.
+            media_id (str, optional): The media ID from the mxc:// URI.
+            mxc (str, optional): The mxc:// URI.
             filename (str, optional): A filename to be returned in the response
                 by the server. If None (default), the original name of the
                 file will be returned instead, if there is one.
@@ -2404,6 +2409,11 @@ class AsyncClient(Client):
                 itself.
         """
         # TODO: support TransferMonitor
+
+        if mxc:
+            url = urlparse(mxc)
+            server_name = url.netloc
+            media_id = url.path
 
         http_method, path = Api.download(
             server_name, media_id, filename, allow_remote


### PR DESCRIPTION
Closes #94 

Make `server_name` and `media_id` optional
Add optional `mxc` parameter

Either `server_name` and `media_id` or `mxc` is required

I don´t know if this is the perfect solution. Feedback welcome.