### PR TITLE
Add room_get_event method to api

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -470,6 +470,32 @@ class Api:
         )
 
     @staticmethod
+    def room_get_event(
+        access_token: str,
+        room_id: str,
+        event_id: str
+    ) -> Tuple[str, str]:
+        """Get a single event based on roomId/eventId.
+
+        Returns the HTTP method and HTTP path for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+            room_id (str): The room id of the room where the event is in.
+            event_id (str): The event id to get.
+        """
+        query_parameters = {"access_token": access_token}
+
+        path = "rooms/{room}/event/{event_id}".format(
+            room=room_id, event_id=event_id
+        )
+
+        return (
+            "GET",
+            Api._build_path(path, query_parameters)
+        )
+
+    @staticmethod
     def room_put_state(
         access_token, # type str
         room_id,      # type str

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -466,20 +466,6 @@ class AsyncClient(Client):
             parsed_dict = await self.parse_body(transport_response)
             resp = DeleteDevicesAuthResponse.from_dict(parsed_dict)
 
-        elif issubclass(response_class, RoomGetEventResponse):
-            parsed_dict = await self.parse_body(transport_response)
-            if transport_response.status == 404:
-                resp = RoomGetEventResponse.create_error(parsed_dict)
-
-            else:
-                parsed_dict = await self.parse_body(transport_response)
-                event = Event.parse_event(parsed_dict)
-                if isinstance(event, MegolmEvent):
-                    event = self.decrypt_event(event)
-
-                resp = RoomGetEventResponse()
-                resp.event = event
-
         else:
             parsed_dict = await self.parse_body(transport_response)
             resp = response_class.from_dict(parsed_dict, *data)

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -477,7 +477,8 @@ class AsyncClient(Client):
                 if isinstance(event, MegolmEvent):
                     event = self.decrypt_event(event)
 
-                resp = RoomGetEventResponse(event)
+                resp = RoomGetEventResponse()
+                resp.event = event
 
         else:
             parsed_dict = await self.parse_body(transport_response)

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1440,7 +1440,10 @@ class AsyncClient(Client):
     ) -> Union[RoomGetEventResponse, RoomGetEventError]:
         """Get a single event based on roomId/eventId.
 
-        Returns the HTTP method and HTTP path for the request.
+        Calls receive_response() to update the client state if necessary.
+
+        Returns either a `RoomGetEventResponse` if the request was successful
+        or a `RoomGetEventError` if there was an error with the request.
 
         Args:
             room_id (str): The room id of the room where the event is in.

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -63,6 +63,7 @@ from ..responses import (
     RoomForgetResponse,
     RoomKeyRequestResponse,
     RoomMessagesResponse,
+    RoomGetEventResponse,
     ShareGroupSessionResponse,
     SyncResponse,
     SyncType,
@@ -985,6 +986,9 @@ class Client:
             self._handle_room_forget_response(response)
         elif isinstance(response, ToDeviceResponse):
             self._handle_olm_response(response)
+        elif isinstance(response, RoomGetEventResponse):
+            if isinstance(response.event, MegolmEvent):
+                response.event = self.decrypt_event(response.event)
         elif isinstance(response, ErrorResponse):
             if response.soft_logout:
                 self.access_token = ""

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -842,7 +842,7 @@ class RoomGetEventResponse(Response):
     """A response indicating successful room get event request.
 
     Attributes:
-        event (Dict): The requested event.
+        event (Event): The requested event.
     """
 
     event: Event = field()
@@ -850,6 +850,19 @@ class RoomGetEventResponse(Response):
     @staticmethod
     def create_error(parsed_dict):
         return RoomGetEventError.from_dict(parsed_dict)
+
+    @classmethod
+    def from_dict(
+        cls,
+        parsed_dict: Dict[str, Any]
+    ) -> Union["RoomGetEventResponse", RoomGetEventError]:
+        if "errcode" in parsed_dict:
+            return RoomGetEventError.from_dict(parsed_dict)
+
+        event = Event.parse_event(parsed_dict)
+        resp = cls()
+        resp.event = event
+        return resp
 
 
 class RoomPutStateResponse(RoomEventIdResponse):

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -857,7 +857,7 @@ class RoomGetEventResponse(Response):
         parsed_dict: Dict[str, Any]
     ) -> Union["RoomGetEventResponse", RoomGetEventError]:
         if "errcode" in parsed_dict:
-            return RoomGetEventError.from_dict(parsed_dict)
+            return cls.create_error(parsed_dict)
 
         event = Event.parse_event(parsed_dict)
         resp = cls()

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -847,18 +847,16 @@ class RoomGetEventResponse(Response):
 
     event: Event = field()
 
-    @staticmethod
-    def create_error(parsed_dict):
-        return RoomGetEventError.from_dict(parsed_dict)
-
     @classmethod
+    @verify(
+        Schemas.room_event,
+        RoomGetEventError,
+        pass_arguments=False,
+    )
     def from_dict(
         cls,
         parsed_dict: Dict[str, Any]
     ) -> Union["RoomGetEventResponse", RoomGetEventError]:
-        if "errcode" in parsed_dict:
-            return cls.create_error(parsed_dict)
-
         event = Event.parse_event(parsed_dict)
         resp = cls()
         resp.event = event

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -838,14 +838,14 @@ class RoomGetStateEventResponse(Response):
         return cls(parsed_dict, event_type, state_key, room_id)
 
 
-class RoomGetEventResponse(ErrorResponse):
+class RoomGetEventResponse(Response):
     """A response indicating successful room get event request.
 
     Attributes:
         event (Dict): The requested event.
     """
 
-    event: Dict = field()
+    event: Event = field()
 
     @staticmethod
     def create_error(parsed_dict):

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -93,6 +93,8 @@ __all__ = [
     "RoomGetStateError",
     "RoomGetStateEventResponse",
     "RoomGetStateEventError",
+    "RoomGetEventResponse",
+    "RoomGetEventError",
     "RoomPutStateResponse",
     "RoomPutStateError",
     "RoomRedactResponse",
@@ -380,6 +382,11 @@ class RoomGetStateError(_ErrorWithRoomId):
 
 class RoomGetStateEventError(_ErrorWithRoomId):
     """A response representing an unsuccessful room state query."""
+    pass
+
+
+class RoomGetEventError(ErrorResponse):
+    """A response representing an unsuccessful room get event request."""
     pass
 
 
@@ -829,6 +836,20 @@ class RoomGetStateEventResponse(Response):
         room_id: str,
     ) -> Union["RoomGetStateEventResponse", RoomGetStateEventError] :
         return cls(parsed_dict, event_type, state_key, room_id)
+
+
+class RoomGetEventResponse(ErrorResponse):
+    """A response indicating successful room get event request.
+
+    Attributes:
+        event (Dict): The requested event.
+    """
+
+    event: Dict = field()
+
+    @staticmethod
+    def create_error(parsed_dict):
+        return RoomGetEventError.from_dict(parsed_dict)
 
 
 class RoomPutStateResponse(RoomEventIdResponse):

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -805,7 +805,7 @@ class TestClass:
             }
 
         aioresponse.get(
-            "{base}/rooms/{room}/event/{event_id}/?{query}".format(
+            "{base}/rooms/{room}/event/{event_id}?{query}".format(
                 base=base_url,
                 room=TEST_ROOM_ID,
                 event_id="$15163622445EBvZJ:localhost",

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -39,6 +39,7 @@ from nio import (ContentRepositoryConfigResponse,
                  RoomMemberEvent, RoomMessagesResponse, Rooms,
                  RoomGetStateResponse, RoomGetStateEventResponse,
                  RoomKickResponse,
+                 RoomGetEventResponse,
                  RoomPutStateResponse, RoomReadMarkersResponse,
                  RoomRedactResponse, RoomResolveAliasResponse,
                  RoomSendResponse, RoomSummary,
@@ -777,6 +778,49 @@ class TestClass:
         )
 
         assert isinstance(response, RoomSendResponse)
+
+    async def test_room_get_event(self, async_client, aioresponse):
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response)
+        )
+        assert async_client.logged_in
+
+        base_url = "https://example.org/_matrix/client/r0"
+
+        response = {
+                "content": {
+                    "body": "This is an example text message",
+                    "msgtype": "m.text",
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": "<b>This is an example text message</b>"
+                },
+                "type": "m.room.message",
+                "event_id": "$15163622445EBvZJ:localhost",
+                "room_id": TEST_ROOM_ID,
+                "sender": "@example:example.org",
+                "origin_server_ts": 1432735824653,
+                "unsigned": {
+                    "age": 1234
+                }
+            }
+
+        aioresponse.get(
+            "{base}/rooms/{room}/event/{event_id}/?{query}".format(
+                base=base_url,
+                room=TEST_ROOM_ID,
+                event_id="$15163622445EBvZJ:localhost",
+                query="access_token=abc123"
+            ),
+            status=200,
+            payload=response
+        )
+
+        resp = await async_client.room_get_event(
+            TEST_ROOM_ID,
+            "$15163622445EBvZJ:localhost"
+        )
+
+        assert isinstance(resp, RoomGetEventResponse)
 
     async def test_room_put_state(self, async_client, aioresponse):
         await async_client.receive_response(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -39,7 +39,7 @@ from nio import (ContentRepositoryConfigResponse,
                  RoomMemberEvent, RoomMessagesResponse, Rooms,
                  RoomGetStateResponse, RoomGetStateEventResponse,
                  RoomKickResponse,
-                 RoomGetEventResponse,
+                 RoomGetEventResponse, RoomGetEventError,
                  RoomPutStateResponse, RoomReadMarkersResponse,
                  RoomRedactResponse, RoomResolveAliasResponse,
                  RoomSendResponse, RoomSummary,
@@ -821,6 +821,28 @@ class TestClass:
         )
 
         assert isinstance(resp, RoomGetEventResponse)
+        assert isinstance(resp.event, RoomMessageText)
+
+        aioresponse.get(
+            "{base}/rooms/{room}/event/{event_id}?{query}".format(
+                base=base_url,
+                room=TEST_ROOM_ID,
+                event_id="$not-found:localhost",
+                query="access_token=abc123"
+            ),
+            status=200,
+            payload={
+                "errcode": "M_NOT_FOUND",
+                "error": "Event not found."
+            }
+        )
+
+        resp = await async_client.room_get_event(
+            TEST_ROOM_ID,
+            "$not-found:localhost"
+        )
+
+        assert isinstance(resp, RoomGetEventError)
 
     async def test_room_put_state(self, async_client, aioresponse):
         await async_client.receive_response(


### PR DESCRIPTION
I´m trying to implement `room_get_event` - [Matrix Specs](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-rooms-roomid-event-eventid)

I got the api part.
But have a question to the `async_client` part. If i use `_send` it will call `receive_response` but i don´t think that´s what we want.
Ideally the method `async_client.room_get_event()` should return the requested event as EventObject or None?! if not_found?