### PR TITLE
Fix room summary update when new summary has falsy attributes

### DIFF
--- a/nio/responses.py
+++ b/nio/responses.py
@@ -195,7 +195,7 @@ class InviteInfo:
 class RoomSummary:
     invited_member_count: Optional[int] = None
     joined_member_count: Optional[int] = None
-    heroes: List[str] = field(default_factory=list)
+    heroes: Optional[List[str]] = None
 
 
 @dataclass
@@ -1563,7 +1563,7 @@ class _SyncResponse(Response):
         summary = RoomSummary(
             summary_events.get("m.invited_member_count", None),
             summary_events.get("m.joined_member_count", None),
-            summary_events.get("m.heroes", [])
+            summary_events.get("m.heroes", None),
         )
 
         account_data = RoomInfo.parse_account_data(account_data_events)

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -388,19 +388,20 @@ class MatrixRoom:
             self.summary = summary
             return
 
-        if summary.joined_member_count:
+        if summary.joined_member_count is not None:
             self.summary.joined_member_count = summary.joined_member_count
 
-        if summary.invited_member_count:
+        if summary.invited_member_count is not None:
             self.summary.invited_member_count = summary.invited_member_count
 
-        if summary.heroes:
+        if summary.heroes is not None:
             self.summary.heroes = summary.heroes
 
     def _summary_details(self) -> Tuple[List[str], int, int]:
         """Return the summary attributes if it can be used for calculations."""
         valid = bool(
             self.summary is not None and
+            self.summary.heroes is not None and
             self.summary.joined_member_count is not None and
             self.summary.invited_member_count is not None,
         )

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -401,7 +401,6 @@ class MatrixRoom:
         """Return the summary attributes if it can be used for calculations."""
         valid = bool(
             self.summary is not None and
-            self.summary.heroes is not None and
             self.summary.joined_member_count is not None and
             self.summary.invited_member_count is not None,
         )
@@ -409,7 +408,7 @@ class MatrixRoom:
             raise ValueError("Unusable summary")
 
         return (  # type: ignore
-            self.summary.heroes,                # type: ignore
+            self.summary.heroes or [],          # type: ignore
             self.summary.joined_member_count,   # type: ignore
             self.summary.invited_member_count,  # type: ignore
         )


### PR DESCRIPTION
- Update the room's summary with the new summary's joined/invited member
  if that count isn't `None`, lets `0` be a valid new value

- Summary heroes can now be a list or `None`, the room's summary will be
  updated if the new summary is a list (empty or not) but not if
  it's `None`