### PR TITLE
Fix typo in encryption warning

### DIFF
--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -157,7 +157,7 @@ class ClientConfig:
             raise ImportWarning(
                 "Encryption is enabled in the client "
                 "configuration but dependencies for E2E "
-                "encrytpion aren't installed."
+                "encryption aren't installed."
             )
 
 


### PR DESCRIPTION
Just a small typo fix in a user-visible warning: `encrytpion` -> `encryption`.