### PR TITLE
Add presence support

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -409,7 +409,7 @@ class Api:
                 to.
             timeout (int): The maximum time to wait, in milliseconds, before
                 returning this request.
-            sync_filter (Union[None, str, Dict[Any, Any]):
+            filter (Union[None, str, Dict[Any, Any]):
                 A filter ID or dict that should be used for this sync request.
             full_state (bool, optional): Controls whether to include the full
                 state for all rooms the user is a member of. If this is set to

--- a/nio/api.py
+++ b/nio/api.py
@@ -32,7 +32,7 @@ from enum import Enum, unique
 from typing import (Any, DefaultDict, Dict, Iterable, List,
                     Optional, Set, Sequence, Tuple, Union)
 
-from . import MatrixUserPresence
+from .rooms import MatrixUserPresence
 from .exceptions import LocalProtocolError
 from .http import Http2Request, HttpRequest, TransportRequest
 

--- a/nio/api.py
+++ b/nio/api.py
@@ -396,6 +396,7 @@ class Api:
         timeout:      Optional[int]  = None,
         filter:       _FilterT       = None,
         full_state:   Optional[bool] = None,
+        set_presence: Optional[str]  = None,
     ):
         # type: (...) -> Tuple[str, str]
         """Synchronise the client's state with the latest state on the server.
@@ -415,6 +416,13 @@ class Api:
                 true, then all state events will be returned, even if since is
                 non-empty. The timeline will still be limited by the since
                 parameter.
+            set_presence (str, optinal): Controls whether the client is automatically
+                marked as online by polling this API. If this parameter is omitted
+                then the client is automatically marked as online when it uses this API.
+                Otherwise if the parameter is set to "offline" then the client is not
+                marked as being online when it uses this API. When set to "unavailable",
+                the client is marked as being idle.
+                One of: ["offline", "online", "unavailable"]
         """
         query_parameters = {"access_token": access_token}
 
@@ -426,6 +434,9 @@ class Api:
 
         if timeout is not None:
             query_parameters["timeout"] = str(timeout)
+
+        if set_presence:
+            query_parameters["set_presence"] = set_presence
 
         if isinstance(filter, dict):
             filter_json = json.dumps(filter, separators=(",", ":"))

--- a/nio/api.py
+++ b/nio/api.py
@@ -32,7 +32,6 @@ from enum import Enum, unique
 from typing import (Any, DefaultDict, Dict, Iterable, List,
                     Optional, Set, Sequence, Tuple, Union)
 
-from .rooms import MatrixUserPresence
 from .exceptions import LocalProtocolError
 from .http import Http2Request, HttpRequest, TransportRequest
 
@@ -1503,7 +1502,7 @@ class Api:
         )
 
     @staticmethod
-    def set_presence(access_token: str, user_id: str, presence: MatrixUserPresence, status_msg: str = None):
+    def set_presence(access_token: str, user_id: str, presence: str, status_msg: str = None):
         """This API sets the given user's presence state.
 
         Returns the HTTP method, HTTP path and data for the request.
@@ -1511,11 +1510,11 @@ class Api:
         Args:
             access_token (str): The access token to be used with the request.
             user_id (str): User id whose presence state to get.
-            presence (MatrixUserPresence): The new presence state.
+            presence (str): The new presence state.
             status_msg (str, optional): The status message to attach to this state.
         """
         query_parameters = {"access_token": access_token}
-        content = {"presence": presence.name}
+        content = {"presence": presence}
         if status_msg:
             content["status_msg"] = status_msg
         path = "presence/{user_id}/status".format(user_id=user_id)

--- a/nio/api.py
+++ b/nio/api.py
@@ -32,6 +32,7 @@ from enum import Enum, unique
 from typing import (Any, DefaultDict, Dict, Iterable, List,
                     Optional, Set, Sequence, Tuple, Union)
 
+from . import MatrixUserPresence
 from .exceptions import LocalProtocolError
 from .http import Http2Request, HttpRequest, TransportRequest
 
@@ -1476,6 +1477,48 @@ class Api:
         query_parameters = {"access_token": access_token}
         content = {"avatar_url": avatar_url}
         path = "profile/{user}/avatar_url".format(user=user_id)
+
+        return (
+            "PUT",
+            Api._build_path(path, query_parameters),
+            Api.to_json(content)
+        )
+
+    @staticmethod
+    def get_presence(access_token: str, user_id: str) -> Tuple[str, str]:
+        """Get the given user's presence state.
+
+        Returns the HTTP method and HTTP path for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+            user_id (str): User id whose presence state to get.
+        """
+        query_parameters = {"access_token": access_token}
+        path = "presence/{user_id}/status".format(user_id=user_id)
+
+        return (
+            "GET",
+            Api._build_path(path, query_parameters),
+        )
+
+    @staticmethod
+    def set_presence(access_token: str, user_id: str, presence: MatrixUserPresence, status_msg: str = None):
+        """This API sets the given user's presence state.
+
+        Returns the HTTP method, HTTP path and data for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+            user_id (str): User id whose presence state to get.
+            presence (MatrixUserPresence): The new presence state.
+            status_msg (str, optional): The status message to attach to this state.
+        """
+        query_parameters = {"access_token": access_token}
+        content = {"presence": presence.name}
+        if status_msg:
+            content["status_msg"] = status_msg
+        path = "presence/{user_id}/status".format(user_id=user_id)
 
         return (
             "PUT",

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -577,6 +577,10 @@ class AsyncClient(Client):
                 self.rooms[room_id].users[event.user_id].currently_active = event.currently_active
                 self.rooms[room_id].users[event.user_id].status_msg = event.status_msg
 
+            for cb in self.presence_callbacks:
+                if cb.filter is None or isinstance(event, cb.filter):
+                    await asyncio.coroutine(cb.func)(event)
+
     async def _handle_expired_verifications(self):
         expired_verifications = self.olm.clear_verifications()
 

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -2622,11 +2622,11 @@ class AsyncClient(Client):
 
     @client_session
     async def set_presence(
-            self,
-            presence: str,
-            status_msg: str = None
+        self,
+        presence: str,
+        status_msg: str = None
     ) -> Union[PresenceSetResponse, PresenceSetError]:
-        """Set a user's presence state.
+        """Set our user's presence state.
 
         This tells the server to set presence state of the currently logged
         in user to the supplied string.

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -368,7 +368,7 @@ class AsyncClient(Client):
         self.ssl = ssl
         self.proxy = proxy
 
-        self.presence = presence
+        self._presence = presence
 
         self.synced = AsyncioEvent()
         self.response_callbacks: List[ResponseCb] = []
@@ -937,7 +937,7 @@ class AsyncClient(Client):
         """
 
         sync_token = since or self.next_batch
-        presence = set_presence or self.presence
+        presence = set_presence or self._presence
         method, path = Api.sync(
             self.access_token,
             since=sync_token or self.loaded_sync_token,
@@ -2665,7 +2665,7 @@ class AsyncClient(Client):
             PresenceSetResponse, method, path, data
         )
         if isinstance(resp, PresenceSetResponse):
-            self.presence = presence
+            self._presence = presence
 
         return resp
 

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -971,7 +971,7 @@ class Client:
 
                 self.rooms[room_id].users[response.user_id].presence = response.presence
                 self.rooms[room_id].users[response.user_id].last_active_ago = response.last_active_ago
-                self.rooms[room_id].users[response.user_id].currently_active = response.currently_active
+                self.rooms[room_id].users[response.user_id].currently_active = response.currently_active or False
                 self.rooms[room_id].users[response.user_id].status_msg = response.status_msg
 
     def receive_response(

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -69,7 +69,7 @@ from ..responses import (
     SyncType,
     ToDeviceResponse,
 )
-from ..rooms import MatrixInvitedRoom, MatrixRoom, MatrixUserPresence
+from ..rooms import MatrixInvitedRoom, MatrixRoom
 
 from ..crypto import DeviceStore, OlmDevice, OutgoingKeyRequest
 
@@ -771,10 +771,10 @@ class Client:
                 if event.user_id not in self.rooms[room_id].users:
                     continue
 
-                self.rooms[room_id].users[event.user_id].presence = MatrixUserPresence(event.presence)
-                self.rooms[room_id].users[event.user_id].last_active_ago = MatrixUserPresence(event.last_active_ago)
-                self.rooms[room_id].users[event.user_id].currently_active = MatrixUserPresence(event.currently_active)
-                self.rooms[room_id].users[event.user_id].status_msg = MatrixUserPresence(event.status_msg)
+                self.rooms[room_id].users[event.user_id].presence = event.presence
+                self.rooms[room_id].users[event.user_id].last_active_ago = event.last_active_ago
+                self.rooms[room_id].users[event.user_id].currently_active = event.currently_active
+                self.rooms[room_id].users[event.user_id].status_msg = event.status_msg
 
     def _handle_expired_verifications(self):
         expired_verifications = self.olm.clear_verifications()

--- a/nio/events/__init__.py
+++ b/nio/events/__init__.py
@@ -13,3 +13,4 @@ from .ephemeral import *
 from .account_data import *
 from .invite_events import *
 from .misc import *
+from .presence import *

--- a/nio/events/presence.py
+++ b/nio/events/presence.py
@@ -33,9 +33,9 @@ class PresenceEvent:
 
     user_id: str = field()
     presence: str = field()
-    last_active_ago: int = field(default=None)
-    currently_active: bool = field(default=None)
-    status_msg: str = field(default=None)
+    last_active_ago: int = field()
+    currently_active: bool = field()
+    status_msg: str = field()
 
     @classmethod
     @verify_or_none(Schemas.presence)

--- a/nio/events/presence.py
+++ b/nio/events/presence.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018-2019 Damir Jelić <poljar@termina.org.uk>
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+# CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from typing import Dict
+
+from dataclasses import dataclass, field
+from logbook import Logger
+from .misc import verify_or_none
+
+from ..log import logger_group
+from ..schemas import Schemas
+
+logger = Logger("nio.events")
+logger_group.add_logger(logger)
+
+
+@dataclass
+class PresenceEvent:
+    """Informs the client of a user's presence state change."""
+
+    user_id: str = field()
+    presence: str = field()
+    last_active_ago: int = field(default=None)
+    currently_active: bool = field(default=None)
+    status_msg: str = field(default=None)
+
+    @classmethod
+    @verify_or_none(Schemas.presence)
+    def from_dict(cls, parsed_dict):
+        """Create an Presence event from a dictionary.
+
+        Args:
+            parsed_dict (dict): The dictionary representation of the event.
+
+        """
+        args = Dict[str, any]
+        args["user_id"] = parsed_dict["sender"]
+        args["presence"] = parsed_dict["content"]["presence"]
+
+        if "last_active_ago" in parsed_dict["content"]:
+            args["last_active_ago"] = parsed_dict["content"]["last_active_ago"]
+        if "currently_active" in parsed_dict["content"]:
+            args["currently_active"] = parsed_dict["content"]["currently_active"]
+        if "status_msg" in parsed_dict["content"]:
+            args["status_msg"] = parsed_dict["content"]["status_msg"]
+
+        return cls(**args)

--- a/nio/events/presence.py
+++ b/nio/events/presence.py
@@ -18,7 +18,8 @@ from typing import Dict
 
 from dataclasses import dataclass, field
 from logbook import Logger
-from .misc import verify_or_none
+
+from .misc import verify
 
 from ..log import logger_group
 from ..schemas import Schemas
@@ -38,7 +39,7 @@ class PresenceEvent:
     status_msg: str = field()
 
     @classmethod
-    @verify_or_none(Schemas.presence)
+    @verify(Schemas.presence)
     def from_dict(cls, parsed_dict):
         """Create an Presence event from a dictionary.
 
@@ -46,9 +47,7 @@ class PresenceEvent:
             parsed_dict (dict): The dictionary representation of the event.
 
         """
-        args = Dict[str, any]
-        args["user_id"] = parsed_dict["sender"]
-        args["presence"] = parsed_dict["content"]["presence"]
+        args = {"user_id": parsed_dict["sender"], "presence": parsed_dict["content"]["presence"]}
 
         if "last_active_ago" in parsed_dict["content"]:
             args["last_active_ago"] = parsed_dict["content"]["last_active_ago"]

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -132,6 +132,10 @@ __all__ = [
     "ProfileGetAvatarError",
     "ProfileSetAvatarResponse",
     "ProfileSetAvatarError",
+    "PresenceGetResponse",
+    "PresenceGetError",
+    "PresenceSetResponse",
+    "PresenceSetError",
     "RoomKeyRequestResponse",
     "RoomKeyRequestError",
     "ThumbnailResponse",
@@ -533,6 +537,16 @@ class ProfileSetDisplayNameError(ErrorResponse):
 
 
 class ProfileGetAvatarError(ErrorResponse):
+    pass
+
+
+class PresenceGetError(ErrorResponse):
+    """Response representing a unsuccessful get presence request."""
+    pass
+
+
+class PresenceSetError(ErrorResponse):
+    """Response representing a unsuccessful set presence request."""
     pass
 
 
@@ -1337,6 +1351,38 @@ class ProfileSetAvatarResponse(EmptyResponse):
     @staticmethod
     def create_error(parsed_dict):
         return ProfileSetAvatarError.from_dict(parsed_dict)
+
+
+@dataclass
+class PresenceGetResponse(Response):
+    """Response representing a successful get presence request.
+
+    Attributes:
+        presence (str): The user's presence state. One of: ["online", "offline", "unavailable"]
+        last_active_ago (int, optional): The length of time in milliseconds since an action was performed by this user.
+            None if not set.
+        currently_active (bool, optional): Whether the user is currently active. None if not set.
+        status_msg (str, optional): The state message for this user. None if not set.
+    """
+
+    presence: str
+    last_active_ago: int = None
+    currently_active: bool = None
+    status_msg: str = None
+
+    @classmethod
+    @verify(Schemas.get_presence, PresenceGetError)
+    def from_dict(cls, parsed_dict: Dict[any, any]) -> Union["PresenceGetResponse", PresenceGetError]:
+        return cls(parsed_dict.get("presence"), parsed_dict.get("last_active_ago", None),
+                   parsed_dict.get("currently_active", None), parsed_dict.get("status_msg", None))
+
+
+class PresenceSetResponse(EmptyResponse):
+    """Response representing a successful set presence request."""
+
+    @staticmethod
+    def create_error(parsed_dict):
+        return PresenceSetError.from_dict(parsed_dict)
 
 
 @dataclass

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -1363,18 +1363,21 @@ class PresenceGetResponse(Response):
             None if not set.
         currently_active (bool, optional): Whether the user is currently active. None if not set.
         status_msg (str, optional): The state message for this user. None if not set.
+        user_id (str, optional): The user´s id
     """
 
     presence: str
     last_active_ago: Optional[int]
     currently_active: Optional[bool]
     status_msg: Optional[str]
+    user_id: Optional[str]
 
     @classmethod
     @verify(Schemas.get_presence, PresenceGetError)
     def from_dict(cls, parsed_dict: Dict[Any, Any]) -> Union["PresenceGetResponse", PresenceGetError]:
         return cls(parsed_dict.get("presence", "offline"), parsed_dict.get("last_active_ago"),
-                   parsed_dict.get("currently_active"), parsed_dict.get("status_msg"))
+                   parsed_dict.get("currently_active"), parsed_dict.get("status_msg"),
+                   parsed_dict.get("user_id"))
 
 
 class PresenceSetResponse(EmptyResponse):

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -1366,15 +1366,15 @@ class PresenceGetResponse(Response):
     """
 
     presence: str
-    last_active_ago: int = None
-    currently_active: bool = None
-    status_msg: str = None
+    last_active_ago: Optional[int]
+    currently_active: Optional[bool]
+    status_msg: Optional[str]
 
     @classmethod
     @verify(Schemas.get_presence, PresenceGetError)
-    def from_dict(cls, parsed_dict: Dict[any, any]) -> Union["PresenceGetResponse", PresenceGetError]:
-        return cls(parsed_dict.get("presence"), parsed_dict.get("last_active_ago", None),
-                   parsed_dict.get("currently_active", None), parsed_dict.get("status_msg", None))
+    def from_dict(cls, parsed_dict: Dict[Any, Any]) -> Union["PresenceGetResponse", PresenceGetError]:
+        return cls(parsed_dict.get("presence", "offline"), parsed_dict.get("last_active_ago"),
+                   parsed_dict.get("currently_active"), parsed_dict.get("status_msg"))
 
 
 class PresenceSetResponse(EmptyResponse):

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 
 from builtins import super
 from collections import defaultdict
+from enum import Enum
 from typing import (Any, DefaultDict, Dict, List, NamedTuple, Optional, Tuple,
                     Union)
 
@@ -482,6 +483,17 @@ class MatrixInvitedRoom(MatrixRoom):
             self.canonical_alias = event.canonical_alias
 
 
+class UserPresence(Enum):
+    """The user presence state.
+
+    An Enum holding differing values that a user presence can be in.
+    """
+
+    online = "online"
+    offline = "offline"
+    unavailable = "unavailable"
+
+
 class MatrixUser:
     def __init__(
         self,
@@ -490,6 +502,8 @@ class MatrixUser:
         avatar_url:   str  = None,
         power_level:  int  = 0,
         invited:      bool = False,
+        presence:     UserPresence = UserPresence.offline,
+        status_msg:   str = None
     ):
         # yapf: disable
         self.user_id = user_id
@@ -497,6 +511,8 @@ class MatrixUser:
         self.avatar_url = avatar_url
         self.power_level = power_level
         self.invited = invited
+        self.presence = presence
+        self.status_msg = status_msg
         # yapf: enable
 
     @property

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -41,6 +41,7 @@ logger_group.add_logger(logger)
 __all__ = [
     "MatrixRoom",
     "MatrixInvitedRoom",
+    "MatrixUserPresence",
     "MatrixUser",
 ]
 
@@ -483,7 +484,7 @@ class MatrixInvitedRoom(MatrixRoom):
             self.canonical_alias = event.canonical_alias
 
 
-class UserPresence(Enum):
+class MatrixUserPresence(Enum):
     """The user presence state.
 
     An Enum holding differing values that a user presence can be in.
@@ -502,7 +503,7 @@ class MatrixUser:
         avatar_url:   str  = None,
         power_level:  int  = 0,
         invited:      bool = False,
-        presence:     UserPresence = UserPresence.offline,
+        presence:     MatrixUserPresence = MatrixUserPresence.offline,
         status_msg:   str = None
     ):
         # yapf: disable

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -489,7 +489,6 @@ class MatrixUserPresence(Enum):
 
     An Enum holding differing values that a user presence can be in.
     """
-
     online = "online"
     offline = "offline"
     unavailable = "unavailable"
@@ -504,7 +503,9 @@ class MatrixUser:
         power_level:  int  = 0,
         invited:      bool = False,
         presence:     MatrixUserPresence = MatrixUserPresence.offline,
-        status_msg:   str = None
+        last_active_ago: int = None,
+        currently_active: bool = False,
+        status_msg: str = None
     ):
         # yapf: disable
         self.user_id = user_id
@@ -513,6 +514,8 @@ class MatrixUser:
         self.power_level = power_level
         self.invited = invited
         self.presence = presence
+        self.last_active_ago = last_active_ago
+        self.currently_active = currently_active
         self.status_msg = status_msg
         # yapf: enable
 

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -41,7 +41,6 @@ logger_group.add_logger(logger)
 __all__ = [
     "MatrixRoom",
     "MatrixInvitedRoom",
-    "MatrixUserPresence",
     "MatrixUser",
 ]
 
@@ -484,16 +483,6 @@ class MatrixInvitedRoom(MatrixRoom):
             self.canonical_alias = event.canonical_alias
 
 
-class MatrixUserPresence(Enum):
-    """The user presence state.
-
-    An Enum holding differing values that a user presence can be in.
-    """
-    online = "online"
-    offline = "offline"
-    unavailable = "unavailable"
-
-
 class MatrixUser:
     def __init__(
         self,
@@ -502,7 +491,7 @@ class MatrixUser:
         avatar_url:   str  = None,
         power_level:  int  = 0,
         invited:      bool = False,
-        presence:     MatrixUserPresence = MatrixUserPresence.offline,
+        presence:     str = "offline",
         last_active_ago: int = None,
         currently_active: bool = False,
         status_msg: str = None

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1778,6 +1778,7 @@ class Schemas:
             "last_active_ago": {"type": "integer"},
             "status_msg": {"type": "string"},
             "currently_active": {"type": "boolean"},
+            "user_id": {"type": "string"},
         },
         "required": [
             "presence",

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1739,4 +1739,29 @@ class Schemas:
         ],
     }
 
+    presence = {
+        "type": "object",
+        "properties": {
+            "sender": {"type": "string"},
+            "type": {"type": "string", "const": "m.presence"},
+            "content": {
+                "type": "object",
+                "properties": {
+                    "presence": {"type": "string"},
+                    "currently_active": {"type": "boolean"},
+                    "last_active_ago": {"type": "integer"},
+                    "status_msg": {"type": "string"},
+                },
+                "required": [
+                    "presence",
+                ]
+            }
+        },
+        "required": [
+            "sender",
+            "type",
+            "content"
+        ],
+    }
+
     empty = {"type": "object", "properties": {}, "additionalProperties": False}

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1764,4 +1764,17 @@ class Schemas:
         ],
     }
 
+    get_presence = {
+        "type": "object",
+        "properties": {
+            "presence": {"type": "string"},
+            "last_active_ago": {"type": "integer"},
+            "status_msg": {"type": "string"},
+            "currently_active": {"type": "boolean"},
+        },
+        "required": [
+            "presence",
+        ],
+    }
+
     empty = {"type": "object", "properties": {}, "additionalProperties": False}

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -420,6 +420,13 @@ class Schemas:
                 },
                 "required": ["events"]
             },
+            "presence": {
+                "type": "object",
+                "properties": {
+                    "events": {"type": "array"}
+                },
+                "required": ["events"]
+            }
         },
         "required": [
             "next_batch",

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -2074,7 +2074,7 @@ class TestClass:
             payload={}
         )
 
-        resp = await async_client.set_presence("online")
+        resp = await async_client.set_presence("online", "I am here.")
 
         assert isinstance(resp, PresenceSetResponse)
 

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -207,6 +207,7 @@ class TestClass:
             rooms,
             DeviceOneTimeKeyCount(49, 50),
             DeviceList([ALICE_ID], []),
+            [],
             []
         )
 
@@ -255,6 +256,7 @@ class TestClass:
             rooms,
             DeviceOneTimeKeyCount(50, 50),
             DeviceList([other_user], []),
+            [],
             []
         )
 

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -691,6 +691,30 @@ class TestClass:
         resp4 = await async_client.sync(sync_filter={})
         assert isinstance(resp4, SyncResponse)
 
+    async def test_sync_presence(self, async_client, aioresponse):
+        """Test if prsences info in sync events are parsed correctly
+        """
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response)
+        )
+        assert async_client.logged_in
+
+        aioresponse.get(
+            "https://example.org/_matrix/client/r0/sync?access_token={}".format(async_client.access_token),
+            status=200,
+            payload=self.sync_response
+        )
+
+        resp = await async_client.sync()
+        assert isinstance(resp, SyncResponse)
+
+        user = async_client.rooms["!SVkFJHzfwvuaIEawgC:localhost"].users["@example:localhost"]
+
+        assert user.currently_active
+        assert user.last_active_ago == 1337
+        assert user.presence == "online"
+        assert user.status_msg == "I am here."
+
     def test_keys_upload(self, async_client, aioresponse):
         loop = asyncio.get_event_loop()
 

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -2008,6 +2008,30 @@ class TestClass:
         assert isinstance(resp, PresenceGetResponse)
         assert resp.presence == "unavailable"
         assert resp.last_active_ago == 420845
+        assert not resp.currently_active
+        assert not resp.status_msg
+
+        aioresponse.get(
+            "https://example.org/_matrix/client/r0/presence/{}/status?access_token={}".format(
+                user_id,
+                async_client.access_token
+            ),
+            status=200,
+            payload={
+                "presence": "online",
+                "last_active_ago": 0,
+                "currently_active": True,
+                "status_msg": "I am here."
+            }
+        )
+
+        resp = await async_client.get_presence(user_id)
+
+        assert isinstance(resp, PresenceGetResponse)
+        assert resp.presence == "online"
+        assert resp.last_active_ago == 0
+        assert resp.currently_active
+        assert resp.status_msg == "I am here."
 
     async def test_set_presence(self, async_client, aioresponse):
         """Test if we can set the presence state of user

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -326,7 +326,8 @@ class TestClass:
                         "origin_server_ts": 1516809890615
                     }
                 )
-            ]
+            ],
+            []
         )
 
     @property
@@ -358,6 +359,7 @@ class TestClass:
             rooms,
             DeviceOneTimeKeyCount(49, 50),
             DeviceList([ALICE_ID], []),
+            [],
             []
         )
 
@@ -391,6 +393,7 @@ class TestClass:
             rooms,
             DeviceOneTimeKeyCount(49, 50),
             DeviceList([ALICE_ID], []),
+            [],
             []
         )
 
@@ -432,6 +435,7 @@ class TestClass:
             rooms,
             DeviceOneTimeKeyCount(49, 50),
             DeviceList([], []),
+            [],
             []
         )
 

--- a/tests/data/sync.json
+++ b/tests/data/sync.json
@@ -230,6 +230,16 @@
                     "currently_active": true,
                     "status_msg": "I am here."
                 }
+            },
+            {
+                "type": "m.presence",
+                "sender": "@example2:localhost",
+                "content": {
+                    "presence": "offline",
+                    "last_active_ago": 1337,
+                    "currently_active": false,
+                    "status_msg": "I am gone."
+                }
             }
         ]
     }

--- a/tests/data/sync.json
+++ b/tests/data/sync.json
@@ -218,5 +218,8 @@
     },
     "to_device": {
         "events": []
+    },
+    "presence": {
+        "events": []
     }
 }

--- a/tests/data/sync.json
+++ b/tests/data/sync.json
@@ -220,6 +220,17 @@
         "events": []
     },
     "presence": {
-        "events": []
+        "events": [
+            {
+                "type": "m.presence",
+                "sender": "@example:localhost",
+                "content": {
+                    "presence": "online",
+                    "last_active_ago": 1337,
+                    "currently_active": true,
+                    "status_msg": "I am here."
+                }
+            }
+        ]
     }
 }


### PR DESCRIPTION
Yesterday there was the question if nio supports presence/status in the nio matrix room.

So i did a thing :)

Add support for `m.presence` in sync events. [Spec](https://matrix.org/docs/spec/client_server/latest#m-presence)
Add support for PresenceEvent callbacks
Add `get_presence` and `set_presence` to async client
Add `presence`, `last_active_ago`, `currently_active` and `status_msg` fields to MatrixUser