### PR TITLE
Add a docker container with e2ee deps pre-installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ $ pip install "matrix-nio[e2e]"
 
 ```
 
+Additionally, a docker image with the e2ee enabled version of nio is provided in
+the `docker/` directory.
+
 Examples
 --------
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,72 @@
+# To build the image, run `docker build` command from the root of the
+# repository:
+#
+#    docker build -f docker/Dockerfile .
+#
+# There is an optional PYTHON_VERSION build argument which sets the
+# version of python to build against. For example:
+#
+#    docker build -f docker/Dockerfile --build-arg PYTHON_VERSION=3.8 .
+#
+#
+# And an optional LIBOLM_VERSION build argument which sets the
+# version of libolm to build against. For example:
+#
+#    docker build -f docker/Dockerfile --build-arg LIBOLM_VERSION=3.1.4 .
+#
+
+##
+## Creating a builder container
+##
+
+# We use an initial docker container to build all of the runtime dependencies,
+# then transfer those dependencies to the container we're going to ship,
+# before throwing this one away
+ARG PYTHON_VERSION=3.8
+FROM docker.io/python:${PYTHON_VERSION}-alpine3.11 as builder
+
+##
+## Build libolm for matrix-nio e2e support
+##
+
+# Install libolm build dependencies
+ARG LIBOLM_VERSION=3.1.4
+RUN apk add --no-cache \
+    make \
+    cmake \
+    gcc \
+    g++ \
+    git \
+    libffi-dev \
+    python3-dev
+
+# Build libolm at the specified version
+#
+# This will build libolm and place it at /libolm
+# This will also build the libolm python bindings and place them at /python-libs
+# We will later copy contents from both of these folders to the runtime container
+COPY docker/build_and_install_libolm.sh /scripts/
+RUN /scripts/build_and_install_libolm.sh ${LIBOLM_VERSION} /python-libs
+
+# Now that libolm is installed, install matrix-nio with e2e dependencies
+# We again install to /python-libs
+RUN pip install --prefix="/python-libs" --no-warn-script-location \
+    "matrix-nio[e2e]"
+
+##
+## Creating the runtime container
+##
+
+# Create the container we'll actually ship. We need to copy libolm and any
+# python dependencies that we built above to this container
+FROM docker.io/python:${PYTHON_VERSION}-alpine3.11
+
+# Copy python dependencies from the "builder" container
+COPY --from=builder /python-libs /usr/local
+
+# Copy libolm from the "builder" container
+COPY --from=builder /usr/local/lib/libolm* /usr/local/lib/
+
+# Install any native runtime dependencies
+RUN apk add --no-cache \
+    libstdc++

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,28 @@
+# Docker
+
+The provided docker base image is based on alpine, and comes with libolm and libolm python3
+bindings installed. This image can then be built on top of for projects that use matrix-nio.
+
+## Building the Image
+
+To build the image from source, use the following `docker build` command from
+the repo's root:
+
+```sh
+docker build -t poljar/matrix-nio:latest -f docker/Dockerfile .
+```
+
+You can also customise the version of libolm and python that is bundled in the container
+using the following build arguments.
+
+To customise the python version, set `PYTHON_VERSION`:
+
+```sh
+docker build -t poljar/matrix-nio:latest -f docker/Dockerfile --build-arg PYTHON_VERSION=3.8 .
+```
+
+To customise the libolm version, set `LIBOLM_VERSION`:
+
+```sh
+docker build -t poljar/matrix-nio:latest -f docker/Dockerfile --build-arg LIBOLM_VERSION=3.1.4 .
+```

--- a/docker/build_and_install_libolm.sh
+++ b/docker/build_and_install_libolm.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+#
+# Call with the following arguments:
+#
+#    ./build_and_install_libolm.sh <libolm version> <python bindings install dir>
+#
+# Example:
+#
+#    ./build_and_install_libolm.sh 3.1.4 /python-bindings
+#
+# Note that if a python bindings installation directory is not supplied, bindings will
+# be installed to the default directory.
+#
+
+set -ex
+
+# Download the specified version of libolm
+git clone -b "$1" https://gitlab.matrix.org/matrix-org/olm.git olm && cd olm
+
+# Build libolm
+cmake . -Bbuild
+cmake --build build
+
+# Install
+make install
+
+# Build the python3 bindings
+cd python && make olm-python3
+
+# Install python3 bindings
+mkdir -p "$2"
+DESTDIR="$2" make install-python3


### PR DESCRIPTION
This PR adds a docker image that can be used as a base for others using matrix-nio in their projects. It sets up an alpine environment with libolm and olm python3 bindings already installed.

Someone can then create another docker image on top which then installs their own necessary dependencies when shipping their project.

I'm hoping this will make matrix-nio-based projects easier to deploy, as the dependency on the libolm C library can be somewhat of a slight hindrance.