### PR TITLE
Fix PresenceEvent.from_dict() parsing

### DIFF
--- a/nio/events/presence.py
+++ b/nio/events/presence.py
@@ -14,7 +14,7 @@
 # CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from typing import Dict
+from typing import Optional
 
 from dataclasses import dataclass, field
 from logbook import Logger
@@ -34,9 +34,9 @@ class PresenceEvent:
 
     user_id: str = field()
     presence: str = field()
-    last_active_ago: int = field()
-    currently_active: bool = field()
-    status_msg: str = field()
+    last_active_ago: Optional[int] = None
+    currently_active: Optional[bool] = None
+    status_msg: Optional[str] = None
 
     @classmethod
     @verify(Schemas.presence)
@@ -47,7 +47,10 @@ class PresenceEvent:
             parsed_dict (dict): The dictionary representation of the event.
 
         """
-        args = {"user_id": parsed_dict["sender"], "presence": parsed_dict["content"]["presence"]}
+        args = {
+            "user_id": parsed_dict["sender"],
+            "presence": parsed_dict["content"]["presence"],
+        }
 
         if "last_active_ago" in parsed_dict["content"]:
             args["last_active_ago"] = parsed_dict["content"]["last_active_ago"]

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -498,14 +498,14 @@ class MatrixUser:
     def __init__(
         self,
         user_id:      str,
-        display_name: str  = None,
-        avatar_url:   str  = None,
+        display_name: Optional[str] = None,
+        avatar_url:   Optional[str] = None,
         power_level:  int  = 0,
         invited:      bool = False,
         presence:     str = "offline",
-        last_active_ago: int = None,
-        currently_active: bool = False,
-        status_msg: str = None
+        last_active_ago: Optional[int] = None,
+        currently_active: Optional[bool] = None,
+        status_msg: Optional[str] = None
     ):
         # yapf: disable
         self.user_id = user_id


### PR DESCRIPTION
The `last_active_ago`, `currently_active` and `status_msg` keys are
optional in `parsed_dict`, fix `PresenceEvent` fields to reflect that
and some related type hints.