### PR TITLE
presence: Use user_id from request instead of response

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -2634,7 +2634,7 @@ class AsyncClient(Client):
         )
 
         return await self._send(
-            PresenceGetResponse, method, path
+            PresenceGetResponse, method, path, response_data=(user_id,)
         )
 
     @client_session

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -974,15 +974,14 @@ class Client:
             del self.invited_rooms[response.room_id]
 
     def _handle_presence_response(self, response: PresenceGetResponse):
-        if response.user_id:
-            for room_id in self.rooms.keys():
-                if response.user_id not in self.rooms[room_id].users:
-                    continue
+        for room_id in self.rooms.keys():
+            if response.user_id not in self.rooms[room_id].users:
+                continue
 
-                self.rooms[room_id].users[response.user_id].presence = response.presence
-                self.rooms[room_id].users[response.user_id].last_active_ago = response.last_active_ago
-                self.rooms[room_id].users[response.user_id].currently_active = response.currently_active or False
-                self.rooms[room_id].users[response.user_id].status_msg = response.status_msg
+            self.rooms[room_id].users[response.user_id].presence = response.presence
+            self.rooms[room_id].users[response.user_id].last_active_ago = response.last_active_ago
+            self.rooms[room_id].users[response.user_id].currently_active = response.currently_active or False
+            self.rooms[room_id].users[response.user_id].status_msg = response.status_msg
 
     def receive_response(
         self, response: Response

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -1358,26 +1358,25 @@ class PresenceGetResponse(Response):
     """Response representing a successful get presence request.
 
     Attributes:
+        user_id (str): The user´s id
         presence (str): The user's presence state. One of: ["online", "offline", "unavailable"]
         last_active_ago (int, optional): The length of time in milliseconds since an action was performed by this user.
             None if not set.
         currently_active (bool, optional): Whether the user is currently active. None if not set.
         status_msg (str, optional): The state message for this user. None if not set.
-        user_id (str, optional): The user´s id
     """
 
+    user_id: str
     presence: str
     last_active_ago: Optional[int]
     currently_active: Optional[bool]
     status_msg: Optional[str]
-    user_id: Optional[str]
 
     @classmethod
     @verify(Schemas.get_presence, PresenceGetError)
-    def from_dict(cls, parsed_dict: Dict[Any, Any]) -> Union["PresenceGetResponse", PresenceGetError]:
-        return cls(parsed_dict.get("presence", "offline"), parsed_dict.get("last_active_ago"),
-                   parsed_dict.get("currently_active"), parsed_dict.get("status_msg"),
-                   parsed_dict.get("user_id"))
+    def from_dict(cls, parsed_dict: Dict[Any, Any], user_id: str) -> Union["PresenceGetResponse", PresenceGetError]:
+        return cls(user_id, parsed_dict.get("presence", "offline"), parsed_dict.get("last_active_ago"),
+                   parsed_dict.get("currently_active"), parsed_dict.get("status_msg"))
 
 
 class PresenceSetResponse(EmptyResponse):

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1778,7 +1778,6 @@ class Schemas:
             "last_active_ago": {"type": "integer"},
             "status_msg": {"type": "string"},
             "currently_active": {"type": "boolean"},
-            "user_id": {"type": "string"},
         },
         "required": [
             "presence",

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -2031,6 +2031,7 @@ class TestClass:
         resp = await async_client.get_presence(user_id)
 
         assert isinstance(resp, PresenceGetResponse)
+        assert resp.user_id == user_id
         assert resp.presence == "unavailable"
         assert resp.last_active_ago == 420845
         assert not resp.currently_active
@@ -2047,18 +2048,17 @@ class TestClass:
                 "last_active_ago": 0,
                 "currently_active": True,
                 "status_msg": "I am here.",
-                "user_id": user_id
             }
         )
 
         resp = await async_client.get_presence(user_id)
 
         assert isinstance(resp, PresenceGetResponse)
+        assert resp.user_id == user_id
         assert resp.presence == "online"
         assert resp.last_active_ago == 0
         assert resp.currently_active
         assert resp.status_msg == "I am here."
-        assert resp.user_id == user_id
 
     async def test_set_presence(self, async_client, aioresponse):
         """Test if we can set the presence state of user


### PR DESCRIPTION
Because of https://github.com/matrix-org/matrix-doc/issues/2590 and https://github.com/matrix-org/synapse/pull/7606.
This PR takes the `user_id` of `get_presence` and passes it to the response class instead of taking it from the response data.