### PR TITLE
Fix Windows compatibility issue with ':' characters in database file paths

### DIFF
--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -109,7 +109,7 @@ class MatrixStore:
         self.database_name = self.database_name or "{}_{}.db".format(
             self.user_id,
             self.device_id
-        )
+        ).replace(":", "-")
         self.database_path = os.path.join(self.store_path, self.database_name)
         self.database = self._create_database()
         self.database.connect()
@@ -642,7 +642,7 @@ class DefaultStore(MatrixStore):
         trust_file_path = "{}_{}.trusted_devices".format(
             self.user_id,
             self.device_id
-        )
+        ).replace(":", "-")
         self.trust_db = KeyStore(
             os.path.join(self.store_path, trust_file_path)
         )
@@ -650,7 +650,7 @@ class DefaultStore(MatrixStore):
         blacklist_file_path = "{}_{}.blacklisted_devices".format(
             self.user_id,
             self.device_id
-        )
+        ).replace(":", "-")
         self.blacklist_db = KeyStore(
             os.path.join(self.store_path, blacklist_file_path)
         )
@@ -658,7 +658,7 @@ class DefaultStore(MatrixStore):
         ignore_file_path = "{}_{}.ignored_devices".format(
             self.user_id,
             self.device_id
-        )
+        ).replace(":", "-")
         self.ignore_db = KeyStore(
             os.path.join(self.store_path, ignore_file_path)
         )

--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -13,7 +13,7 @@
 
 import os
 import sqlite3
-from urllib.parse import  quote
+from urllib.parse import quote_plus as quote
 from builtins import super
 from functools import wraps
 from typing import Optional, List, Dict

--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -13,6 +13,7 @@
 
 import os
 import sqlite3
+from urllib.parse import  quote
 from builtins import super
 from functools import wraps
 from typing import Optional, List, Dict
@@ -106,10 +107,10 @@ class MatrixStore:
         self._update_version(2)
 
     def __post_init__(self):
-        self.database_name = self.database_name or "{}_{}.db".format(
+        self.database_name = self.database_name or quote("{}_{}.db".format(
             self.user_id,
             self.device_id
-        ).replace(":", "-")
+        ))
         self.database_path = os.path.join(self.store_path, self.database_name)
         self.database = self._create_database()
         self.database.connect()
@@ -639,26 +640,26 @@ class DefaultStore(MatrixStore):
     def __post_init__(self):
         super().__post_init__()
 
-        trust_file_path = "{}_{}.trusted_devices".format(
+        trust_file_path = quote("{}_{}.trusted_devices".format(
             self.user_id,
             self.device_id
-        ).replace(":", "-")
+        ))
         self.trust_db = KeyStore(
             os.path.join(self.store_path, trust_file_path)
         )
 
-        blacklist_file_path = "{}_{}.blacklisted_devices".format(
+        blacklist_file_path = quote("{}_{}.blacklisted_devices".format(
             self.user_id,
             self.device_id
-        ).replace(":", "-")
+        ))
         self.blacklist_db = KeyStore(
             os.path.join(self.store_path, blacklist_file_path)
         )
 
-        ignore_file_path = "{}_{}.ignored_devices".format(
+        ignore_file_path = quote("{}_{}.ignored_devices".format(
             self.user_id,
             self.device_id
-        ).replace(":", "-")
+        ))
         self.ignore_db = KeyStore(
             os.path.join(self.store_path, ignore_file_path)
         )


### PR DESCRIPTION
This will replace ':' with '-' characters in the default database file paths since some filesystems (namely NTFS on Windows) cannot handle them.