### PR TITLE
doc: add a project to the built-with-nio list

### DIFF
--- a/doc/built-with-nio.rst
+++ b/doc/built-with-nio.rst
@@ -9,6 +9,7 @@ Projects built with nio
 - `hemppa <https://github.com/vranki/hemppa>`_
 - `devops-bot <https://github.com/rdagnelie/devops-bot>`_
 - `podbot <https://github.com/interfect/podbot>`_
+- `delator <https://github.com/nogaems/delator>`_
 
 Are we missing a project? Submit a pull request and we'll get you added! Just edit ``doc/built-with-nio.rst``
 


### PR DESCRIPTION
`delator` is basically just yet another bot, but it supports encrypted rooms and is actually easy to extend.