### PR TITLE
added further sentence to ease installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ $ pip install matrix-nio
 Note that this installs nio without end-to-end encryption support. For e2ee
 support, python-olm is needed which requires the
 [libolm](https://gitlab.matrix.org/matrix-org/olm) C library (version 3.x).
+On Debian and Ubuntu one can use `apt-get` to install package `libolm-dev`.
+On Fedora one can use `dnf` to install package `libolm-devel`. 
+Make sure version 3 is installed.
 
 After libolm has been installed, the e2ee enabled version of nio can be
 installed using pip:


### PR DESCRIPTION
- adding this sentence can reduce installation time for many people and avoid frustrations
- I read all of https://gitlab.matrix.org/matrix-org/olm and then started to download libolm source code, compiled it, etc.I ran into an error, had to troubleshoot, etc. 
- I spend 2 hours, just to find out that I could have done it the easy way in 10 seconds with a simple dnf or apt-get. 
- It was just simply nowhere mentioned that these packages are available.
- I think adding this sentence would help a lot, and avoid other people unnecessarily doing what I did (compile the source)