### PR TITLE
made config file more readable

### DIFF
--- a/examples/restore_login.py
+++ b/examples/restore_login.py
@@ -27,9 +27,9 @@ def write_details_to_disk(resp: LoginResponse, homeserver) -> None:
         json.dump(
             {
                 "homeserver": homeserver,  # e.g. "https://matrix.example.org"
-                "access_token": resp.access_token,  # cryptogr. access token
+                "user_id": resp.user_id,  # e.g. "@user:example.org"
                 "device_id": resp.device_id,  # device ID, 10 uppercase letters
-                "user_id": resp.user_id  # e.g. "@user:example.org"
+                "access_token": resp.access_token  # cryptogr. access token
             },
             f
         )


### PR DESCRIPTION
- no real change: just changing the order of 2 fields
- putting the access_token at the end makes the config/credentials file more readable
- imagine the user doing a `more` or `nano` on the file, the user_id was "hiding" behind access_token 
- now the fields are more easy to read, and nothing hides behind the long access_token
- an not one character more in the source file :)
- also I put the user_id before device_id, seems more natural, more top-down, now the complete ordering seems to be more top-down