### PR TITLE
sas: reached assert in receive_mac_event()

### DIFF
--- a/nio/crypto/sas.py
+++ b/nio/crypto/sas.py
@@ -671,7 +671,8 @@ class Sas(olm.Sas):
         if not self._event_ok(event):
             return
 
-        if self.state != SasState.key_received:
+        if ((self.state != SasState.key_received) or 
+                (self.chosen_mac_method == "")):
             self.state = SasState.canceled
             (
                 self.cancel_code,

--- a/nio/crypto/sas.py
+++ b/nio/crypto/sas.py
@@ -634,7 +634,9 @@ class Sas(olm.Sas):
 
     def receive_key_event(self, event):
         """Receive a KeyVerificationKey event."""
-        if self.other_key_set:
+        if (self.other_key_set or
+                ((self.state != SasState.started) and
+                 (self.state != SasState.accepted))):
             self.state = SasState.canceled
             (
                 self.cancel_code,
@@ -671,8 +673,7 @@ class Sas(olm.Sas):
         if not self._event_ok(event):
             return
 
-        if ((self.state != SasState.key_received) or 
-                (self.chosen_mac_method == "")):
+        if self.state != SasState.key_received:
             self.state = SasState.canceled
             (
                 self.cancel_code,


### PR DESCRIPTION
 - Problem: reached assert in receive_mac_event()
- I wrote a client that performed emoji verification
- my client used a mix of AsyncClient and Sas methods 
   (probably in an incorrect order)
- my client logged out and logged back in between the 3 events 
   (KeyVerificationStart, KeyVerificationCancel, KeyVerificationKey)
- under these conditions (constant logout and login between 
   events) I could trigger the assertion stmt 
   (assert self.chosen_mac_method) in function receive_mac_event()
   line 697 many times (about 100)
- it seems that I somehow got into the key_received state either 
   without calling accept_verification (this is a usage error) or 
   without receiving an m.key.verification.accept event.
- It was suggested to add a check that we are in the correct 
   state (started or accepted) at the beginning of function
   receive_key_event() (line 637) 
- this seemed a better fix since we're canceling the SAS flow 
   before we can let the user see the emoji.