### PR TITLE
Fix capitalization of RoomVisibility.Private in docstrings

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -760,7 +760,7 @@ class Api:
 
             visibility (RoomVisibility): whether to have the room published in
                 the server's room directory or not.
-                Defaults to ``RoomVisibility.Private``.
+                Defaults to ``RoomVisibility.private``.
 
             alias (str, optional): The desired canonical alias local part.
                 For example, if set to "foo" and the room is created on the

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1917,7 +1917,7 @@ class AsyncClient(Client):
         Args:
             visibility (RoomVisibility): whether to have the room published in
                 the server's room directory or not.
-                Defaults to ``RoomVisibility.Private``.
+                Defaults to ``RoomVisibility.private``.
 
             alias (str, optional): The desired canonical alias local part.
                 For example, if set to "foo" and the room is created on the

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -423,7 +423,7 @@ class HttpClient(Client):
         Args:
             visibility (RoomVisibility): whether to have the room published in
                 the server's room directory or not.
-                Defaults to ``RoomVisibility.Private``.
+                Defaults to ``RoomVisibility.private``.
 
             alias (str, optional): The desired canonical alias local part.
                 For example, if set to "foo" and the room is created on the


### PR DESCRIPTION
A few places had capitalized even though the enum has lowercase keys.