### PR TITLE
Stricter user ID according to spec

### DIFF
--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -17,10 +17,12 @@
 
 from __future__ import unicode_literals
 
+import re
+
 from jsonschema import Draft4Validator, FormatChecker, validators
 
 RoomRegex = "^!.+:.+$"
-UserIdRegex = "^@.*:.+$"
+UserIdRegex = "^@[a-z0-9._=/]+:.+$"
 EventTypeRegex = r"^.+\..+"
 Base64Regex = r"[^-A-Za-z0-9+/=]|=[^=]|={3,}$"
 KeyRegex = r"(ed25519|curve25519):.+"
@@ -49,14 +51,8 @@ Validator = extend_with_default(Draft4Validator)
 @FormatChecker.cls_checks("user_id", ValueError)
 def check_user_id(value):
     # type: (str) -> bool
-    if not value.startswith("@"):
-        raise ValueError("UserIDs start with @")
-
-    if ":" not in value:
-        raise ValueError(
-            "UserIDs must have a domain component, seperated by a :"
-        )
-
+    if re.match(UserIdRegex, value) is None:
+        raise ValueError(f"UserID does not pass validation. Format: '{UserIdRegex}'")
     return True
 
 

--- a/tests/schemas_test.py
+++ b/tests/schemas_test.py
@@ -1,0 +1,28 @@
+from nio.schemas import check_user_id
+
+
+class TestClass:
+    def test_check_user_id__valid(self):
+        assert check_user_id("@foobar:example.com") is True
+
+    def test_check_user_id__invalid(self):
+        try:
+            check_user_id("foobar:example.com")
+        except ValueError:
+            pass
+        try:
+            check_user_id("@foobar@example.com")
+        except ValueError:
+            pass
+        try:
+            check_user_id("@FOOBAR:example.com")
+        except ValueError:
+            pass
+        try:
+            check_user_id("https://example.com")
+        except ValueError:
+            pass
+        try:
+            check_user_id("@foobar:")
+        except ValueError:
+            pass


### PR DESCRIPTION
Make the user ID regexp stricter according
to the Matrix specification. Add tests for the function.

See https://matrix.org/docs/spec/appendices#user-identifiers