### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist
 doc/html
 *.swp
 build
+.idea/


### PR DESCRIPTION
To exclude JetBrains IDE files like PyCharm.