### PR TITLE
renamed to credentials.json

### DIFF
--- a/examples/restore_login.py
+++ b/examples/restore_login.py
@@ -8,7 +8,7 @@ import getpass
 
 from nio import AsyncClient, LoginResponse
 
-CONFIG_FILE = "restore_login_config.json"
+CONFIG_FILE = "credentials.json"
 
 # Check out main() below to see how it's done.
 


### PR DESCRIPTION
- renamed to credentials.json
- 2 advantages
- consistency
- can be used across examples
- create here, then use later in verify_with_emoji.py for example