### PR TITLE
renamed to credentials.json

### DIFF
--- a/examples/send_image.py
+++ b/examples/send_image.py
@@ -11,7 +11,7 @@ import magic
 
 from nio import AsyncClient, LoginResponse, UploadResponse
 
-CONFIG_FILE = "restore_login_config.json"
+CONFIG_FILE = "credentials.json"
 
 # Check out main() below to see how it's done.
 


### PR DESCRIPTION
- renamed to credentials.json
- 2 advantages
- consistency
- can be used across examples
- has been created in restore_login then used here with send_image to send image
- create here, then use later in verify_with_emoji.py for example