### PR TITLE
renamed to credentials.json

### DIFF
--- a/examples/manual_encrypted_verify.py
+++ b/examples/manual_encrypted_verify.py
@@ -28,7 +28,7 @@ STORE_FOLDER = "nio_store/"
 # This file is for restoring login details after closing the program, so you
 # can preserve your device ID. If @alice logged in every time instead, @bob
 # would have to re-verify. See the restoring login example for more into.
-SESSION_DETAILS_FILE = STORE_FOLDER + "/manual_encrypted_verify.json"
+SESSION_DETAILS_FILE = STORE_FOLDER + "/credentials.json"
 
 # Only needed for this example, this is who @alice will securely
 # communicate with. We need all the device IDs of this user so we can consider

--- a/examples/manual_encrypted_verify.py
+++ b/examples/manual_encrypted_verify.py
@@ -28,7 +28,7 @@ STORE_FOLDER = "nio_store/"
 # This file is for restoring login details after closing the program, so you
 # can preserve your device ID. If @alice logged in every time instead, @bob
 # would have to re-verify. See the restoring login example for more into.
-SESSION_DETAILS_FILE = STORE_FOLDER + "/credentials.json"
+SESSION_DETAILS_FILE = "credentials.json"
 
 # Only needed for this example, this is who @alice will securely
 # communicate with. We need all the device IDs of this user so we can consider


### PR DESCRIPTION
- renamed to credentials.json
- just so that the file name is consistent across all examples
- BUT: file will NOT be reused!
- Why? Because it is inside STORE_FOLDER
- To be reused, it would have to be in LOCAL dir (.)
- Shall we move it from STORE_FOLDER to . ?
- If so, leave me a comment in review and I make the
  1 line change:
`SESSION_DETAILS_FILE = "credentials.json"
- This way a user who is going thru the examples, can 
   run `restore_login` first and then run right away `manual_encrypt `
   without retyping password.