### PR TITLE
Add support for uploading sync filters

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -925,10 +925,10 @@ class Api:
         access_token:   str,
         room_id:        str,
         start:          str,
-        end:            Optional[str]    = None,
-        direction:      MessageDirection = MessageDirection.back,
-        limit:          int              = 10,
-        message_filter: _FilterT         = None,
+        end:            Optional[str]            = None,
+        direction:      MessageDirection         = MessageDirection.back,
+        limit:          int                      = 10,
+        message_filter: Optional[Dict[Any, Any]] = None,
     ):
         # type (...) -> Tuple[str, str]
         """Get room messages.
@@ -943,8 +943,8 @@ class Api:
             end (str): The token to stop returning events at.
             direction (MessageDirection): The direction to return events from.
             limit (int): The maximum number of events to return.
-            message_filter (Union[None, str, Dict[Any, Any]]):
-                A filter ID or dict that should be used for this room messages
+            message_filter (Optional[Dict[Any, Any]]):
+                A filter dict that should be used for this room messages
                 request.
 
         """
@@ -973,8 +973,6 @@ class Api:
         if isinstance(message_filter, dict):
             filter_json = json.dumps(message_filter, separators=(",", ":"))
             query_parameters["filter"] = filter_json
-        elif isinstance(message_filter, str):
-            query_parameters["filter"] = message_filter
 
         path = "rooms/{room}/messages".format(room=room_id)
 

--- a/nio/api.py
+++ b/nio/api.py
@@ -101,6 +101,18 @@ class RoomPreset(Enum):
     public_chat = "public_chat"
 
 
+@unique
+class EventFormat(Enum):
+    """Available formats in which a filter can make the server return events.
+
+     "client" will return the events in a format suitable for clients.
+     "federation" will return the raw event as received over federation.
+     """
+
+    client = "client"
+    federation = "federation"
+
+
 class Api:
     """Matrix API class.
 
@@ -1601,3 +1613,60 @@ class Api:
         )
 
         return "GET", Api._build_path(path, query_parameters)
+
+    @staticmethod
+    def upload_filter(
+        access_token: str,
+        user_id: str,
+        event_fields: Optional[List[str]] = None,
+        event_format: EventFormat = EventFormat.client,
+        presence: Optional[Dict[str, Any]] = None,
+        account_data: Optional[Dict[str, Any]] = None,
+        room: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[str, str, str]:
+        """Upload a new filter definition to the homeserver.
+
+        Returns the HTTP method, HTTP path and data for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+
+            user_id (str):  ID of the user uploading the filter.
+
+            event_fields (Optional[List[str]]): List of event fields to
+                include. If this list is absent then all fields are included.
+                The entries may include '.' characters to indicate sub-fields.
+                A literal '.' character in a field name may be escaped
+                using a '\'.
+
+            event_format (EventFormat): The format to use for events.
+
+            presence (Dict[str, Any]): The presence updates to include.
+                The dict corresponds to the `EventFilter` type described
+                in https://matrix.org/docs/spec/client_server/latest#id240
+
+            account_data (Dict[str, Any]): The user account data that isn't
+                associated with rooms to include.
+                The dict corresponds to the `EventFilter` type described
+                in https://matrix.org/docs/spec/client_server/latest#id240
+
+            room (Dict[str, Any]): Filters to be applied to room data.
+                The dict corresponds to the `RoomFilter` type described
+                in https://matrix.org/docs/spec/client_server/latest#id240
+        """
+        path = f"user/{user_id}/filter"
+        query_parameters = {"access_token": access_token}
+        content = {
+            "event_fields": event_fields,
+            "event_format": event_format.value,
+            "presence": presence,
+            "account_data": account_data,
+            "room": room,
+        }
+        content = {k: v for k, v in content.items() if v is not None}
+
+        return (
+            "POST",
+            Api._build_path(path, query_parameters),
+            Api.to_json(content),
+        )

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -2187,7 +2187,7 @@ class AsyncClient(Client):
         end: Optional[str] = None,
         direction: MessageDirection = MessageDirection.back,
         limit: int = 10,
-        message_filter: _FilterT = None,
+        message_filter: Optional[Dict[Any, Any]] = None,
     ) -> Union[RoomMessagesResponse, RoomMessagesError]:
         """Fetch a list of message and state events for a room.
 
@@ -2213,10 +2213,8 @@ class AsyncClient(Client):
                 events from. Defaults to MessageDirection.back.
             limit (int, optional): The maximum number of events to return.
                 Defaults to 10.
-            message_filter (Union[None, str, Dict[Any, Any]]):
-                A filter ID that can be obtained from
-                ``AsyncClient.upload_filter()`` (preferred),
-                or filter dict that should be used for this room messages
+            message_filter (Optional[Dict[Any, Any]]):
+                A filter dict that should be used for this room messages
                 request.
 
         Example:

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -143,6 +143,8 @@ __all__ = [
     "ToDeviceError",
     "RoomContextResponse",
     "RoomContextError",
+    "UploadFilterError",
+    "UploadFilterResponse",
     "UpdateReceiptMarkerError",
     "UpdateReceiptMarkerResponse",
 ]
@@ -1713,3 +1715,26 @@ class SyncResponse(Response):
             to_device,
             presence_events
         )
+
+
+class UploadFilterError(ErrorResponse):
+    pass
+
+
+@dataclass
+class UploadFilterResponse(Response):
+    """Response representing a successful filter upload request.
+
+    Attributes:
+        filter_id (str): A filter ID that may be used in
+            future requests to restrict which events are returned to the
+            client.
+    """
+    filter_id: str = field()
+
+    @classmethod
+    @verify(Schemas.upload_filter, UploadFilterError)
+    def from_dict(
+        cls, parsed_dict: Dict[Any, Any],
+    ) -> Union["UploadFilterResponse", UploadFilterError]:
+        return cls(parsed_dict["filter_id"])

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1785,3 +1785,9 @@ class Schemas:
     }
 
     empty = {"type": "object", "properties": {}, "additionalProperties": False}
+
+    upload_filter = {
+        "type": "object",
+        "properties": {"filter_id": {"type": "string"}},
+        "required": ["filter_id"],
+    }

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1402,18 +1402,6 @@ class TestClass:
         resp = await async_client.room_messages(TEST_ROOM_ID, "start_token")
         assert isinstance(resp, RoomMessagesResponse)
 
-        # ID filter
-
-        aioresponse.get(
-            f"{url}&filter=test_id",
-            status=200,
-            payload=self.messages_response,
-        )
-        resp = await async_client.room_messages(
-            TEST_ROOM_ID, "start_token", message_filter="test_id",
-        )
-        assert isinstance(resp, RoomMessagesResponse)
-
         # Dict filter
 
         aioresponse.get(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -50,9 +50,10 @@ from nio import (ContentRepositoryConfigResponse,
                  SyncResponse, ThumbnailError, ThumbnailResponse,
                  Timeline, TransferMonitor, TransferCancelledError,
                  UploadResponse, UpdateDeviceResponse,
+                 UploadFilterResponse,
                  UpdateReceiptMarkerResponse,
                  RoomMessageText, RoomKeyRequest)
-from nio.api import ResizingMethod, RoomPreset, RoomVisibility
+from nio.api import EventFormat, ResizingMethod, RoomPreset, RoomVisibility
 from nio.crypto import OlmDevice, Session, decrypt_attachment
 from nio.client.async_client import connect_wrapper, on_request_chunk_sent
 
@@ -3949,3 +3950,24 @@ class TestClass:
         # "AttributeError: _low_water", but the set... method works?
         ssl_transport = conn.transport._ssl_protocol._transport
         assert ssl_transport.get_write_buffer_limits()[1] == 16 * 1024
+
+    async def test_upload_filter(self, async_client, aioresponse):
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response),
+        )
+        assert async_client.logged_in
+
+        aioresponse.post(
+            f"https://example.org/_matrix/client/r0/user/"
+            f"{async_client.user_id}/filter?access_token=abc123",
+            status=200,
+            payload={"filter_id": "abc123"},
+        )
+
+        resp = await async_client.upload_filter(
+            event_fields = ["content.body"],
+            event_format = EventFormat.federation,
+            room = {"timeline": { "limit": 1 }},
+        )
+        assert isinstance(resp, UploadFilterResponse)
+        assert resp.filter_id == "abc123"


### PR DESCRIPTION
https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-user-userid-filter

Also corrects the `room_messages()` methods to only accept filter dicts, using an ID with `/messages` is not supported by the spec and results in a server error.