### PR TITLE
Add support for push rules account data events and API

### DIFF
--- a/nio/__init__.py
+++ b/nio/__init__.py
@@ -1,7 +1,8 @@
 from .log import logger_group
 from .client import *
 from .api import (
-    MessageDirection, Api, ResizingMethod, RoomVisibility, RoomPreset
+    MessageDirection, Api, ResizingMethod, RoomVisibility, RoomPreset,
+    PushRuleKind,
 )
 from .responses import *
 from .events import *

--- a/nio/api.py
+++ b/nio/api.py
@@ -1787,3 +1787,24 @@ class Api:
             Api._build_path(path, query_parameters),
             Api.to_json(content),
         )
+
+    @staticmethod
+    def delete_pushrule(
+        access_token: str, scope: str, kind: PushRuleKind, rule_id: str,
+    ) -> Tuple[str, str]:
+        """Delete an existing push rule.
+
+        Returns the HTTP method and HTTP path for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+            scope (str): The scope of this rule, e.g. ``"global"``.
+            kind (PushRuleKind): The kind of rule.
+            rule_id (str): The identifier of the rule. Must be unique
+                within its scope and kind.
+        """
+
+        path = ["pushrules", scope, kind.value, rule_id]
+        query_parameters = {"access_token": access_token}
+
+        return ("DELETE", Api._build_path(path, query_parameters))

--- a/nio/api.py
+++ b/nio/api.py
@@ -1719,7 +1719,7 @@ class Api:
         conditions: Optional[Sequence[PushCondition]] = None,
         pattern: Optional[str] = None,
     ) -> Tuple[str, str, str]:
-        """Create or modify an existing push rule.
+        """Create or modify an existing user-created push rule.
 
         Returns the HTTP method, HTTP path and data for the request.
 
@@ -1792,7 +1792,7 @@ class Api:
     def delete_pushrule(
         access_token: str, scope: str, kind: PushRuleKind, rule_id: str,
     ) -> Tuple[str, str]:
-        """Delete an existing push rule.
+        """Delete an existing user-created push rule.
 
         Returns the HTTP method and HTTP path for the request.
 
@@ -1817,7 +1817,7 @@ class Api:
         rule_id: str,
         enable: bool,
     ) -> Tuple[str, str, str]:
-        """Enable or disable an existing push rule.
+        """Enable or disable an existing built-in or user-created push rule.
 
         Returns the HTTP method, HTTP path and data for the request.
 
@@ -1833,6 +1833,45 @@ class Api:
         path = ["pushrules", scope, kind.value, rule_id, "enabled"]
         query_parameters = {"access_token": access_token}
         content = {"enabled": enable}
+
+        return (
+            "PUT",
+            Api._build_path(path, query_parameters),
+            Api.to_json(content),
+        )
+
+    @staticmethod
+    def set_pushrule_actions(
+        access_token: str,
+        scope: str,
+        kind: PushRuleKind,
+        rule_id: str,
+        actions: Sequence[PushAction],
+    ) -> Tuple[str, str, str]:
+        """Set the actions for an existing built-in or user-created push rule.
+
+        Unlike ``set_pushrule``, this method can edit built-in server rules.
+
+        Returns the HTTP method, HTTP path and data for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+
+            scope (str): The scope of this rule, e.g. ``"global"``.
+
+            kind (PushRuleKind): The kind of rule.
+
+            rule_id (str): The identifier of the rule. Must be unique
+                within its scope and kind.
+
+            actions (Sequence[PushAction]): Actions to perform when the
+                conditions for this rule are met. The given actions replace
+                the existing ones.
+        """
+
+        path = ["pushrules", scope, kind.value, rule_id, "actions"]
+        query_parameters = {"access_token": access_token}
+        content = {"actions": [a.as_value for a in actions]}
 
         return (
             "PUT",

--- a/nio/api.py
+++ b/nio/api.py
@@ -1808,3 +1808,34 @@ class Api:
         query_parameters = {"access_token": access_token}
 
         return ("DELETE", Api._build_path(path, query_parameters))
+
+    @staticmethod
+    def enable_pushrule(
+        access_token: str,
+        scope: str,
+        kind: PushRuleKind,
+        rule_id: str,
+        enable: bool,
+    ) -> Tuple[str, str, str]:
+        """Enable or disable an existing push rule.
+
+        Returns the HTTP method, HTTP path and data for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+            scope (str): The scope of this rule, e.g. ``"global"``.
+            kind (PushRuleKind): The kind of rule.
+            rule_id (str): The identifier of the rule. Must be unique
+                within its scope and kind.
+            enable (bool): Whether to enable or disable the rule.
+        """
+
+        path = ["pushrules", scope, kind.value, rule_id, "enabled"]
+        query_parameters = {"access_token": access_token}
+        content = {"enabled": enable}
+
+        return (
+            "PUT",
+            Api._build_path(path, query_parameters),
+            Api.to_json(content),
+        )

--- a/nio/api.py
+++ b/nio/api.py
@@ -31,12 +31,14 @@ from collections import defaultdict
 from enum import Enum, unique
 from typing import (
     Any, DefaultDict, Dict, Iterable, List, Optional, Sequence, Set, Tuple,
-    Union,
+    Union, TYPE_CHECKING,
 )
 
-from .events.account_data import PushAction, PushCondition
 from .exceptions import LocalProtocolError
 from .http import Http2Request, HttpRequest, TransportRequest
+
+if TYPE_CHECKING:
+    from .events.account_data import PushAction, PushCondition
 
 if False:
     from uuid import UUID
@@ -118,7 +120,7 @@ class EventFormat(Enum):
 
 @unique
 class PushRuleKind(Enum):
-    """Enum representing the push rule kinds defined by the Matrix spec."""
+    """Push rule kinds defined by the Matrix spec, ordered by priority."""
 
     override = "override"
     content = "content"
@@ -1715,8 +1717,8 @@ class Api:
         rule_id: str,
         before: Optional[str] = None,
         after: Optional[str] = None,
-        actions: Sequence[PushAction] = (),
-        conditions: Optional[Sequence[PushCondition]] = None,
+        actions: Sequence["PushAction"] = (),
+        conditions: Optional[Sequence["PushCondition"]] = None,
         pattern: Optional[str] = None,
     ) -> Tuple[str, str, str]:
         """Create or modify an existing user-created push rule.
@@ -1846,7 +1848,7 @@ class Api:
         scope: str,
         kind: PushRuleKind,
         rule_id: str,
-        actions: Sequence[PushAction],
+        actions: Sequence["PushAction"],
     ) -> Tuple[str, str, str]:
         """Set the actions for an existing built-in or user-created push rule.
 

--- a/nio/api.py
+++ b/nio/api.py
@@ -1729,11 +1729,16 @@ class Api:
             access_token (str): The access token to be used with the request.
 
             scope (str): The scope of this rule, e.g. ``"global"``.
+                Homeservers currently only process ``global`` rules for
+                event matching, while ``device`` rules are a planned feature.
+                It is up to clients to interpret any other scope name.
 
             kind (PushRuleKind): The kind of rule.
 
             rule_id (str): The identifier of the rule. Must be unique
                 within its scope and kind.
+                For rules of ``room`` kind, this is the room ID to match for.
+                For rules of ``sender`` kind, this is the user ID to match.
 
             before (Optional[str]): Position this rule before the one matching
                 the given rule ID.

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -182,6 +182,8 @@ from ..responses import (
     RoomUnbanResponse,
     SetPushRuleResponse,
     SetPushRuleError,
+    SetPushRuleActionsResponse,
+    SetPushRuleActionsError,
     ShareGroupSessionError,
     ShareGroupSessionResponse,
     SyncError,
@@ -3061,3 +3063,39 @@ class AsyncClient(Client):
         )
 
         return await self._send(EnablePushRuleResponse, method, path, data)
+
+    @logged_in
+    async def set_pushrule_actions(
+        self,
+        scope: str,
+        kind: PushRuleKind,
+        rule_id: str,
+        actions: Sequence[PushAction],
+    ) -> Union[SetPushRuleActionsResponse, SetPushRuleActionsError]:
+        """Set the actions for an existing built-in or user-created push rule.
+
+        Unlike ``set_pushrule``, this method can edit built-in server rules.
+
+        Returns the HTTP method, HTTP path and data for the request.
+        Returns either a `SetPushRuleActionsResponse` if the request was
+        successful or a `SetPushRuleActionsError` if there was an error
+        with the request.
+
+        Args:
+            scope (str): The scope of this rule, e.g. ``"global"``.
+
+            kind (PushRuleKind): The kind of rule.
+
+            rule_id (str): The identifier of the rule. Must be unique
+                within its scope and kind.
+
+            actions (Sequence[PushAction]): Actions to perform when the
+                conditions for this rule are met. The given actions replace
+                the existing ones.
+        """
+
+        method, path, data = Api.set_pushrule_actions(
+            self.access_token, scope, kind, rule_id, actions,
+        )
+
+        return await self._send(SetPushRuleActionsResponse, method, path, data)

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -107,6 +107,8 @@ from ..responses import (
     DiscoveryInfoResponse,
     DownloadError,
     DownloadResponse,
+    EnablePushRuleError,
+    EnablePushRuleResponse,
     ErrorResponse,
     FileResponse,
     JoinResponse,
@@ -3031,3 +3033,31 @@ class AsyncClient(Client):
         )
 
         return await self._send(DeletePushRuleResponse, method, path)
+
+    @logged_in
+    async def enable_pushrule(
+        self,
+        scope: str,
+        kind: PushRuleKind,
+        rule_id: str,
+        enable: bool,
+    ) -> Union[EnablePushRuleResponse, EnablePushRuleError]:
+        """Enable or disable an existing push rule.
+
+        Returns either a `EnablePushRuleResponse` if the request was
+        successful or a `EnablePushRuleError` if there was an error
+        with the request.
+
+        Args:
+            scope (str): The scope of this rule, e.g. ``"global"``.
+            kind (PushRuleKind): The kind of rule.
+            rule_id (str): The identifier of the rule. Must be unique
+                within its scope and kind.
+            enable (bool): Whether to enable or disable this rule.
+        """
+
+        method, path, data = Api.enable_pushrule(
+            self.access_token, scope, kind, rule_id, enable,
+        )
+
+        return await self._send(EnablePushRuleResponse, method, path, data)

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -99,6 +99,8 @@ from ..responses import (
     DeleteDevicesError,
     DeleteDevicesResponse,
     DeleteDevicesAuthResponse,
+    DeletePushRuleError,
+    DeletePushRuleResponse,
     DevicesError,
     DevicesResponse,
     DiscoveryInfoError,
@@ -3006,3 +3008,26 @@ class AsyncClient(Client):
         )
 
         return await self._send(SetPushRuleResponse, method, path, data)
+
+    @logged_in
+    async def delete_pushrule(
+        self, scope: str, kind: PushRuleKind, rule_id: str,
+    ) -> Union[DeletePushRuleResponse, DeletePushRuleError]:
+        """Delete an existing push rule.
+
+        Returns either a `DeletePushRuleResponse` if the request was
+        successful or a `DeletePushRuleError` if there was an error
+        with the request.
+
+        Args:
+            scope (str): The scope of this rule, e.g. ``"global"``.
+            kind (PushRuleKind): The kind of rule.
+            rule_id (str): The identifier of the rule. Must be unique
+                within its scope and kind.
+        """
+
+        method, path = Api.delete_pushrule(
+            self.access_token, scope, kind, rule_id,
+        )
+
+        return await self._send(DeletePushRuleResponse, method, path)

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -607,6 +607,14 @@ class AsyncClient(Client):
                 if cb.filter is None or isinstance(event, cb.filter):
                     await asyncio.coroutine(cb.func)(event)
 
+    async def _handle_global_account_data_events(  # type: ignore
+        self, response: SyncResponse,
+    ) -> None:
+        for event in response.account_data_events:
+            for cb in self.global_account_data_callbacks:
+                if cb.filter is None or isinstance(event, cb.filter):
+                    await asyncio.coroutine(cb.func)(event)
+
     async def _handle_expired_verifications(self):
         expired_verifications = self.olm.clear_verifications()
 
@@ -632,6 +640,8 @@ class AsyncClient(Client):
         await self._handle_joined_rooms(response)
 
         await self._handle_presence_events(response)
+
+        await self._handle_global_account_data_events(response)
 
         if self.olm:
             await self._handle_expired_verifications()

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -2976,11 +2976,16 @@ class AsyncClient(Client):
 
         Args:
             scope (str): The scope of this rule, e.g. ``"global"``.
+                Homeservers currently only process ``global`` rules for
+                event matching, while ``device`` rules are a planned feature.
+                It is up to clients to interpret any other scope name.
 
             kind (PushRuleKind): The kind of rule.
 
             rule_id (str): The identifier of the rule. Must be unique
                 within its scope and kind.
+                For rules of ``room`` kind, this is the room ID to match for.
+                For rules of ``sender`` kind, this is the user ID to match.
 
             before (Optional[str]): Position this rule before the one matching
                 the given rule ID.
@@ -3004,6 +3009,31 @@ class AsyncClient(Client):
             pattern (Optional[str]): Glob-style pattern to match against
                 for the event's content.
                 Only applicable to ``content`` rules.
+
+        Example:
+            >>> client.set_pushrule(
+            ...     scope = "global",
+            ...     kind = PushRuleKind.room,
+            ...     rule_id = "!foo123:example.org",
+            ...     actions = [PushNotify(), PushSetTweak("sound", "default")],
+            ... )
+            ...
+            ... client.set_pushrule(
+            ...     scope = "global",
+            ...     kind = PushRuleKind.override,
+            ...     rule_id = "silence_large_rooms",
+            ...     actions = [],
+            ...     conditions = [PushRoomMemberCount(10, ">")],
+            ... )
+            ...
+            ... client.set_pushrule(
+            ...     scope = "global",
+            ...     kind = PushRuleKind.content,
+            ...     rule_id = "highlight_messages_containing_nio_word",
+            ...     actions = [PushNotify(), PushSetTweak("highlight", True)],
+            ...     pattern = "nio"
+            ... )
+
         """
 
         method, path, data = Api.set_pushrule(
@@ -3025,7 +3055,12 @@ class AsyncClient(Client):
 
         Args:
             scope (str): The scope of this rule, e.g. ``"global"``.
+                Homeservers currently only process ``global`` rules for
+                event matching, while ``device`` rules are a planned feature.
+                It is up to clients to interpret any other scope name.
+
             kind (PushRuleKind): The kind of rule.
+
             rule_id (str): The identifier of the rule. Must be unique
                 within its scope and kind.
         """
@@ -3052,9 +3087,15 @@ class AsyncClient(Client):
 
         Args:
             scope (str): The scope of this rule, e.g. ``"global"``.
+                Homeservers currently only process ``global`` rules for
+                event matching, while ``device`` rules are a planned feature.
+                It is up to clients to interpret any other scope name.
+
             kind (PushRuleKind): The kind of rule.
+
             rule_id (str): The identifier of the rule. Must be unique
                 within its scope and kind.
+
             enable (bool): Whether to enable or disable this rule.
         """
 
@@ -3083,6 +3124,9 @@ class AsyncClient(Client):
 
         Args:
             scope (str): The scope of this rule, e.g. ``"global"``.
+                Homeservers currently only process ``global`` rules for
+                event matching, while ``device`` rules are a planned feature.
+                It is up to clients to interpret any other scope name.
 
             kind (PushRuleKind): The kind of rule.
 

--- a/nio/events/account_data.py
+++ b/nio/events/account_data.py
@@ -25,12 +25,14 @@ across installations on a particular device.
 
 from __future__ import unicode_literals
 
-from typing import Any, Dict, Optional
+import re
+
+from typing import Any, Dict, List, Optional, Union
 
 from dataclasses import dataclass, field
 
 from ..schemas import Schemas
-from .misc import verify
+from .misc import verify, verify_or_none
 
 
 @dataclass
@@ -48,6 +50,8 @@ class AccountDataEvent:
             return FullyReadEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.tag":
             return TagEvent.from_dict(event_dict)
+        elif event_dict["type"] == "m.push_rules":
+            return PushRulesEvent.from_dict(event_dict)
 
         return UnknownAccountDataEvent.from_dict(event_dict)
 
@@ -105,6 +109,305 @@ class TagEvent(AccountDataEvent):
         return cls(
             content["tags"]
         )
+
+
+@dataclass
+class PushCondition:
+    """A condition for a push rule to match an event."""
+
+    @classmethod
+    def from_dict(cls, condition: dict) -> "PushCondition":
+        cnd = condition
+
+        if cnd["kind"] == "event_match" and "key" in cnd and "pattern" in cnd:
+            return PushEventMatch(cnd["key"], cnd["pattern"])
+
+        if cnd["kind"] == "contains_display_name":
+            return PushContainsDisplayName()
+
+        if cnd["kind"] == "room_member_count":
+            return PushRoomMemberCount.from_dict(cnd)
+
+        if cnd["kind"] == "sender_notification_permission" and "key" in cnd:
+            return PushSenderNotificationPermission(cnd["key"])
+
+        return PushUnknownCondition(cnd)
+
+
+@dataclass
+class PushEventMatch(PushCondition):
+    """Require a field of the event to match a glob-style pattern.
+
+    Attributes:
+        key (str): The dot-separated field of the event to match,
+            e.g. ``"type"`` or ``"content.body"``.
+
+        pattern (str): Glob-style pattern to match the field's value against.
+            Patterns with no special glob characters should be treated as
+            starting and ending with an asterisk.
+    """
+
+    key: str = field()
+    pattern: str = field()
+
+
+@dataclass
+class PushContainsDisplayName(PushCondition):
+    """Require a message's ``content.body`` to contain our display name.
+
+    This rule can only match unencrypted messages.
+    """
+
+
+@dataclass
+class PushRoomMemberCount(PushCondition):
+    """Require a certain member count for the room the event is posted in.
+
+    Attributes:
+        count (int): A number of members
+        operator (str): Whether the room's member count should be
+            equal (``"=="``) to ``count``, inferior (``"<"``),
+            superior (``">"``), inferior or equal (``"<="``),
+            or superior or equal (``">="``).
+    """
+
+    count: int = field()
+    operator: str = "=="
+
+    @classmethod
+    def from_dict(cls, condition: dict) -> "PushRoomMemberCount":
+        op, num = re.findall(r"(==|<|>|<=|>=)?([0-9.-]+)", condition["is"])[0]
+        return cls(int(num), op or "==")
+
+
+@dataclass
+class PushSenderNotificationPermission(PushCondition):
+    """Require the event's sender to have a high enough power level.
+
+    Attributes:
+        key (str): Which key from the ``notifications`` dict in
+        power levels event
+        (https://matrix.org/docs/spec/client_server/latest#m-room-power-levels)
+        should be refered to as the required level for the event's sender,
+        e.g. ``room``.
+    """
+
+    key: str = field()
+
+
+@dataclass
+class PushUnknownCondition(PushCondition):
+    """An unknown kind of push rule condition.
+
+    Attributes:
+        condition (dict): The condition as a dict from the source event.
+    """
+    condition: dict = field()
+
+
+@dataclass
+class PushAction:
+    """An action to apply for a push rule when matching."""
+
+    @classmethod
+    def from_dict(cls, action: Union[str, dict]) -> "PushAction":
+        # isinstance() to make mypy happy
+
+        if isinstance(action, str) and action == "notify":
+            return PushNotify()
+
+        if isinstance(action, str) and action == "dont_notify":
+            return PushDontNotify()
+
+        if isinstance(action, str) and action == "coalesce":
+            return PushCoalesce()
+
+        if isinstance(action, dict) and "set_tweak" in action:
+            value = action.get("value")
+
+            if action["set_tweak"] == "sound" and value is None:
+                value = "default"
+
+            if action["set_tweak"] == "highlight" and value is None:
+                value = True
+
+            return PushSetTweak(action["set_tweak"], value)
+
+        return PushUnknownAction(action)
+
+
+@dataclass
+class PushNotify(PushAction):
+    """Cause the matching event to generate a notification."""
+
+
+@dataclass
+class PushDontNotify(PushAction):
+    """Prevents the matching event from generating a notification."""
+
+
+@dataclass
+class PushCoalesce(PushAction):
+    """Causes multiple matching events to be joined into a single notification.
+
+    The behavior is homeserver-dependent. Homeservers not supporting this
+    action should treat it as a ``PushNotify`` action.
+    """
+
+
+@dataclass
+class PushSetTweak(PushAction):
+    """Set a particular tweak for the notification.
+
+    These tweaks are defined by the Matrix specification:
+
+    - ``sound``: The sound to be played when the notification arrives,
+      e.g. a file path.
+      A ``value`` of ``"default"`` means to play the client's default sound.
+      A device may choose to alert the user by some other means if appropriate,
+      e.g. vibration.
+
+    - ``highlight``: Whether this message should be highlighted in the UI.
+      This typically takes the form of presenting the message with a different
+      color or style. The UI might also be adjusted to draw particular
+      attention to the room in which the event occurred.
+
+    Attributes:
+        tweak (str): The name of the tweak to set
+        valeu (Any): The tweak's value.
+    """
+
+    tweak: str = field()
+    value: Any = None
+
+
+@dataclass
+class PushUnknownAction(PushAction):
+    """An unknown kind of push rule action.
+
+    Attributes:
+        action (Union[str, dict]): The action as a string or dict from the
+            source event.
+    """
+    action: Union[str, dict] = field()
+
+
+@dataclass
+class PushRule:
+    """Rule stating how to notify the user for events matching some conditions.
+
+    Attributes:
+        id (str): A unique (within its ruleset) string identifying this rule.
+            The ``id`` for default rules set by the server starts with a ``.``.
+
+        default (bool): Whether this is a default rule set by the server,
+            or one that the user created explicitely.
+
+        enabled (bool): Whether this rule is currently enabled, or
+            disabled and to be ignored.
+
+        pattern (str): Only applies to ``content`` rules.
+            The glob-style pattern to match message text against.
+
+        conditions (List[PushCondition]):
+            Only applies to ``override`` and ``underride`` rules.
+            The conditions that must be true for an event in order for
+            this rule to be applied to it.
+            A rule with no condition always matches.
+
+        actions (List[PushAction]):
+            The actions to perform when this rule matches.
+    """
+
+    id: str = field()
+    default: bool = field()
+    enabled: bool = True
+    pattern: str = ""
+    conditions: List[PushCondition] = field(default_factory=list)
+    actions: List[PushAction] = field(default_factory=list)
+
+    @classmethod
+    @verify_or_none(Schemas.push_rule)
+    def from_dict(cls, rule: Dict[str, Any]) -> "PushRule":
+        return cls(
+            rule["rule_id"],
+            rule["default"],
+            rule["enabled"],
+            rule.get("pattern", ""),
+            [PushCondition.from_dict(c) for c in rule.get("conditions", [])],
+            [PushAction.from_dict(a) for a in rule.get("actions", [])],
+        )
+
+
+@dataclass
+class PushRuleset:
+    """A set of push rules scoped according to some criteria.
+
+    Attributes:
+        override (List[PushRule]): Highest priority rules
+
+        content (List[PushRule]): Rules that configure behaviors for messages
+            with text matching certain patterns.
+
+        room (List[PushRule]): Rules that configure behaviors for all messages
+            in a certain room. Their ``id`` is the room's ID.
+
+        sender (List[PushRule]): Rules that configure behaviors for all
+            messages sent by a specific user. Their ``id`` is the user's ID.
+
+        underride (List[PushRule]): Identical the ``override`` rules, but have
+            a lower priority than ``content``, ``room`` and ``sender`` rules.
+    """
+
+    override: List[PushRule] = field(default_factory=list)
+    content: List[PushRule] = field(default_factory=list)
+    room: List[PushRule] = field(default_factory=list)
+    sender: List[PushRule] = field(default_factory=list)
+    underride: List[PushRule] = field(default_factory=list)
+
+    @classmethod
+    @verify_or_none(Schemas.push_ruleset)
+    def from_dict(cls, ruleset: Dict[str, Any]) -> "PushRuleset":
+        def make(key: str) -> List[PushRule]:
+            rules = [PushRule.from_dict(r) for r in ruleset.get(key, [])]
+            return [r for r in rules if r]
+
+        return cls(
+            make("override"), make("content"), make("room"), make("sender"),
+            make("underride"),
+        )
+
+    def __bool__(self) -> bool:
+        return bool(
+            self.override or self.content or self.room or self.sender or
+            self.underride,
+        )
+
+
+@dataclass
+class PushRulesEvent(AccountDataEvent):
+    """Event representing the account's configured push rules.
+
+    Attributes:
+        global_rules (PushRuleset): Rulesets applying to all devices
+        device_rules (PushRuleset): Rulesets applying to current device only
+    """
+
+    global_rules: PushRuleset = field(default_factory=PushRuleset)
+    device_rules: PushRuleset = field(default_factory=PushRuleset)
+
+    @classmethod
+    @verify(Schemas.push_rules)
+    def from_dict(cls, event: Dict[str, Any]) -> "PushRulesEvent":
+        content = event["content"]
+
+        return cls(
+            PushRuleset.from_dict(content.get("global", {})) or PushRuleset(),
+            PushRuleset.from_dict(content.get("device", {})) or PushRuleset(),
+        )
+
+    def __bool__(self) -> bool:
+        return bool(self.global_rules or self.device_rules)
 
 
 @dataclass

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -1132,7 +1132,9 @@ class DefaultLevels:
             can be overridden by the events power level mapping.
         users_default (int): The default power level for every user in the
             room. This can be overridden by the users power level mapping.
-
+        notifications (Dict[str, int]): The level required to send different
+            kinds of notifications. Used for ``sender_notification_permission``
+            conditions in push rules.
     """
 
     ban: int = 50
@@ -1142,7 +1144,7 @@ class DefaultLevels:
     state_default: int = 0
     events_default: int = 0
     users_default: int = 0
-    # TODO: notifications
+    notifications: Dict[str, int] = field(default_factory=lambda: {"room": 50})
 
     @classmethod
     def from_dict(cls, parsed_dict):
@@ -1163,7 +1165,8 @@ class DefaultLevels:
             content["redact"],
             content["state_default"],
             content["events_default"],
-            content["users_default"]
+            content["users_default"],
+            content["notifications"],
         )
 
 
@@ -1207,6 +1210,17 @@ class PowerLevels:
                 required level for, e.g. `m.room.message`.
         """
         return self.events.get(event_type, self.defaults.events_default)
+
+    def get_notification_required_level(self, notification_type: str) -> int:
+        """Get required power level to send a certain type of notification.
+
+        Returns an integer representing the required power level.
+
+        Args:
+            notification_type (str): The type of notification to get the
+                required level for, e.g. ``"room"``.
+        """
+        return self.defaults.notifications.get(notification_type, 50)
 
     def get_user_level(self, user_id):
         # type: (str) -> int
@@ -1282,11 +1296,16 @@ class PowerLevels:
 
         return can_ban_lower and level > self.get_user_level(target_user_id)
 
-    def can_user_redact(self, user_id):
-        # type: (str) -> bool
+    def can_user_redact(self, user_id: str):
         """Return whether a user has enough power to react other user's events.
         """
         return self.get_user_level(user_id) >= self.defaults.redact
+
+    def can_user_notify(self, user_id: str, notification_type: str):
+        """Return whether user has enough power to send a type of notification.
+        """
+        required = self.get_notification_required_level(notification_type)
+        return self.get_user_level(user_id) >= required
 
     def update(self, new_levels):
         """Update the power levels object with new levels.

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -73,6 +73,33 @@ class Event:
         self.sender = self.source["sender"]
         self.server_timestamp = self.source["origin_server_ts"]
 
+    def flattened(
+        self,
+        _prefix: str = "",
+        _source: Optional[Dict[str, Any]] = None,
+        _flat: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return a flattened version of the ``source`` dict with dotted keys.
+
+        Example:
+            >>> event.source
+            {"content": {"body": "foo"}, "m.test": {"key": "bar"}}
+            >>> event.source.flattened()
+            {"content.body": "foo", "m.test.key": "bar"}
+
+        """
+
+        source = self.source if _source is None else _source
+        flat = {} if _flat is None else _flat
+
+        for key, value in source.items():
+            if isinstance(value, dict):
+                self.flattened(f"{_prefix}{key}.", value, flat)
+            else:
+                flat[f"{_prefix}{key}"] = value
+
+        return flat
+
     @classmethod
     def from_dict(cls, parsed_dict):
         # type: (Dict[Any, Any]) -> Union[Event, BadEventType]

--- a/nio/http.py
+++ b/nio/http.py
@@ -406,6 +406,7 @@ class Http2Connection(Connection):
             client_side=True, validate_inbound_headers=False
         )
         self._connection = h2.connection.H2Connection(config=config)
+        self._connection.max_inbound_frame_size = 64 * 1024
         self._responses = OrderedDict()  \
             # type: OrderedDict[int, Http2Response]
         self._data_to_send = OrderedDict() \

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -56,6 +56,8 @@ __all__ = [
     "DiscoveryInfoResponse",
     "DownloadResponse",
     "DownloadError",
+    "EnablePushRuleResponse",
+    "EnablePushRuleError",
     "ErrorResponse",
     "InviteInfo",
     "JoinResponse",
@@ -1826,4 +1828,15 @@ class DeletePushRuleResponse(EmptyResponse):
 
 
 class DeletePushRuleError(ErrorResponse):
+    pass
+
+
+@dataclass
+class EnablePushRuleResponse(EmptyResponse):
+    @staticmethod
+    def create_error(parsed_dict: Dict[str, Any]):
+        return EnablePushRuleError.from_dict(parsed_dict)
+
+
+class EnablePushRuleError(ErrorResponse):
     pass

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -110,6 +110,8 @@ __all__ = [
     "RoomUnbanResponse",
     "RoomUnbanError",
     "Rooms",
+    "SetPushRuleError",
+    "SetPushRuleResponse",
     "ShareGroupSessionResponse",
     "ShareGroupSessionError",
     "SyncResponse",
@@ -1801,3 +1803,14 @@ class WhoamiResponse(Response):
         cls, parsed_dict: Dict[Any, Any],
     ) -> Union["WhoamiResponse", WhoamiError]:
         return cls(parsed_dict["user_id"])
+
+
+@dataclass
+class SetPushRuleResponse(EmptyResponse):
+    @staticmethod
+    def create_error(parsed_dict: Dict[str, Any]):
+        return SetPushRuleError.from_dict(parsed_dict)
+
+
+class SetPushRuleError(ErrorResponse):
+    pass

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -45,6 +45,8 @@ __all__ = [
     "DeleteDevicesAuthResponse",
     "DeleteDevicesResponse",
     "DeleteDevicesError",
+    "DeletePushRuleError",
+    "DeletePushRuleResponse",
     "Device",
     "DeviceList",
     "DevicesResponse",
@@ -1813,4 +1815,15 @@ class SetPushRuleResponse(EmptyResponse):
 
 
 class SetPushRuleError(ErrorResponse):
+    pass
+
+
+@dataclass
+class DeletePushRuleResponse(EmptyResponse):
+    @staticmethod
+    def create_error(parsed_dict: Dict[str, Any]):
+        return DeletePushRuleError.from_dict(parsed_dict)
+
+
+class DeletePushRuleError(ErrorResponse):
     pass

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -116,6 +116,8 @@ __all__ = [
     "Rooms",
     "SetPushRuleError",
     "SetPushRuleResponse",
+    "SetPushRuleActionsError",
+    "SetPushRuleActionsResponse",
     "ShareGroupSessionResponse",
     "ShareGroupSessionError",
     "SyncResponse",
@@ -1839,4 +1841,15 @@ class EnablePushRuleResponse(EmptyResponse):
 
 
 class EnablePushRuleError(ErrorResponse):
+    pass
+
+
+@dataclass
+class SetPushRuleActionsResponse(EmptyResponse):
+    @staticmethod
+    def create_error(parsed_dict: Dict[str, Any]):
+        return SetPushRuleActionsError.from_dict(parsed_dict)
+
+
+class SetPushRuleActionsError(ErrorResponse):
     pass

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -436,6 +436,20 @@ class MatrixRoom:
         )
 
     @property
+    def joined_count(self) -> int:
+        try:
+            return self._summary_details()[1]
+        except ValueError:
+            return len(tuple(u for u in self.users.values() if not u.invited))
+
+    @property
+    def invited_count(self) -> int:
+        try:
+            return self._summary_details()[2]
+        except ValueError:
+            return len(tuple(u for u in self.users.values() if u.invited))
+
+    @property
     def member_count(self) -> int:
         try:
             _, joined, invited = self._summary_details()

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1554,6 +1554,67 @@ class Schemas:
         ],
     }
 
+    push_rules = {
+        "type": "object",
+        "properties": {
+            "type": {
+                "type": "string",
+                "const": "m.push_rules",
+            },
+            "content": {
+                "type": "object",
+                "properties": {
+                    "global": {"type": "object"},
+                    "device": {"type": "object"},
+                },
+                "required": ["global"],
+            },
+        },
+        "required": ["type", "content"],
+    }
+
+    push_ruleset = {
+        "type": "object",
+        "properties": {
+            "override": {"type": "array", "items": {"type": "object"}},
+            "content": {"type": "array", "items": {"type": "object"}},
+            "room": {"type": "array", "items": {"type": "object"}},
+            "sender": {"type": "array", "items": {"type": "object"}},
+            "underride": {"type": "array", "items": {"type": "object"}},
+        },
+    }
+
+    push_rule = {
+        "type": "object",
+        "properties": {
+            "rule_id": {"type": "string"},
+            "default": {"type": "boolean"},
+            "enabled": {"type": "boolean"},
+            "pattern": {"type": "string"},
+            "conditions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "kind": {"type": "string"},
+                        "key": {"type": "string"},
+                        "pattern": {"type": "string"},
+                        "is": {
+                            "type": "string",
+                            "pattern": r"(==|<=|>=|<|>)?[0-9.-]+",
+                        },
+                    },
+                    "required": ["kind"],
+                },
+            },
+            "actions": {
+                "type": "array",
+                "items": {"type": ["string", "object"]},
+            },
+        },
+        "required": ["rule_id", "default", "enabled", "actions"],
+    }
+
     upload = {
         "type": "object",
         "properties": {"content_uri": {"type": "string"}},

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -995,6 +995,14 @@ class Schemas:
                         },
                         "additionalProperties": False,
                     },
+                    "notifications": {
+                        "type": "object",
+                        "default": {},
+                        "properties": {
+                            "room": {"type": "integer", "default": 50},
+                        },
+                        "additionalProperties": {"type": "integer"},
+                    },
                 },
             },
         },

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -20,6 +20,7 @@ from nio import (ContentRepositoryConfigResponse,
                  DeviceList, DeviceOneTimeKeyCount, DownloadError,
                  DevicesResponse, DeleteDevicesAuthResponse,
                  DeleteDevicesResponse,
+                 DeletePushRuleResponse,
                  DiscoveryInfoError, DiscoveryInfoResponse,
                  DownloadResponse, ErrorResponse,
                  FullyReadEvent,
@@ -4321,3 +4322,21 @@ class TestClass:
 
         resp = await async_client.set_pushrule(*content, pattern="foo*bar")
         assert isinstance(resp, SetPushRuleResponse)
+
+    async def test_delete_pushrule(self, async_client, aioresponse):
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response),
+        )
+        assert async_client.logged_in
+
+        aioresponse.delete(
+            "https://example.org/_matrix/client/r0/pushrules/"
+            "global/override/foo?access_token=abc123",
+            status=200,
+            payload={},
+        )
+
+        resp = await async_client.delete_pushrule(
+            "global", PushRuleKind.override, "foo",
+        )
+        assert isinstance(resp, DeletePushRuleResponse)

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -840,6 +840,7 @@ class TestClass:
 
         assert rules.global_rules.override == [
             PushRule(
+                kind = PushRuleKind.override,
                 id = ".m.rule.suppress_notices",
                 default = True,
                 enabled = False,
@@ -850,6 +851,7 @@ class TestClass:
 
         assert rules.global_rules.content == [
             PushRule(
+                kind = PushRuleKind.content,
                 id = ".m.rule.contains_user_name",
                 default = True,
                 pattern = "alice",
@@ -867,6 +869,7 @@ class TestClass:
 
         assert rules.global_rules.underride == [
             PushRule(
+                kind = PushRuleKind.underride,
                 id = ".m.rule.special_call",
                 default = True,
                 conditions = [
@@ -880,6 +883,7 @@ class TestClass:
                 ],
             ),
             PushRule(
+                kind = PushRuleKind.underride,
                 id = ".m.rule.room_less_than_10_room_perm",
                 default = True,
                 conditions = [
@@ -890,6 +894,7 @@ class TestClass:
                 actions = [PushNotify()],
             ),
             PushRule(
+                kind = PushRuleKind.underride,
                 id = ".m.rule.room_one_to_one",
                 default = True,
                 conditions = [

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -66,6 +66,7 @@ from nio import (ContentRepositoryConfigResponse,
                  RoomSendResponse, RoomSummary,
                  RoomUnbanResponse,
                  SetPushRuleResponse,
+                 SetPushRuleActionsResponse,
                  ShareGroupSessionResponse,
                  SyncResponse, ThumbnailError, ThumbnailResponse,
                  Timeline, TransferMonitor, TransferCancelledError,
@@ -4360,3 +4361,23 @@ class TestClass:
             "global", PushRuleKind.override, "foo", enable=True,
         )
         assert isinstance(resp, EnablePushRuleResponse)
+
+    async def test_set_pushrule_actions(self, async_client, aioresponse):
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response),
+        )
+        assert async_client.logged_in
+
+        aioresponse.put(
+            "https://example.org/_matrix/client/r0/pushrules/"
+            "global/override/foo/actions?access_token=abc123",
+            body={"actions": [{"set_tweak": "highlight", "value": True}]},
+            status=200,
+            payload={},
+        )
+
+        tweak = PushSetTweak("highlight", True)
+        resp = await async_client.set_pushrule_actions(
+            "global", PushRuleKind.override, "foo", [tweak],
+        )
+        assert isinstance(resp, SetPushRuleActionsResponse)

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -24,6 +24,7 @@ from nio import (ContentRepositoryConfigResponse,
                  DiscoveryInfoError, DiscoveryInfoResponse,
                  DownloadResponse, ErrorResponse,
                  FullyReadEvent,
+                 EnablePushRuleResponse,
                  GroupEncryptionError,
                  JoinResponse, JoinedRoomsResponse,
                  JoinedMembersResponse, KeysClaimResponse, KeysQueryResponse,
@@ -4340,3 +4341,22 @@ class TestClass:
             "global", PushRuleKind.override, "foo",
         )
         assert isinstance(resp, DeletePushRuleResponse)
+
+    async def test_enable_pushrule(self, async_client, aioresponse):
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response),
+        )
+        assert async_client.logged_in
+
+        aioresponse.put(
+            "https://example.org/_matrix/client/r0/pushrules/"
+            "global/override/foo/enabled?access_token=abc123",
+            body={"enabled": True},
+            status=200,
+            payload={},
+        )
+
+        resp = await async_client.enable_pushrule(
+            "global", PushRuleKind.override, "foo", enable=True,
+        )
+        assert isinstance(resp, EnablePushRuleResponse)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -615,6 +615,8 @@ class TestClass:
         assert room.encrypted
         assert room.summary
         assert len(room.users) == 2
+        assert room.invited_count == 1
+        assert room.joined_count == 2
         assert room.member_count == 3
         assert room.summary.invited_member_count == 1
         assert room.summary.joined_member_count == 2

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -15,6 +15,7 @@ from nio import (Client, DeviceList, DeviceOneTimeKeyCount, DownloadResponse,
                  LogoutResponse, MegolmEvent, ProfileGetAvatarResponse,
                  ProfileGetDisplayNameResponse, ProfileGetResponse,
                  ProfileSetAvatarResponse, ProfileSetDisplayNameResponse,
+                 PushRulesEvent,
                  RoomCreateResponse,
                  RoomEncryptionEvent, RoomForgetResponse, RoomInfo,
                  RoomKeyRequestResponse, RoomMember, RoomMemberEvent, Rooms,
@@ -336,7 +337,10 @@ class TestClass:
             ],
             presence_events = [
                 PresenceEvent(ALICE_ID, "online", 1337, True, "I am here.")
-            ]
+            ],
+            account_data_events = [
+                PushRulesEvent(),
+            ],
         )
 
     @property
@@ -1172,6 +1176,20 @@ class TestClass:
         client.add_room_account_data_callback(cb, FullyReadEvent)
 
         with pytest.raises(CallbackException):
+            client.receive_response(self.sync_response)
+
+    def test_global_account_data_cb(self, client):
+        client.receive_response(self.login_response)
+
+        class CallbackCalled(Exception):
+            pass
+
+        def cb(_event):
+            raise CallbackCalled()
+
+        client.add_global_account_data_callback(cb, PushRulesEvent)
+
+        with pytest.raises(CallbackCalled):
             client.receive_response(self.sync_response)
 
     def test_handle_account_data(self, client):

--- a/tests/data/events/power_levels.json
+++ b/tests/data/events/power_levels.json
@@ -20,7 +20,8 @@
             "@carol:localhost": 25,
             "@bob:localhost": 0
         },
-        "users_default": 0
+        "users_default": 0,
+        "notifications": {"room": 60}
     },
     "event_id": "$15139375512JaHAW:localhost",
     "origin_server_ts": 1513937551359,

--- a/tests/data/events/push_rules.json
+++ b/tests/data/events/push_rules.json
@@ -1,0 +1,29 @@
+{
+    "type": "m.push_rules",
+    "content": {
+        "global": {
+            "override": [
+                {
+                    "actions": [
+                        "notify",
+                        "dont_notify",
+                        "coalesce",
+                        {"set_tweak": "sound", "value": "default"},
+                        {"unknown": "abc"}
+                    ],
+                    "conditions": [
+                        {"kind": "event_match", "key": "foo", "pattern": "bar"},
+                        {"kind": "contains_display_name"},
+                        {"kind": "room_member_count", "is": "10"},
+                        {"kind": "room_member_count", "is": "<10"},
+                        {"kind": "sender_notification_permission", "key": "foo"},
+                        {"kind": "unknown", "foo": "bar"}
+                    ],
+                    "default": true,
+                    "enabled": true,
+                    "rule_id": "actions_conditions_test"
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/events/to_flatten.json
+++ b/tests/data/events/to_flatten.json
@@ -1,0 +1,12 @@
+{
+    "content": {
+        "body": "foo",
+        "m.dotted": {
+            "key": "bar"
+        }
+    },
+    "event_id": "!test:example.org",
+    "origin_server_ts": 0,
+    "sender": "@alice:example.org",
+    "type": "m.flatten_test"
+}

--- a/tests/data/sync.json
+++ b/tests/data/sync.json
@@ -233,9 +233,11 @@
         },
         "leave": {}
     },
+
     "to_device": {
         "events": []
     },
+
     "presence": {
         "events": [
             {
@@ -256,6 +258,134 @@
                     "last_active_ago": 1337,
                     "currently_active": false,
                     "status_msg": "I am gone."
+                }
+            }
+        ]
+    },
+
+    "account_data": {
+        "events": [
+            {
+                "type": "m.push_rules",
+                "content": {
+                    "global": {
+                        "override": [
+                            {
+                                "actions": [
+                                    "dont_notify"
+                                ],
+                                "conditions": [
+                                    {
+                                        "key": "content.msgtype",
+                                        "kind": "event_match",
+                                        "pattern": "m.notice"
+                                    }
+                                ],
+                                "default": true,
+                                "enabled": false,
+                                "rule_id": ".m.rule.suppress_notices"
+                            }
+                        ],
+                        "content": [
+                            {
+                                "actions": [
+                                    "notify",
+                                    "do_special_thing",
+                                    {
+                                        "set_tweak": "sound",
+                                        "value": "default"
+                                    },
+                                    {
+                                        "set_tweak": "highlight"
+                                    }
+                                ],
+                                "default": true,
+                                "enabled": true,
+                                "pattern": "alice",
+                                "rule_id": ".m.rule.contains_user_name"
+                            }
+                        ],
+                        "room": [],
+                        "sender": [],
+                        "underride": [
+                            {
+                                "actions": [
+                                    "coalesce",
+                                    {
+                                        "set_tweak": "sound",
+                                        "value": "ring"
+                                    },
+                                    {
+                                        "set_tweak": "highlight",
+                                        "value": false
+                                    }
+                                ],
+                                "conditions": [
+                                    {
+                                        "kind": "special_kind"
+                                    },
+                                    {
+                                        "key": "type",
+                                        "kind": "event_match",
+                                        "pattern": "m.call.invite"
+                                    }
+                                ],
+                                "default": true,
+                                "enabled": true,
+                                "rule_id": ".m.rule.special_call"
+                            },
+                            {
+                                "actions": [
+                                    "notify"
+                                ],
+                                "conditions": [
+                                    {
+                                        "key": "room",
+                                        "kind": "sender_notification_permission"
+                                    },
+                                    {
+                                        "is": "<10",
+                                        "kind": "room_member_count"
+                                    },
+                                    {
+                                        "key": "type",
+                                        "kind": "event_match",
+                                        "pattern": "m.room.message"
+                                    }
+                                ],
+                                "default": true,
+                                "enabled": true,
+                                "rule_id": ".m.rule.room_less_than_10_room_perm"
+                            },
+                            {
+                                "actions": [
+                                    "notify",
+                                    {
+                                        "set_tweak": "sound",
+                                        "value": "default"
+                                    },
+                                    {
+                                        "set_tweak": "highlight",
+                                        "value": false
+                                    }
+                                ],
+                                "conditions": [
+                                    {
+                                        "is": "2",
+                                        "kind": "room_member_count"
+                                    },
+                                    {
+                                        "key": "type",
+                                        "kind": "event_match",
+                                        "pattern": "m.room.message"
+                                    }
+                                ],
+                                "default": true,
+                                "enabled": true,
+                                "rule_id": ".m.rule.room_one_to_one"
+                            }
+                        ]
+                    }
                 }
             }
         ]

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -57,6 +57,7 @@ from nio.events import (
     DummyEvent,
     RoomKeyRequest,
     RoomKeyRequestCancellation,
+    PushRulesEvent,
 )
 
 
@@ -485,3 +486,20 @@ class TestClass:
         assert event.thumbnail_key
         assert event.thumbnail_hashes
         assert event.thumbnail_iv
+
+    def test_pushrules_parsing(self):
+        parsed_dict = TestClass._load_response(
+            "tests/data/events/push_rules.json",
+        )
+        parsed_rule = parsed_dict["content"]["global"]["override"][0]
+
+        event = PushRulesEvent.from_dict(parsed_dict)
+        assert isinstance(event, PushRulesEvent)
+        assert bool(event) is True
+        rule = event.global_rules.override[0]
+
+        for i, action in enumerate(rule.actions):
+            assert action.as_value == parsed_rule["actions"][i]
+
+        for i, condition in enumerate(rule.conditions):
+            assert condition.as_value == parsed_rule["conditions"][i]

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -492,6 +492,21 @@ class TestClass:
         assert event.thumbnail_hashes
         assert event.thumbnail_iv
 
+    def test_event_flattening(self):
+        parsed_dict = TestClass._load_response(
+            "tests/data/events/to_flatten.json",
+        )
+
+        event = Event.from_dict(parsed_dict)
+        assert event.flattened() == {
+            "content.body": "foo",
+            "content.m.dotted.key": "bar",
+            "event_id": "!test:example.org",
+            "origin_server_ts": 0,
+            "sender": "@alice:example.org",
+            "type": "m.flatten_test",
+        }
+
     def test_pushrules_parsing(self):
         parsed_dict = TestClass._load_response(
             "tests/data/events/push_rules.json",

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -162,6 +162,8 @@ class TestClass:
         assert levels.get_state_event_required_level("m.room.undefined") == 50
         assert levels.get_message_event_required_level("m.room.message") == 25
         assert levels.get_message_event_required_level("m.room.undefined") == 0
+        assert levels.get_notification_required_level("room") == 60
+        assert levels.get_notification_required_level("non_existant") == 50
 
         assert levels.get_user_level(admin) == 100
         assert levels.get_user_level(user) == 0
@@ -192,6 +194,9 @@ class TestClass:
 
         assert levels.can_user_redact(admin) is True
         assert levels.can_user_redact(user) is False
+
+        assert levels.can_user_notify(admin, "room") is True
+        assert levels.can_user_notify(mod, "room") is False
 
     def test_membership(self):
         parsed_dict = TestClass._load_response("tests/data/events/member.json")

--- a/tests/http2_test.py
+++ b/tests/http2_test.py
@@ -94,6 +94,7 @@ class TestClass:
         conf = h2.config.H2Configuration(client_side=True)
 
         server = h2.connection.H2Connection(conf)
+        server.max_inbound_frame_size = 64 * 1024
         server.initiate_connection()
         server.receive_data(frame_factory.preamble())
 

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -41,10 +41,12 @@ class TestClass:
         room.summary.heroes.append(mx_id)
         room.summary.joined_member_count += 1
         assert room.users
-        assert room.member_count == 1
+        assert room.member_count == room.joined_count == 1
+        assert room.invited_count == 0
 
         room.summary = None
-        assert room.member_count == 1
+        assert room.member_count == room.joined_count == 1
+        assert room.invited_count == 0
 
         member = list(room.users.values())[0]
         assert member.user_id == mx_id
@@ -459,10 +461,14 @@ class TestClass:
         room.summary = None
 
         room.update_summary(RoomSummary(1, 2, []))
+        assert room.invited_count == 1
+        assert room.joined_count == 2
         assert room.member_count == 3
         assert room.summary
 
         room.update_summary(RoomSummary(1, 3, ["@alice:example.org"]))
+        assert room.invited_count == 1
+        assert room.joined_count == 3
         assert room.member_count == 4
         assert room.summary.heroes == ["@alice:example.org"]
 


### PR DESCRIPTION
As per:
https://matrix.org/docs/spec/client_server/latest#push-rules-events
https://matrix.org/docs/spec/client_server/latest#put-matrix-client-r0-pushrules-scope-kind-ruleid
https://matrix.org/docs/spec/client_server/latest#delete-matrix-client-r0-pushrules-scope-kind-ruleid
https://matrix.org/docs/spec/client_server/latest#put-matrix-client-r0-pushrules-scope-kind-ruleid-enabled
https://matrix.org/docs/spec/client_server/latest#put-matrix-client-r0-pushrules-scope-kind-ruleid-actions
