### PR TITLE
async-client: Add support for account data.

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -575,6 +575,13 @@ class AsyncClient(Client):
                     if cb.filter is None or isinstance(event, cb.filter):
                         await asyncio.coroutine(cb.func)(room, event)
 
+            for event in join_info.account_data:
+                room.handle_account_data(event)
+
+                for cb in self.room_account_data_callbacks:
+                    if cb.filter is None or isinstance(event, cb.filter):
+                        await asyncio.coroutine(cb.func)(room, event)
+
             if room.encrypted and self.olm is not None:
                 self.olm.update_tracked_users(room)
 

--- a/tests/data/sync.json
+++ b/tests/data/sync.json
@@ -13,7 +13,24 @@
         "join": {
             "!SVkFJHzfwvuaIEawgC:localhost": {
                 "account_data": {
-                    "events": []
+                    "events": [
+                        {
+                            "type": "m.fully_read",
+                            "content": {
+                                "event_id": "event_id_2"
+                            }
+                        },
+                        {
+                            "type": "m.tag",
+                            "content": {
+                                "tags": {
+                                    "u.test": {
+                                        "order": 1
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 },
                 "ephemeral": {
                     "events": [


### PR DESCRIPTION
PR #153 added account data support to base-client, but did not add the
needed changes to async-client's _handle_joined_rooms. Copy needed code
and tests form base-client to async-client.