### PR TITLE
Treat "device_lists" in SyncResponse as optional.

### DIFF
--- a/nio/responses.py
+++ b/nio/responses.py
@@ -1736,8 +1736,8 @@ class SyncResponse(Response):
         )
 
         devices = DeviceList(
-            parsed_dict["device_lists"]["changed"],
-            parsed_dict["device_lists"]["left"],
+            parsed_dict.get("device_lists", {}).get("changed", []),
+            parsed_dict.get("device_lists", {}).get("left", []),
         )
 
         presence_events = SyncResponse._get_presence(parsed_dict)

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -460,7 +460,6 @@ class Schemas:
         "required": [
             "next_batch",
             "device_one_time_keys_count",
-            "device_lists",
             "rooms",
             "to_device",
         ],


### PR DESCRIPTION
This tiny pull request changes parsing of SyncResponse such that when "device_lists" field is absent, it is substituted by the empty default. The sub-fields of "device_lists" are also supplied with empty defaults.

The spec says that "device_lists" is optional in the sync response (["End-to-End Encryption" -> "Protocol definitions" -> "Extensions to /sync"](https://matrix.org/docs/spec/client_server/r0.6.1#device-lists-sync)) My experience with dendrite is a bit more nuanced: I see `parsed_dict["device_lists"]["changed"]` present in the response, while `parsed_dict["device_lists"]["left"]` absent (which makes matrix-nio throw `KeyError`)