### PR TITLE
Authenticated access to /profile endpoints

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -1487,19 +1487,28 @@ class Api:
         )
 
     @staticmethod
-    def profile_get(user_id: str) -> Tuple[str, str]:
+    def profile_get(user_id: str, access_token: str = None) -> Tuple[str, str]:
         """Get the combined profile information for a user.
 
         Returns the HTTP method and HTTP path for the request.
 
         Args:
             user_id (str): User id to get the profile for.
+            access_token (str): The access token to be used with the request. If
+                                omitted, an unauthenticated request is perfomed.
         """
         assert user_id
-        return "GET", Api._build_path(path=["profile", user_id])
+
+        query_parameters = {}
+        if access_token is not None:
+            query_parameters["access_token"] = access_token
+
+        path = ["profile", user_id]
+
+        return "GET", Api._build_path(path, query_parameters)
 
     @staticmethod
-    def profile_get_displayname(user_id):
+    def profile_get_displayname(user_id, access_token: str = None):
         # type (str, str) -> Tuple[str, str]
         """Get display name.
 
@@ -1507,10 +1516,16 @@ class Api:
 
         Args:
             user_id (str): User id to get display name for.
+            access_token (str): The access token to be used with the request. If
+                                omitted, an unauthenticated request is perfomed.
         """
+        query_parameters = {}
+        if access_token is not None:
+            query_parameters["access_token"] = access_token
+
         path = ["profile", user_id, "displayname"]
 
-        return "GET", Api._build_path(path)
+        return "GET", Api._build_path(path, query_parameters)
 
     @staticmethod
     def profile_set_displayname(access_token, user_id, display_name):
@@ -1535,7 +1550,7 @@ class Api:
         )
 
     @staticmethod
-    def profile_get_avatar(user_id):
+    def profile_get_avatar(user_id, access_token: str = None):
         # type (str, str) -> Tuple[str, str]
         """Get avatar URL.
 
@@ -1543,10 +1558,15 @@ class Api:
 
         Args:
             user_id (str): User id to get avatar for.
+            access_token (str): The access token to be used with the request. If
+                                omitted, an unauthenticated request is perfomed.
         """
+        query_parameters = {}
+        if access_token is not None:
+            query_parameters["access_token"] = access_token
         path = ["profile", user_id, "avatar_url"]
 
-        return "GET", Api._build_path(path)
+        return "GET", Api._build_path(path, query_parameters)
 
     @staticmethod
     def profile_set_avatar(access_token, user_id, avatar_url):

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -2732,7 +2732,10 @@ class AsyncClient(Client):
         Args:
             user_id (str): User id of the user to get the profile for.
         """
-        method, path = Api.profile_get(user_id or self.user_id)
+        method, path = Api.profile_get(
+            user_id or self.user_id,
+            access_token=self.access_token or None
+        )
 
         return await self._send(ProfileGetResponse, method, path,)
 
@@ -2816,7 +2819,10 @@ class AsyncClient(Client):
         Args:
             user_id (str): User id of the user to get the display name for.
         """
-        method, path = Api.profile_get_displayname(user_id or self.user_id)
+        method, path = Api.profile_get_displayname(
+            user_id or self.user_id,
+            access_token=self.access_token or None
+        )
 
         return await self._send(ProfileGetDisplayNameResponse, method, path,)
 
@@ -2864,7 +2870,10 @@ class AsyncClient(Client):
         Args:
             user_id (str): User id of the user to get the avatar for.
         """
-        method, path = Api.profile_get_avatar(user_id or self.user_id)
+        method, path = Api.profile_get_avatar(
+            user_id or self.user_id,
+            access_token=self.access_token or None
+        )
 
         return await self._send(ProfileGetAvatarResponse, method, path,)
 

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -937,7 +937,10 @@ class HttpClient(Client):
         Args:
             user_id (str): User id of the user to get the profile for.
         """
-        request = self._build_request(Api.profile_get(user_id or self.user_id))
+        request = self._build_request(
+            Api.profile_get(user_id or self.user_id,
+                            access_token=self.access_token or None)
+        )
 
         return self._send(
             request,
@@ -958,9 +961,10 @@ class HttpClient(Client):
         Args:
             user_id (str): User id of the user to get the display name for.
         """
-        request = self._build_request(Api.profile_get_displayname(
-            user_id or self.user_id
-        ))
+        request = self._build_request(
+            Api.profile_get_displayname(user_id or self.user_id,
+                                        access_token=self.access_token or None)
+        )
 
         return self._send(
             request,
@@ -1006,9 +1010,10 @@ class HttpClient(Client):
         Args:
             user_id (str): User id of the user to get the avatar for.
         """
-        request = self._build_request(Api.profile_get_avatar(
-            user_id or self.user_id
-        ))
+        request = self._build_request(
+            Api.profile_get_avatar(user_id or self.user_id,
+                                   access_token=self.access_token or None)
+        )
 
         return self._send(
             request,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -24,3 +24,15 @@ class TestClass:
             expected_path = f"/_matrix/client/r0/profile/{encoded}"
             (method, actual_path) = api.profile_get(unencoded)
             assert actual_path == expected_path
+
+    def test_profile_get_authed(self) -> None:
+        """Test that profile_get sets access_token in query param"""
+        api = Api()
+        user_id = "@bob:example.com"
+        encoded = "%40bob%3Aexample.com"
+        token = "SECRET_TOKEN"
+
+        expected = f"/_matrix/client/r0/profile/{encoded}?access_token={token}"
+        resp = api.profile_get(user_id, token)
+
+        assert resp == ('GET', expected)


### PR DESCRIPTION
This is a fix for #238, to allow nio to access profile endpoints on a matrix server that requires authentication (in contrast with what the spec currently says). The new parameter follows the pattern `profile_get(user_id: str, access_token: str = None)`. AsyncClient and HttpClient will pass the access_token on to the profile Api module methods, if it has been set (or None if missing).

Missing from this pull requests, for which I'd be happy to get some input: testing for HttpClient. The async client uses aioresponse in its test suite, which makes it easy to make sure the client requested the right URI and give back appropriate response. Any suggestions for how to test the http client as well?

Fixes #238