### PR TITLE
async_client: Support SOCKS proxys

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -35,7 +35,6 @@ from typing import (
 )
 
 from .exceptions import LocalProtocolError
-from .http import Http2Request, HttpRequest, TransportRequest
 
 if TYPE_CHECKING:
     from .events.account_data import PushAction, PushCondition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ python-olm = { version = "^3.1.3", optional = true }
 peewee = { version = "^3.13.2", optional = true }
 cachetools = { version = "^4.0.0", optional = true }
 atomicwrites = { version = "^1.3.0", optional = true }
+aiohttp-socks = "^0.5.5"
 
 [tool.poetry.extras]
 e2e = ["python-olm", "peewee", "cachetools", "atomicwrites"]


### PR DESCRIPTION
This changes provide support for SOCKS4(a) and SOCKS5 proxys as discussed in https://github.com/poljar/matrix-nio/issues/245. Because aiohttp only supports HTTP proxys this needs the new dependency [aiohttp-socks](https://github.com/romis2012/aiohttp-socks).