### PR TITLE
Add Sticker events for Reactions

### DIFF
--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -162,6 +162,8 @@ class Event:
             return RedactionEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.encrypted":
             return Event.parse_encrypted_event(event_dict)
+        elif event_dict["type"] == "m.sticker":
+            return StickerEvent.parse_event(event_dict)
         elif event_dict["type"].startswith("m.call"):
             return CallEvent.parse_event(event_dict)
 
@@ -1455,4 +1457,42 @@ class RoomMemberEvent(Event):
             prev_membership,
             content,
             prev_content,
+        )
+
+
+@dataclass
+class StickerEvent(Event):
+    """An event indicating the use of a sticker
+
+    Sticker messages are specialised image messages that are displayed
+    without controls. Sticker messages are intended to provide simple
+    "reaction" events in the message timeline.
+
+    Attributes:
+        body (str): A textual representation or associated description of
+        the sticker image. This could be the alt text of the original image,
+        or a message to accompany and further describe the sticker.
+        url (str): The URL to the sticker image.
+        content (dict): The content of the of the redaction event.
+
+    """
+
+    body: str = field()
+    url: str = field()
+    content: Dict[str, Any] = field()
+
+    @classmethod
+    @verify(Schemas.sticker)
+    def from_dict(cls, parsed_dict):
+        # type: (Dict[Any, Any]) -> Union[StickerEvent, BadEventType]
+        content = parsed_dict.get("content", {})
+
+        body = content["body"]
+        url = content["url"]
+
+        return cls(
+            parsed_dict,
+            body,
+            url,
+            content,
         )

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1067,9 +1067,10 @@ class Schemas:
                     "body": {"type": "string"},
                     "url": {"type": "string"},
                 },
+                "required": ["body", "url"],
             },
         },
-        "required": ["sender", "body", "url"],
+        "required": ["sender"],
     }
 
     room_resolve_alias = {

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1057,6 +1057,21 @@ class Schemas:
         "required": ["sender", "redacts"],
     }
 
+    sticker = {
+        "type": "object",
+        "properties": {
+            "sender": {"type": "string", "format": "user_id"},
+            "content": {
+                "type": "object",
+                "properties": {
+                    "body": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+        },
+        "required": ["sender", "body", "url"],
+    }
+
     room_resolve_alias = {
         "type": "object",
         "properties": {

--- a/tests/data/events/sticker.json
+++ b/tests/data/events/sticker.json
@@ -1,0 +1,27 @@
+{
+    "content": {
+        "body": "Landing",
+        "info": {
+            "h": 200,
+            "mimetype": "image/png",
+            "size": 73602,
+            "thumbnail_info": {
+                "h": 200,
+                "mimetype": "image/png",
+                "size": 73602,
+                "w": 140
+            },
+            "thumbnail_url": "mxc://matrix.org/sHhqkFCvSkFwtmvtETOtKnLP",
+            "w": 140
+        },
+        "url": "mxc://matrix.org/sHhqkFCvSkFwtmvtETOtKnLP"
+    },
+    "event_id": "$143273582443PhrSn:example.org",
+    "origin_server_ts": 1432735824653,
+    "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
+    "sender": "@example:example.org",
+    "type": "m.sticker",
+    "unsigned": {
+        "age": 1234
+    }
+}

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -12,6 +12,7 @@ from nio.events import (
     PowerLevelsEvent,
     RedactedEvent,
     RedactionEvent,
+    StickerEvent,
     RoomAliasEvent,
     RoomCreateEvent,
     RoomGuestAccessEvent,
@@ -217,6 +218,11 @@ class TestClass:
         parsed_dict = TestClass._load_response("tests/data/events/redaction.json")
         event = RedactionEvent.from_dict(parsed_dict)
         assert isinstance(event, RedactionEvent)
+
+    def test_sticker(self):
+        parsed_dict = TestClass._load_response("tests/data/events/sticker.json")
+        event = StickerEvent.from_dict(parsed_dict)
+        assert isinstance(event, StickerEvent)
 
     def test_empty_event(self):
         parsed_dict = {}


### PR DESCRIPTION
~Closes #174~ Edit: Looks like I had misunderstood that issue. See discussion below

Adds the ability to have Sticker Events which currently give the 
1. body (which is like the tooltip)
2. URL (The mxc url to the image)

Feel free to let me know if I have missed out adding any more fields. 
And feel free to let me know if this PR covers everything that's required out of the issue this is closing. 