### PR TITLE
Support BytesIO streams for uploads

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -218,6 +218,7 @@ SynchronousFile = (
     io.TextIOBase,
     io.BufferedReader,
     io.BufferedRandom,
+    io.BytesIO,
     io.FileIO
 )
 AsyncFile = (AsyncBufferedReader, AsyncTextIOWrapper)


### PR DESCRIPTION
When you need to transform a bytearray to a readable interface the suggested one to use is BytesIO but the current type checking doesn't allow you to do so.

So I just added the BytesIO type to the list.