### PR TITLE
schema: add defaults for compatibility with dendrite

### DIFF
--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -325,6 +325,7 @@ class Schemas:
         "properties": {
             "device_one_time_keys_count": {
                 "type": "object",
+                "default": {},
                 "properties": {
                     "curve25519": {"type": "integer", "default": 0},
                     "signed_curve25519": {"type": "integer", "default": 0},
@@ -452,7 +453,7 @@ class Schemas:
             "presence": {
                 "type": "object",
                 "properties": {
-                    "events": {"type": "array"}
+                    "events": {"type": "array", "default": []},
                 },
                 "required": ["events"]
             }


### PR DESCRIPTION
This fixes compatibility issues for sync with dendrite. 

I can add additional defaults when testing with conduit.