### PR TITLE
crypto: Always try to load the crypto data.

### DIFF
--- a/nio/crypto/olm_machine.py
+++ b/nio/crypto/olm_machine.py
@@ -220,8 +220,8 @@ class Olm:
                 self.user_id, self.device_id))
             account = OlmAccount()
             self.save_account(account)
-        else:
-            self.load()
+
+        self.load()
 
         self.account = account  # type: OlmAccount
 


### PR DESCRIPTION
This allows a custom store to return customized caches as well, for example a custom GroupSessionStore that only holds a single key per room id, sender key pair.