### PR TITLE
Initialize the whole counter block IV when decoding encrypted attachments

### DIFF
--- a/nio/crypto/attachments.py
+++ b/nio/crypto/attachments.py
@@ -60,12 +60,13 @@ def decrypt_attachment(ciphertext: bytes, key: str, hash: str, iv: str):
         raise EncryptionError("Error decoding key.")
 
     try:
-        # Drop last 8 bytes, which are 0
-        byte_iv: bytes = unpaddedbase64.decode_base64(iv)[:8]
+        byte_iv: bytes = unpaddedbase64.decode_base64(iv)
     except (BinAsciiError, TypeError):
         raise EncryptionError("Error decoding initial values.")
 
-    ctr = Counter.new(64, prefix=byte_iv, initial_value=0)
+    prefix: bytes = byte_iv[:8]
+    cnt: int = int.from_bytes(byte_iv[8:], 'big')
+    ctr = Counter.new(64, prefix=prefix, initial_value=cnt)
 
     try:
         cipher = AES.new(byte_key, AES.MODE_CTR, counter=ctr)


### PR DESCRIPTION
Do not truncate the IV, but instead decode the initial counter value in the last 32bits and initialize the Counter correctly.

This fixes attachment decoding as produced by FluffyChat, and fixes https://github.com/poljar/weechat-matrix/issues/275

famedlysdk (used by FluffyChat) is using the following amendment to the matrix protocol, which changes the IV to be a full 128 bit counter block (padding + counter) when encrypting attachments: https://github.com/matrix-org/matrix-doc/pull/2492/files

After a discussion with Lukas Lihotzki (one of the authors of the famedlysdk), it seems that this change was discussed last year as not to waste half the entropy of the IV and should have been adopted by Element itself, but hasn't been done yet. Element still produces an IV with a zero counter, but it will decode properly attachments with a full 128bit counter block.

The change is retrocompatible, since the IV produced by clients which don't use this amendment pad the IV with zeros, which results in the same starting value as before. This includes matrix-nio itself and Element.