### PR TITLE
schemas: allow for devices in keys query that have no signatures

### DIFF
--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1255,8 +1255,7 @@ class Schemas:
                         "required": [
                             "algorithms",
                             "device_id",
-                            "keys",
-                            "signatures"
+                            "keys"
                         ]
                     }}
                 }},


### PR DESCRIPTION
This appears to allow the Weechat plugin to engage in E2EE conversations with new devices.

Fixes #263.