### PR TITLE
Add media mimetype to emxc:// urls

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -193,7 +193,14 @@ class Api:
         return http_url
 
     @staticmethod
-    def encrypted_mxc_to_plumb(mxc, key, hash, iv, homeserver=None):
+    def encrypted_mxc_to_plumb(
+        mxc,
+        key,
+        hash,
+        iv,
+        homeserver=None,
+        mimetype=None,
+    ):
         # type: (str, str, str, str, Optional[str]) -> Optional[str]
         """Convert a matrix content URI to a encrypted mxc URI.
 
@@ -215,6 +222,7 @@ class Api:
                 payload the URI is pointing to.
             hash (str): The hash of the payload.
             iv (str): The initial value needed to decrypt the payload.
+            mimetype (str): The mimetype of the payload.
         """
         url = urlparse(mxc)
 
@@ -243,6 +251,8 @@ class Api:
             "hash": hash,
             "iv": iv,
         }
+        if mimetype is not None:
+            query_parameters["mimetype"] = mimetype
 
         plumb_url += "?{}".format(urlencode(query_parameters))
 

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -905,6 +905,7 @@ class RoomEncryptedMedia(RoomMessage):
         hashes (dict): A mapping from an algorithm name to a hash of the
             ciphertext encoded as base64.
         iv (str): The initialisation vector that was used to encrypt the file.
+        mimetype (str): The mimetype of the message.
 
         thumbnail_url (str, optional): The URL of the thumbnail file.
         thumbnail_key (dict, optional): The key that can be used to decrypt the
@@ -920,6 +921,7 @@ class RoomEncryptedMedia(RoomMessage):
     key: Dict[str, Any] = field()
     hashes: Dict[str, Any] = field()
     iv: str = field()
+    mimetype: str = field()
 
     thumbnail_url: Optional[str] = None
     thumbnail_key: Optional[Dict] = None
@@ -944,6 +946,7 @@ class RoomEncryptedMedia(RoomMessage):
             parsed_dict["content"]["file"]["key"],
             parsed_dict["content"]["file"]["hashes"],
             parsed_dict["content"]["file"]["iv"],
+            parsed_dict["content"]["file"]["mimetype"],
             thumbnail_url,
             thumbnail_key,
             thumbnail_hashes,

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -507,6 +507,7 @@ class TestClass:
         assert event.thumbnail_key
         assert event.thumbnail_hashes
         assert event.thumbnail_iv
+        assert event.mimetype
 
     def test_event_flattening(self):
         parsed_dict = TestClass._load_response(


### PR DESCRIPTION
`emxc://` URLs currently do not preserve mimetype information from the encrypted media message. Clients have to infer the mimetype with `file` or similar. This commit adds an optional `?mimetype` field to `emxc://` URLs to avoid client-side guessing.