### PR TITLE
Use user identifier for login

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -383,7 +383,10 @@ class Api:
         if password is not None:
             content_dict = {
                 "type": "m.login.password",
-                "user": user,
+                "identifier": {
+                    "type": "m.id.user",
+                    "user": user
+                },
                 "password": password,
             }
         elif token is not None:


### PR DESCRIPTION
This makes it possible to log in to a Conduit server.

According to [the spec](https://matrix.org/docs/spec/client_server/r0.6.1#identifier-types), `"user"` is deprecated in favor of `"identifier"`.