### PR TITLE
Remove `chain_index` field when sending room keys.

### DIFF
--- a/nio/crypto/olm_machine.py
+++ b/nio/crypto/olm_machine.py
@@ -478,7 +478,6 @@ class Olm:
             "session_key": group_session.export_session(
                 group_session.first_known_index
             ),
-            "chain_index": group_session.first_known_index,
         }
 
         olm_dict = self._olm_encrypt(session, device, "m.forwarded_room_key",
@@ -1812,7 +1811,6 @@ class Olm:
             "room_id": room_id,
             "session_id": group_session.id,
             "session_key": group_session.session_key,
-            "chain_index": group_session.message_index,
         }
 
         already_shared_set = group_session.users_shared_with
@@ -1900,7 +1898,6 @@ class Olm:
             "room_id": room_id,
             "session_id": group_session.id,
             "session_key": group_session.session_key,
-            "chain_index": group_session.message_index,
         }
 
         to_device_dict = {"messages": {}}  # type: Dict[str, Any]

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -755,7 +755,6 @@ class Schemas:
                     "room_id": {"type": "string", "format": "room_id"},
                     "session_id": {"type": "string"},
                     "session_key": {"type": "string"},
-                    "chain_index": {"type": "integer"},
                 },
                 "required": [
                     "algorithm",


### PR DESCRIPTION
This field has been deprecated for quite a while and is not used anymore
by Matrix clients. The Olm message index is instead embedded in the
serialized ratchet key format (since https://gitlab.matrix.org/matrix-org/olm/-/commit/e0b5197).

Also see https://github.com/matrix-org/matrix-doc/issues/1249#issuecomment-395358088.