### PR TITLE
Update aiohttp-socks dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .pytest_cache/
 packages/
 __pycache__
+poetry.lock
 *.pyc
 .hypothesis/
 .tox/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ python-olm = { version = "^3.1.3", optional = true }
 peewee = { version = "^3.14.4", optional = true }
 cachetools = { version = "^4.2.1", optional = true }
 atomicwrites = { version = "^1.4.0", optional = true }
-aiohttp-socks = "^0.6.0"
+aiohttp-socks = "^0.7.0"
 
 [tool.poetry.extras]
 e2e = ["python-olm", "peewee", "cachetools", "atomicwrites"]


### PR DESCRIPTION
The changes appear pretty simple: https://github.com/romis2012/aiohttp-socks/compare/v0.6.0...v0.7.1

This allows compatibility with python-socks 2.x. Tests all pass.