### PR TITLE
Send empty object with m.read receipt

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -2463,6 +2463,7 @@ class AsyncClient(Client):
             UpdateReceiptMarkerResponse,
             method,
             path,
+            "{}",
         )
 
     @logged_in


### PR DESCRIPTION
According to [the spec](https://matrix.org/docs/spec/client_server/r0.6.1#id55), m.read events should send an empty object.
New Synapse versions seem more strict about this and ignore requests with `""` instead of `"{}"`.