### PR TITLE
Add special check for "room_id" in PushEventMatch

### DIFF
--- a/nio/events/account_data.py
+++ b/nio/events/account_data.py
@@ -181,6 +181,10 @@ class PushEventMatch(PushCondition):
     def matches(
         self, event: Event, room: "MatrixRoom", display_name: str,
     ) -> bool:
+        
+        if self.key == "room_id":
+            return fnmatchcase(room.room_id, self.pattern)
+        
         value = event.flattened().get(self.key)
 
         if not isinstance(value, str):


### PR DESCRIPTION
We can not rely on Event having `room_id`. See [here](https://github.com/poljar/matrix-nio/blob/master/nio/events/room_events.py#L36).
Only encrypted events have `room_id`, so in unencrypted rooms you definitely need to use `room.room_id`.
And since room ids are case sensitive, `.lower()` should not be used in this case.