### PR TITLE
Update jsonschema to version 4.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6.1"
+python = "^3.7.0"
 future = "^0.18.2"
 aiohttp = "^3.7.4"
 aiofiles = "^0.6.0"
@@ -24,7 +24,7 @@ dataclasses = { version = "^0.7", python = ">= 3.6, <3.7" }
 h11 = "^0.12.0"
 h2 = "^4.0.0"
 logbook = "^1.5.3"
-jsonschema = "^3.2.0"
+jsonschema = "^4.4.0"
 unpaddedbase64 = "^2.1.0"
 pycryptodome = "^3.10.1"
 python-olm = { version = "^3.1.3", optional = true }


### PR DESCRIPTION
jsonschema 4.4.0 requires python >=3.7, so python got an update, too.

As of 2021-12-23, python 3.6 has reached the end-of-life phase, see
https://www.python.org/dev/peps/pep-0494/#lifespan

- [x] ran `make test` to ensure everything is fine