### PR TITLE
feat: Add mxc URI parameter to `AsyncClient.download`.

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -2858,10 +2858,10 @@ class AsyncClient(Client):
                 media_id = url.path.replace("/", "")
 
         http_method, path = Api.download(
-            filename=filename,
-            allow_remote=allow_remote,
-            server_name=server_name,
-            media_id=media_id,
+            server_name,
+            media_id,
+            filename,
+            allow_remote,
         )
 
         return await self._send(


### PR DESCRIPTION
Also deprecate `server_name` and `media_id`.

Fixes #94.