### PR TITLE
style: Convert from `str.format` to f-strings.

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -194,7 +194,7 @@ class Api:
             homeserver=(
                 parsed_homeserver.geturl()
                 if parsed_homeserver
-                else "https://{}".format(url.netloc)
+                else f"https://{url.netloc}"
             ),
             server_name=url.hostname,
             mediaId=url.path,
@@ -253,7 +253,7 @@ class Api:
         plumb_url = (
             "{homeserver}/_matrix/media/r0/download/" "{server_name}{mediaId}"
         ).format(
-            homeserver=host if host else "emxc://{}".format(url.netloc),
+            homeserver=host if host else f"emxc://{url.netloc}",
             server_name=url.hostname,
             mediaId=url.path,
         )
@@ -266,7 +266,7 @@ class Api:
         if mimetype is not None:
             query_parameters["mimetype"] = mimetype
 
-        plumb_url += "?{}".format(urlencode(query_parameters))
+        plumb_url += f"?{urlencode(query_parameters)}"
 
         return plumb_url
 
@@ -299,12 +299,12 @@ class Api:
                 f"'path' must be of type List[str] or str, got {type(path)}"
             )
 
-        built_path = "{base}/{path}".format(base=base_path, path=quoted_path)
+        built_path = f"{base_path}/{quoted_path}"
 
         built_path = built_path.rstrip("/")
 
         if query_parameters:
-            built_path += "?{}".format(urlencode(query_parameters))
+            built_path += f"?{urlencode(query_parameters)}"
 
         return built_path
 

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1266,8 +1266,7 @@ class AsyncClient(Client):
         """
         if transaction_id not in self.key_verifications:
             raise LocalProtocolError(
-                "Key verification with the transaction "
-                "id {} does not exist.".format(transaction_id)
+                f"Key verification with the transaction id {transaction_id} does not exist."
             )
 
         sas = self.key_verifications[transaction_id]
@@ -1297,8 +1296,7 @@ class AsyncClient(Client):
         """
         if transaction_id not in self.key_verifications:
             raise LocalProtocolError(
-                "Key verification with the transaction "
-                "id {} does not exist.".format(transaction_id)
+                f"Key verification with the transaction id {transaction_id} does not exist."
             )
 
         sas = self.key_verifications[transaction_id]
@@ -1917,15 +1915,13 @@ class AsyncClient(Client):
         try:
             room = self.rooms[room_id]
         except KeyError:
-            raise LocalProtocolError("No such room with id {}".format(room_id))
+            raise LocalProtocolError(f"No such room with id {room_id}")
 
         if not room.encrypted:
-            raise LocalProtocolError("Room with id {} is not encrypted".format(room_id))
+            raise LocalProtocolError(f"Room with id {room_id} is not encrypted")
 
         if room_id in self.sharing_session:
-            raise LocalProtocolError(
-                "Already sharing a group session for {}".format(room_id)
-            )
+            raise LocalProtocolError(f"Already sharing a group session for {room_id}")
 
         self.sharing_session[room_id] = AsyncioEvent()
 
@@ -3410,16 +3406,14 @@ class AsyncClient(Client):
                 if isinstance(
                     await self.room_delete_alias(alias), RoomDeleteAliasError
                 ):
-                    return RoomUpdateAliasError(
-                        "Could not delete alias {}".format(alias)
-                    )
+                    return RoomUpdateAliasError(f"Could not delete alias {alias}")
 
         # Register new aliases
         for alias in new_aliases:
             if isinstance(
                 await self.room_put_alias(alias, room_id), RoomDeleteAliasError
             ):
-                return RoomUpdateAliasError("Could not put alias {}".format(alias))
+                return RoomUpdateAliasError(f"Could not put alias {alias}")
 
         # Send m.room.canonical_alias event
         put_alias_event = await self.room_put_state(
@@ -3605,7 +3599,7 @@ class AsyncClient(Client):
             elif event_type == "state":
                 event_power_level = power_levels.content["state_default"]
             else:
-                return ErrorResponse("event_type {} unknown".format(event_type))
+                return ErrorResponse(f"event_type {event_type} unknown")
         else:
             return ErrorResponse("Couldn't get event power levels")
 
@@ -3627,6 +3621,6 @@ class AsyncClient(Client):
         try:
             permission_power_level = power_levels.content[permission_type]
         except KeyError:
-            return ErrorResponse("permission_type {} unknown".format(permission_type))
+            return ErrorResponse(f"permission_type {permission_type} unknown")
 
         return user_power_level >= permission_power_level

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -413,7 +413,7 @@ class Client:
         try:
             room = self.rooms[room_id]
         except KeyError:
-            raise LocalProtocolError("No room found with room id {}".format(room_id))
+            raise LocalProtocolError(f"No room found with room id {room_id}")
 
         if not room.encrypted:
             return False
@@ -448,7 +448,7 @@ class Client:
         if session and not session.shared:
             self.olm.outbound_group_sessions[room_id] = session
         elif session:
-            logger.info("Invalidating session for {}".format(room_id))
+            logger.info(f"Invalidating session for {room_id}")
 
     def _invalidate_outbound_sessions(self, device):
         # type: (OlmDevice) -> None
@@ -668,7 +668,7 @@ class Client:
 
     def _get_invited_room(self, room_id: str) -> MatrixInvitedRoom:
         if room_id not in self.invited_rooms:
-            logger.info("New invited room {}".format(room_id))
+            logger.info(f"New invited room {room_id}")
             self.invited_rooms[room_id] = MatrixInvitedRoom(room_id, self.user_id)
 
         return self.invited_rooms[room_id]
@@ -691,7 +691,7 @@ class Client:
             del self.invited_rooms[room_id]
 
         if room_id not in self.rooms:
-            logger.info("New joined room {}".format(room_id))
+            logger.info(f"New joined room {room_id}")
             self.rooms[room_id] = MatrixRoom(
                 room_id, self.user_id, room_id in self.encrypted_rooms
             )
@@ -961,10 +961,7 @@ class Client:
                     ):
                         return
 
-            logger.info(
-                "Marking outbound group session for room {} "
-                "as shared".format(room_id)
-            )
+            logger.info(f"Marking outbound group session for room {room_id} as shared")
             session.shared = True
 
         elif isinstance(response, KeysQueryResponse):
@@ -1130,11 +1127,11 @@ class Client:
         assert self.olm
 
         if room_id not in self.rooms:
-            raise LocalProtocolError("No room found with room id {}".format(room_id))
+            raise LocalProtocolError(f"No room found with room id {room_id}")
         room = self.rooms[room_id]
 
         if not room.encrypted:
-            raise LocalProtocolError("Room with id {} is not encrypted".format(room_id))
+            raise LocalProtocolError(f"Room with id {room_id} is not encrypted")
 
         return self.olm.get_missing_sessions(list(room.users))
 
@@ -1177,10 +1174,10 @@ class Client:
         try:
             room = self.rooms[room_id]
         except KeyError:
-            raise LocalProtocolError("No such room with id {} found.".format(room_id))
+            raise LocalProtocolError(f"No such room with id {room_id} found.")
 
         if not room.encrypted:
-            raise LocalProtocolError("Room {} is not encrypted".format(room_id))
+            raise LocalProtocolError(f"Room {room_id} is not encrypted")
 
         if not room.members_synced:
             raise MembersSyncError(
@@ -1369,8 +1366,7 @@ class Client:
         """
         if transaction_id not in self.key_verifications:
             raise LocalProtocolError(
-                "Key verification with the transaction "
-                "id {} does not exist.".format(transaction_id)
+                f"Key verification with the transaction id {transaction_id} does not exist."
             )
 
         sas = self.key_verifications[transaction_id]
@@ -1403,7 +1399,7 @@ class Client:
         try:
             room = self.rooms[room_id]
         except KeyError:
-            raise LocalProtocolError("No room found with room id {}".format(room_id))
+            raise LocalProtocolError(f"No room found with room id {room_id}")
 
         if not room.encrypted:
             return devices

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -139,7 +139,7 @@ class HttpClient(Client):
     @staticmethod
     def _parse_homeserver(homeserver):
         if not homeserver.startswith("http"):
-            homeserver = "https://{}".format(homeserver)
+            homeserver = f"https://{homeserver}"
 
         homeserver = urlparse(homeserver)
 
@@ -153,7 +153,7 @@ class HttpClient(Client):
             else:
                 raise ValueError("Invalid URI scheme for Homeserver")
 
-        host = "{}:{}".format(homeserver.hostname, port)
+        host = f"{homeserver.hostname}:{port}"
         extra_path = homeserver.path.strip("/")
 
         return host, extra_path
@@ -174,7 +174,7 @@ class HttpClient(Client):
 
     def _add_extra_path(self, path):
         if self.extra_path:
-            return "/{}{}".format(self.extra_path, path)
+            return f"/{self.extra_path}{path}"
         return path
 
     def _build_request(self, api_response, timeout=0):
@@ -305,9 +305,7 @@ class HttpClient(Client):
             try:
                 room = self.rooms[room_id]
             except KeyError:
-                raise LocalProtocolError(
-                    "No such room with id {} found.".format(room_id)
-                )
+                raise LocalProtocolError(f"No such room with id {room_id} found.")
 
             if room.encrypted:
                 message_type, content = self.encrypt(
@@ -763,10 +761,10 @@ class HttpClient(Client):
         try:
             room = self.rooms[room_id]
         except KeyError:
-            raise LocalProtocolError("No such room with id {}".format(room_id))
+            raise LocalProtocolError(f"No such room with id {room_id}")
 
         if not room.encrypted:
-            raise LocalProtocolError("Room with id {} is not encrypted".format(room_id))
+            raise LocalProtocolError(f"Room with id {room_id} is not encrypted")
 
         user_map, to_device_dict = self.olm.share_group_session(
             room_id,
@@ -1017,8 +1015,7 @@ class HttpClient(Client):
         """
         if transaction_id not in self.key_verifications:
             raise LocalProtocolError(
-                "Key verification with the transaction "
-                "id {} does not exist.".format(transaction_id)
+                f"Key verification with the transaction id {transaction_id} does not exist."
             )
 
         sas = self.key_verifications[transaction_id]
@@ -1043,8 +1040,7 @@ class HttpClient(Client):
         """
         if transaction_id not in self.key_verifications:
             raise LocalProtocolError(
-                "Key verification with the transaction "
-                "id {} does not exist.".format(transaction_id)
+                f"Key verification with the transaction id {transaction_id} does not exist."
             )
 
         sas = self.key_verifications[transaction_id]
@@ -1151,9 +1147,7 @@ class HttpClient(Client):
 
         assert response
 
-        logger.info(
-            "Received new response of type {}".format(response.__class__.__name__)
-        )
+        logger.info(f"Received new response of type {response.__class__.__name__}")
 
         response.start_time = transport_response.send_time
         response.end_time = transport_response.receive_time
@@ -1186,13 +1180,11 @@ class HttpClient(Client):
             try:
                 request_info = self.requests_made.pop(response.uuid)
             except KeyError:
-                logger.error("{}".format(pprint.pformat(self.requests_made)))
+                logger.error(f"{pprint.pformat(self.requests_made)}")
                 raise
 
             if response.is_ok:
-                logger.info(
-                    "Received response of type: {}".format(request_info.request_class)
-                )
+                logger.info(f"Received response of type: {request_info.request_class}")
             else:
                 logger.info(
                     ("Error with response of type type: {}, " "error code {}").format(

--- a/nio/crypto/olm_machine.py
+++ b/nio/crypto/olm_machine.py
@@ -248,9 +248,7 @@ class Olm:
         # data from the store as well.
         if not account:
             logger.info(
-                "Creating new Olm account for {} on device {}".format(
-                    self.user_id, self.device_id
-                )
+                f"Creating new Olm account for {self.user_id} on device {self.device_id}"
             )
             account = OlmAccount()
             self.save_account(account)
@@ -404,8 +402,7 @@ class Olm:
         olm_dict = self._olm_encrypt(session, device, "m.dummy", {})
 
         logger.info(
-            "Queuing a dummy Olm message for device {} of user "
-            "{}".format(device.device_id, device.user_id)
+            f"Queuing a dummy Olm message for device {device.device_id} of user {device.user_id}"
         )
 
         self.outgoing_to_device_messages.append(
@@ -442,10 +439,8 @@ class Olm:
                 self.received_key_requests[event.request_id] = event
             else:
                 logger.warn(
-                    "Received key request from {} via {} with an "
-                    "unknown algorithm: {}".format(
-                        event.sender, event.requesting_device_id, event.algorithm
-                    )
+                    f"Received key request from {event.sender} via {event.requesting_device_id} "
+                    f"with an unknown algorithm: {event.algorithm}"
                 )
 
         elif isinstance(event, RoomKeyRequestCancellation):
@@ -519,26 +514,21 @@ class Olm:
         handled.
 
         """
-        logger.debug(
-            "Trying to reshare key {} with {}".format(event.session_id, event.sender)
-        )
+        logger.debug(f"Trying to reshare key {event.session_id} with {event.sender}")
 
         outbound_session = self.outbound_group_sessions.get(event.room_id)
 
         if not outbound_session or outbound_session.id != event.session_id:
             raise KeyShareError(
-                "Failed to re-share key {} with {}: No "
-                "outbound session found".format(event.session_id, event.sender)
+                f"Failed to re-share key {event.session_id} with {event.sender}: No outbound session found"
             )
 
         user_tuple = (event.sender, event.requesting_device_id)
 
         if user_tuple not in outbound_session.users_shared_with:
             raise KeyShareError(
-                "Failed to re-share key {} with {}: Session wasn't "
-                "shared with the device {}".format(
-                    event.session_id, event.sender, event.requesting_device_id
-                )
+                f"Failed to re-share key {event.session_id} with {event.sender}: "
+                f"Session wasn't shared with the device {event.requesting_device_id}"
             )
 
         sender_key = self.account.identity_keys["curve25519"]
@@ -555,32 +545,25 @@ class Olm:
             device = self.device_store[event.sender][event.requesting_device_id]
         except KeyError:
             raise KeyShareError(
-                "Failed to re-share key {} with {}: Unknown requesting "
-                "device {}.".format(
-                    event.session_id, event.sender, event.requesting_device_id
-                )
+                f"Failed to re-share key {event.session_id} with {event.sender}: "
+                f"Unknown requesting device {event.requesting_device_id}."
             )
 
         if device.deleted:
             raise KeyShareError(
-                "Failed to re-share key {} with {}: Request from a "
-                "deleted device {}.".format(
-                    event.session_id, event.sender, event.requesting_device_id
-                )
+                f"Failed to re-share key {event.session_id} with {event.sender}: "
+                f"Request from a deleted device {event.requesting_device_id}."
             )
 
         session = self.session_store.get(device.curve25519)
 
         if not session:
             raise EncryptionError(
-                "No Olm session found for {} and device "
-                "{}".format(device.user_id, device.id)
+                f"No Olm session found for {device.user_id} and device {device.id}"
             )
 
         logger.debug(
-            "Successfully re-shared key {} with {}".format(
-                event.session_id, event.sender
-            )
+            f"Successfully re-shared key {event.session_id} with {event.sender}"
         )
 
         self.outgoing_to_device_messages.append(
@@ -603,9 +586,7 @@ class Olm:
         can't be handled.
         """
         logger.debug(
-            "Trying to share key {} with {}:{}".format(
-                event.session_id, event.sender, event.requesting_device_id
-            )
+            f"Trying to share key {event.session_id} with {event.sender}:{event.requesting_device_id}"
         )
 
         group_session = self.inbound_group_store.get(
@@ -614,17 +595,14 @@ class Olm:
 
         if not group_session:
             raise KeyShareError(
-                "Failed to re-share key {} with {}: No "
-                "session found".format(event.session_id, event.sender)
+                f"Failed to re-share key {event.session_id} with {event.sender}: No session found"
             )
         try:
             device = self.device_store[event.sender][event.requesting_device_id]
         except KeyError:
             raise KeyShareError(
-                "Failed to re-share key {} with {}: Unknown requesting "
-                "device {}.".format(
-                    event.session_id, event.sender, event.requesting_device_id
-                )
+                f"Failed to re-share key {event.session_id} with {event.sender}: "
+                f"Unknown requesting device {event.requesting_device_id}."
             )
 
         session = self.session_store.get(device.curve25519)
@@ -643,23 +621,18 @@ class Olm:
             ] = event
 
             raise EncryptionError(
-                "No Olm session found for {} and device "
-                "{}".format(device.user_id, device.id)
+                f"No Olm session found for {device.user_id} and device {device.id}"
             )
 
         if not device.verified:
             raise OlmUnverifiedDeviceError(
                 device,
-                "Failed to re-share key {} with {}: Device {} is not "
-                "verified".format(
-                    event.session_id, event.sender, event.requesting_device_id
-                ),
+                f"Failed to re-share key {event.session_id} with {event.sender}: "
+                f"Device {event.requesting_device_id} is not verified",
             )
 
         logger.debug(
-            "Successfully shared a key {} with {}:{}".format(
-                event.session_id, event.sender, event.requesting_device_id
-            )
+            f"Successfully shared a key {event.session_id} with {event.sender}:{event.requesting_device_id}"
         )
 
         self.outgoing_to_device_messages.append(
@@ -780,15 +753,12 @@ class Olm:
                     device = self.device_store[user_id][device_id]
                 except KeyError:
                     logger.warn(
-                        "Curve key for user {} and device {} not "
-                        "found, failed to start Olm session".format(user_id, device_id)
+                        f"Curve key for user {user_id} and device {device_id} not found, failed to start Olm session"
                     )
                     continue
 
                 logger.info(
-                    "Found curve key for user {} and device {}".format(
-                        user_id, device_id
-                    )
+                    f"Found curve key for user {user_id} and device {device_id}"
                 )
 
                 key_object = next(iter(one_time_key.values()))
@@ -798,12 +768,10 @@ class Olm:
                 )
                 if verified:
                     logger.info(
-                        "Successfully verified signature for one-time "
-                        "key of device {} of user {}.".format(device_id, user_id)
+                        f"Successfully verified signature for one-time key of device {device_id} of user {user_id}."
                     )
                     logger.info(
-                        "Creating Outbound Session for device {} of "
-                        "user {}".format(device_id, user_id)
+                        f"Creating Outbound Session for device {device_id} of user {user_id}"
                     )
                     session = self.create_session(key_object["key"], device.curve25519)
 
@@ -822,8 +790,8 @@ class Olm:
                 else:
                     logger.warn(
                         "Signature verification for one-time key of "
-                        "device {} of user {} failed, could not start "
-                        "Olm session.".format(device_id, user_id)
+                        f"device {device_id} of user {user_id} failed, could not start "
+                        "Olm session."
                     )
 
     # This function is copyrighted under the Apache 2.0 license Zil0
@@ -854,8 +822,8 @@ class Olm:
 
                 try:
                     key_dict = payload["keys"]
-                    signing_key = key_dict["ed25519:{}".format(device_id)]
-                    curve_key = key_dict["curve25519:{}".format(device_id)]
+                    signing_key = key_dict[f"ed25519:{device_id}"]
+                    curve_key = key_dict[f"curve25519:{device_id}"]
                     if "unsigned" in payload:
                         display_name = payload["unsigned"].get(
                             "device_display_name", ""
@@ -864,8 +832,8 @@ class Olm:
                         display_name = ""
                 except KeyError as e:
                     logger.warning(
-                        "Invalid identity keys payload from device {} of"
-                        " user {}: {}.".format(device_id, user_id, e)
+                        f"Invalid identity keys payload from device {device_id} of"
+                        f" user {user_id}: {e}."
                     )
                     continue
 
@@ -873,8 +841,8 @@ class Olm:
 
                 if not verified:
                     logger.warning(
-                        "Signature verification failed for device {} of "
-                        "user {}.".format(device_id, user_id)
+                        f"Signature verification failed for device {device_id} of "
+                        f"user {user_id}."
                     )
                     continue
 
@@ -885,7 +853,7 @@ class Olm:
                 except KeyError:
                     logger.info(
                         "Adding new device to the device store for "
-                        "user {} with device id {}".format(user_id, device_id)
+                        f"user {user_id} with device id {device_id}"
                     )
                     self.device_store.add(
                         OlmDevice(
@@ -898,8 +866,8 @@ class Olm:
                 else:
                     if device.ed25519 != signing_key:
                         logger.warning(
-                            "Ed25519 key has changed for device {} "
-                            "of user {}.".format(device_id, user_id)
+                            f"Ed25519 key has changed for device {device_id} "
+                            f"of user {user_id}."
                         )
                         continue
 
@@ -913,15 +881,14 @@ class Olm:
                         device.curve25519 = curve_key
                         logger.info(
                             "Updating curve key in the device store "
-                            "for user {} with device id {}".format(user_id, device_id)
+                            f"for user {user_id} with device id {device_id}"
                         )
 
                     elif device.display_name != display_name:
                         device.display_name = display_name
                         logger.info(
                             "Updating display name in the device "
-                            "store for user {} with device id "
-                            "{}".format(user_id, device_id)
+                            f"store for user {user_id} with device id {device_id}"
                         )
 
                 changed[user_id][device_id] = user_devices[device_id]
@@ -935,9 +902,7 @@ class Olm:
             for device_id in deleted_devices:
                 device = self.device_store[user_id][device_id]
                 device.deleted = True
-                logger.info(
-                    "Marking device {} of user {} as deleted".format(user_id, device_id)
-                )
+                logger.info(f"Marking device {user_id} of user {device_id} as deleted")
                 changed[user_id][device_id] = device
 
         self.store.save_device_keys(changed)
@@ -1015,10 +980,10 @@ class Olm:
         message,  # type: Union[OlmPreKeyMessage, OlmMessage]
     ):
         # type: (...) -> InboundSession
-        logger.info("Creating Inbound session for {}".format(sender))
+        logger.info(f"Creating Inbound session for {sender}")
         # Let's create a new inbound session.
         session = InboundSession(self.account, message, sender_key)
-        logger.info("Created Inbound session for {}".format(sender))
+        logger.info(f"Created Inbound session for {sender}")
         # Remove the one time keys the session used so it can't be reused
         # anymore.
         self.account.remove_one_time_keys(session)
@@ -1079,9 +1044,7 @@ class Olm:
         self, sender_key, sender_fp_key, room_id, session_id, session_key
     ):
         # type: (str, str, str, str, str) -> None
-        logger.info(
-            "Creating inbound group session for {} from {}".format(room_id, sender_key)
-        )
+        logger.info(f"Creating inbound group session for {room_id} from {sender_key}")
 
         try:
             session = InboundGroupSession(
@@ -1101,7 +1064,7 @@ class Olm:
 
     def create_outbound_group_session(self, room_id):
         # type: (str) -> None
-        logger.info("Creating outbound group session for {}".format(room_id))
+        logger.info(f"Creating outbound group session for {room_id}")
         session = OutboundGroupSession()
         self.outbound_group_sessions[room_id] = session
 
@@ -1111,7 +1074,7 @@ class Olm:
         self.create_group_session(
             id_key, fp_key, room_id, session.id, session.session_key
         )
-        logger.info("Created outbound group session for {}".format(room_id))
+        logger.info(f"Created outbound group session for {room_id}")
 
     def get_missing_sessions(self, users):
         # type: (List[str]) -> Dict[str, List[str]]
@@ -1124,7 +1087,7 @@ class Olm:
                     continue
 
                 if not self.session_store.get(device.curve25519):
-                    logger.warn("Missing session for device {}".format(device.id))
+                    logger.warn(f"Missing session for device {device.id}")
                     missing[user_id].append(device.id)
 
         return missing
@@ -1161,8 +1124,8 @@ class Olm:
             # TODO we should probably mark this user for a key query.
             logger.warn(
                 "Attempted to mark a device for Olm session "
-                "unwedging, but no device was found for user {} with "
-                "sender key {}".format(sender, sender_key)
+                f"unwedging, but no device was found for user {sender} with "
+                f"sender key {sender_key}"
             )
             return
 
@@ -1174,17 +1137,15 @@ class Olm:
             session_age = datetime.now() - session.creation_time
             if session_age < self._unwedging_interval:
                 logger.warn(
-                    "Attempted to mark device {} of user {} for Olm "
-                    "session unwedging, but a new session was created "
-                    "recently.".format(device.device_id, device.user_id)
+                    f"Attempted to mark device {device.device_id} of user "
+                    f"{device.user_id} for Olm session unwedging, but a new "
+                    "session was created recently."
                 )
                 return
 
         if device not in self.wedged_devices:
             logger.info(
-                "Marking device {} of user {} as wedged".format(
-                    device.device_id, device.user_id
-                )
+                f"Marking device {device.device_id} of user {device.user_id} as wedged"
             )
 
             self.wedged_devices.append(device)
@@ -1212,7 +1173,7 @@ class Olm:
 
                 logger.info(
                     "Trying to decrypt olm message using existing "
-                    "session for {} and sender_key {}".format(sender, sender_key)
+                    f"session for {sender} and sender_key {sender_key}"
                 )
 
                 plaintext = session.decrypt(message)
@@ -1230,16 +1191,16 @@ class Olm:
                 if matches:
                     logger.error(
                         "Found matching session yet decryption "
-                        "failed for sender {} and "
-                        "sender key {}".format(sender, sender_key)
+                        f"failed for sender {sender} and "
+                        f"sender key {sender_key}"
                     )
                     raise EncryptionError("Decryption failed for matching session")
 
                 # Decryption failed, we'll try another session in the next
                 # iteration.
                 logger.info(
-                    "Error decrypting olm message from {} "
-                    "and sender key {}: {}".format(sender, sender_key, str(e))
+                    f"Error decrypting olm message from {sender} "
+                    f"and sender key {sender_key}: {e}"
                 )
 
         return None
@@ -1278,14 +1239,11 @@ class Olm:
         content = payload["content"]
 
         if event.algorithm != "m.megolm.v1.aes-sha2":
-            logger.error(
-                "Error: unsupported room key of type {}".format(event.algorithm)
-            )
+            logger.error(f"Error: unsupported room key of type {event.algorithm}")
             return event
 
         logger.info(
-            "Received new group session key for room {} "
-            "from {}".format(event.room_id, sender)
+            f"Received new group session key for room {event.room_id} from {sender}"
         )
 
         sender_fp_key = payload["keys"].get("ed25519", None)
@@ -1319,9 +1277,7 @@ class Olm:
 
         if event.algorithm != "m.megolm.v1.aes-sha2":
             logger.error(
-                "Error: unsupported forwarded room key of type {}".format(
-                    event.algorithm
-                )
+                f"Error: unsupported forwarded room key of type {event.algorithm}"
             )
             return None
 
@@ -1381,9 +1337,7 @@ class Olm:
     ):
         # type: (...) -> DecryptedOlmT
         logger.info(
-            "Received Olm event of type: {} from {} {}".format(
-                payload["type"], sender, sender_key
-            )
+            f"Received Olm event of type: {payload['type']} from {sender} {sender_key}"
         )
 
         if payload["type"] == "m.room_key":
@@ -1397,9 +1351,7 @@ class Olm:
             return DummyEvent.from_dict(payload, sender, sender_key)
 
         else:
-            logger.warn(
-                "Received unsupported Olm event of type {}".format(payload["type"])
-            )
+            logger.warn(f"Received unsupported Olm event of type {payload['type']}")
             return None
 
     def message_index_ok(self, message_index, event):
@@ -1510,7 +1462,7 @@ class Olm:
         if not session:
             message = (
                 "Error decrypting megolm event, no session found "
-                "with session id {} for room {}".format(event.session_id, room_id)
+                f"with session id {event.session_id} for room {room_id}"
             )
             self.check_if_wedged(event)
             logger.warn(message)
@@ -1519,14 +1471,14 @@ class Olm:
         try:
             plaintext, message_index = session.decrypt(event.ciphertext)
         except OlmGroupSessionError as e:
-            message = "Error decrypting megolm event: {}".format(str(e))
+            message = f"Error decrypting megolm event: {str(e)}"
             logger.warn(message)
             raise EncryptionError(message)
 
         if not self.message_index_ok(message_index, event):
             raise EncryptionError(
-                "Duplicate message index, possible replay attack from {} {} "
-                "{}".format(event.sender, event.sender_key, event.session_id)
+                f"Duplicate message index, possible replay attack from "
+                f"{event.sender} {event.sender_key} {event.session_id}"
             )
 
         # If the message is from our own session mark it as verified
@@ -1555,19 +1507,18 @@ class Olm:
                         or device.curve25519 != event.sender_key
                     ):
                         message = (
-                            "Device keys mismatch in event sent "
-                            "by device {}.".format(device.id)
+                            f"Device keys mismatch in event sent by device {device.id}."
                         )
                         logger.warn(message)
                         raise EncryptionError(message)
 
-                    logger.info("Event {} successfully verified".format(event.event_id))
+                    logger.info(f"Event {event.event_id} successfully verified")
                     verified = True
 
         try:
             parsed_dict = json.loads(plaintext)  # type: Dict[Any, Any]
         except JSONDecodeError as e:
-            raise EncryptionError("Error parsing payload: {}".format(str(e)))
+            raise EncryptionError(f"Error parsing payload: {str(e)}")
 
         bad = validate_or_badevent(parsed_dict, Schemas.room_megolm_decrypted)
 
@@ -1609,7 +1560,7 @@ class Olm:
         room_id=None,  # type: str
     ):
         # type: (...) -> Union[Event, RoomKeyEvent, BadEventType, None]
-        logger.debug("Decrypting event of type {}".format(type(event).__name__))
+        logger.debug(f"Decrypting event of type {type(event).__name__}")
         if isinstance(event, OlmEvent):
             try:
                 own_key = self.account.identity_keys["curve25519"]
@@ -1623,9 +1574,7 @@ class Olm:
             elif own_ciphertext["type"] == 1:
                 message = OlmMessage(own_ciphertext["body"])
             else:
-                logger.warn(
-                    "Unsupported olm message type: {}".format(own_ciphertext["type"])
-                )
+                logger.warn(f"Unsupported olm message type: {own_ciphertext['type']}")
                 return None
 
             return self.decrypt(event.sender, event.sender_key, message)
@@ -1676,8 +1625,7 @@ class Olm:
                 self.save_session(sender_key, s)
             except OlmSessionError as e:
                 logger.error(
-                    "Failed to create new session from prekey"
-                    "message: {}".format(str(e))
+                    f"Failed to create new session from prekeymessage: {str(e)}"
                 )
                 self._mark_device_for_unwedging(sender, sender_key)
                 return None
@@ -1693,7 +1641,7 @@ class Olm:
             parsed_payload = json.loads(plaintext)
         except JSONDecodeError as e:
             # Failed parsing the payload, return early.
-            logger.error("Failed to parse Olm message payload: {}".format(str(e)))
+            logger.error(f"Failed to parse Olm message payload: {str(e)}")
             return None
 
         # Validate the payload, check that it contains all required keys as
@@ -1706,8 +1654,7 @@ class Olm:
             # Something is wrong with the payload log an error and return
             # early.
             logger.error(
-                "Error validating decrypted Olm event from {}"
-                ": {}".format(sender, str(e.message))
+                f"Error validating decrypted Olm event from {sender}: {str(e.message)}"
             )
             return None
 
@@ -1728,7 +1675,7 @@ class Olm:
             return self._handle_olm_event(sender, sender_key, parsed_payload)
 
     def rotate_outbound_group_session(self, room_id):
-        logger.info("Rotating outbound group session for room {}".format(room_id))
+        logger.info(f"Rotating outbound group session for room {room_id}")
         self.create_outbound_group_session(room_id)
 
     def should_share_group_session(self, room_id: str) -> bool:
@@ -1760,9 +1707,7 @@ class Olm:
             session = self.outbound_group_sessions[room_id]
 
         if not session.shared:
-            raise GroupEncryptionError(
-                "Group session for room {} not " "shared.".format(room_id)
-            )
+            raise GroupEncryptionError(f"Group session for room {room_id} not shared.")
 
         plaintext_dict["room_id"] = room_id
         ciphertext = session.encrypt(Api.to_json(plaintext_dict))
@@ -1780,7 +1725,7 @@ class Olm:
     def share_group_session_parallel(
         self, room_id: str, users: List[str], ignore_unverified_devices: bool = False
     ) -> Iterator[Tuple[Set[Tuple[str, str]], Dict[str, Any]]]:
-        logger.info("Sharing group session for room {}".format(room_id))
+        logger.info(f"Sharing group session for room {room_id}")
 
         if room_id not in self.outbound_group_sessions:
             self.create_outbound_group_session(room_id)
@@ -1871,7 +1816,7 @@ class Olm:
         ignore_unverified_devices=False,  # type: bool
     ):
         # type: (...) -> Tuple[Set[Tuple[str, str]], Dict[str, Any]]
-        logger.info("Sharing group session for room {}".format(room_id))
+        logger.info(f"Sharing group session for room {room_id}")
         if room_id not in self.outbound_group_sessions:
             self.create_outbound_group_session(room_id)
 
@@ -1920,8 +1865,7 @@ class Olm:
                         continue
                     else:
                         raise EncryptionError(
-                            "Missing Olm session for user {}"
-                            " and device {}".format(user_id, device.id)
+                            f"Missing Olm session for user {user_id} and device {device.id}"
                         )
 
                 if not self.is_device_verified(device):
@@ -1932,10 +1876,7 @@ class Olm:
                     else:
                         raise OlmUnverifiedDeviceError(
                             device,
-                            "Device {} for user {} is not "
-                            "verified or blacklisted.".format(
-                                device.id, device.user_id
-                            ),
+                            f"Device {device.id} for user {device.user_id} is not verified or blacklisted.",
                         )
 
                 user_map.append((user_id, device, session))
@@ -2009,7 +1950,7 @@ class Olm:
         except (KeyError, ValueError):
             return False
 
-        key_id = "ed25519:{}".format(device_id)
+        key_id = f"ed25519:{device_id}"
         try:
             signature_base64 = signatures[user_id][key_id]
         except KeyError:
@@ -2072,7 +2013,7 @@ class Olm:
 
         Olm.export_keys_static(inbound_group_store, outfile, passphrase, count)
 
-        logger.info("Successfully exported encryption keys to {}".format(outfile))
+        logger.info(f"Successfully exported encryption keys to {outfile}")
 
     @staticmethod
     def _import_group_session(
@@ -2087,7 +2028,7 @@ class Olm:
                 forwarding_chain,
             )
         except OlmSessionError as e:
-            logger.warn("Error importing inbound group session: {}".format(e))
+            logger.warn(f"Error importing inbound group session: {e}")
             return None
 
     @staticmethod
@@ -2103,13 +2044,13 @@ class Olm:
         try:
             session_list = json.loads(data)
         except JSONDecodeError as e:
-            raise EncryptionError("Error parsing key file: {}".format(str(e)))
+            raise EncryptionError(f"Error parsing key file: {str(e)}")
 
         try:
             validate_json(session_list, Schemas.megolm_key_import)
         except (ValidationError, SchemaError) as e:
             logger.warning(e)
-            raise EncryptionError("Error parsing key file: {}".format(str(e)))
+            raise EncryptionError(f"Error parsing key file: {str(e)}")
 
         for session_dict in session_list:
             if session_dict["algorithm"] != Olm._megolm_algorithm:
@@ -2150,7 +2091,7 @@ class Olm:
             if self.inbound_group_store.add(session):
                 self.save_inbound_group_session(session)
 
-        logger.info("Successfully imported encryption keys from {}".format(infile))
+        logger.info(f"Successfully imported encryption keys from {infile}")
 
     def clear_verifications(self):
         """Remove canceled or done key verifications from our cache.
@@ -2219,15 +2160,13 @@ class Olm:
         """Receive key verification events."""
         if isinstance(event, KeyVerificationStart):
             logger.info(
-                "Received key verification start event from "
-                "{} {} {}".format(event.sender, event.from_device, event.transaction_id)
+                f"Received key verification start event from {event.sender} {event.from_device} {event.transaction_id}"
             )
             try:
                 device = self.device_store[event.sender][event.from_device]
             except KeyError:
                 logger.warn(
-                    "Received key verification event from unknown "
-                    "device: {} {}".format(event.sender, event.from_device)
+                    f"Received key verification event from unknown device: {event.sender} {event.from_device}"
                 )
                 self.users_for_key_query.add(event.sender)
                 return
@@ -2242,8 +2181,7 @@ class Olm:
 
             if new_sas.canceled:
                 logger.warn(
-                    "Received malformed key verification event from "
-                    "{} {}".format(event.sender, event.from_device)
+                    f"Received malformed key verification event from {event.sender} {event.from_device}"
                 )
                 message = new_sas.get_cancellation()
                 self.outgoing_to_device_messages.append(message)
@@ -2256,19 +2194,15 @@ class Olm:
                         "Found an active verification process for the "
                         "same user/device combination, "
                         "canceling the old one. "
-                        "Old Sas: {} {} {}".format(
-                            event.sender, event.from_device, old_sas.transaction_id
-                        )
+                        f"Old Sas: {event.sender} {event.from_device} {old_sas.transaction_id}"
                     )
                     old_sas.cancel()
                     cancel_message = old_sas.get_cancellation()
                     self.outgoing_to_device_messages.append(cancel_message)
 
                 logger.info(
-                    "Successfully started key verification with "
-                    "{} {} {}".format(
-                        event.sender, event.from_device, new_sas.transaction_id
-                    )
+                    f"Successfully started key verification with "
+                    f"{event.sender} {event.from_device} {new_sas.transaction_id}"
                 )
                 self.key_verifications[event.transaction_id] = new_sas
 
@@ -2278,7 +2212,7 @@ class Olm:
             if not sas:
                 logger.warn(
                     "Received key verification event with an unknown "
-                    "transaction id from {}".format(event.sender)
+                    f"transaction id from {event.sender}"
                 )
                 return
 
@@ -2289,10 +2223,8 @@ class Olm:
                     message = sas.get_cancellation()
                 else:
                     logger.info(
-                        "Received a key verification accept event "
-                        "from {} {}, sharing keys {}".format(
-                            event.sender, sas.other_olm_device.id, sas.transaction_id
-                        )
+                        f"Received a key verification accept event from {event.sender} "
+                        f"{sas.other_olm_device.id}, sharing keys {sas.transaction_id}"
                     )
                     message = sas.share_key()
 
@@ -2300,10 +2232,8 @@ class Olm:
 
             elif isinstance(event, KeyVerificationCancel):
                 logger.info(
-                    "Received a key verification cancellation "
-                    "from {} {}. Canceling verification {}.".format(
-                        event.sender, sas.other_olm_device.id, sas.transaction_id
-                    )
+                    f"Received a key verification cancellation from {event.sender} "
+                    f"{sas.other_olm_device.id}. Canceling verification {sas.transaction_id}."
                 )
                 sas = self.key_verifications.pop(event.transaction_id, None)
 
@@ -2318,10 +2248,8 @@ class Olm:
                     to_device_message = sas.get_cancellation()
                 else:
                     logger.info(
-                        "Received a key verification pubkey "
-                        "from {} {} {}.".format(
-                            event.sender, sas.other_olm_device.id, sas.transaction_id
-                        )
+                        f"Received a key verification pubkey from {event.sender} "
+                        f"{sas.other_olm_device.id} {sas.transaction_id}."
                     )
 
                 if not sas.we_started_it and not sas.canceled:
@@ -2338,18 +2266,14 @@ class Olm:
                     return
 
                 logger.info(
-                    "Received a valid key verification MAC "
-                    "from {} {} {}.".format(
-                        event.sender, sas.other_olm_device.id, event.transaction_id
-                    )
+                    f"Received a valid key verification MAC from {event.sender} "
+                    f"{sas.other_olm_device.id} {event.transaction_id}."
                 )
 
                 if sas.verified:
                     logger.info(
-                        "Interactive key verification successful, "
-                        "verifying device {} of user {} {}.".format(
-                            sas.other_olm_device.id, event.sender, event.transaction_id
-                        )
+                        "Interactive key verification successful, verifying device "
+                        f"{sas.other_olm_device.id} of user {event.sender} {event.transaction_id}."
                     )
                     device = sas.other_olm_device
                     self.verify_device(device)

--- a/nio/crypto/sas.py
+++ b/nio/crypto/sas.py
@@ -523,7 +523,7 @@ class Sas(olm.Sas):
                 "SAS verification was canceled, can't " "generate MAC."
             )
 
-        key_id = "ed25519:{}".format(self.own_device)
+        key_id = f"ed25519:{self.own_device}"
 
         assert self.chosen_mac_method
         if self.chosen_mac_method == self._mac_normal:
@@ -533,14 +533,8 @@ class Sas(olm.Sas):
 
         info = (
             "MATRIX_KEY_VERIFICATION_MAC"
-            "{first_user}{first_device}"
-            "{second_user}{second_device}{transaction_id}".format(
-                first_user=self.own_user,
-                first_device=self.own_device,
-                second_user=self.other_olm_device.user_id,
-                second_device=self.other_olm_device.id,
-                transaction_id=self.transaction_id,
-            )
+            f"{self.own_user}{self.own_device}"
+            f"{self.other_olm_device.user_id}{self.other_olm_device.id}{self.transaction_id}"
         )
 
         mac = {key_id: calculate_mac(self.own_fp_key, info + key_id)}
@@ -681,15 +675,8 @@ class Sas(olm.Sas):
             return
 
         info = (
-            "MATRIX_KEY_VERIFICATION_MAC"
-            "{first_user}{first_device}"
-            "{second_user}{second_device}{transaction_id}".format(
-                first_user=self.other_olm_device.user_id,
-                first_device=self.other_olm_device.id,
-                second_user=self.own_user,
-                second_device=self.own_device,
-                transaction_id=self.transaction_id,
-            )
+            f"MATRIX_KEY_VERIFICATION_MAC{self.other_olm_device.user_id}{self.other_olm_device.id}"
+            f"{self.own_user}{self.own_device}{self.transaction_id}"
         )
 
         key_ids = ",".join(sorted(event.mac.keys()))

--- a/nio/event_builders/state_events.py
+++ b/nio/event_builders/state_events.py
@@ -84,7 +84,7 @@ class ChangeNameBuilder(EventBuilder):
     def __post_init__(self):
         if len(self.name) > 255:
             raise ValueError(
-                "Room names exceeds 255 characters: {}".format(self.name),
+                f"Room names exceeds 255 characters: {self.name}",
             )
 
     def as_dict(self):

--- a/nio/events/misc.py
+++ b/nio/events/misc.py
@@ -36,7 +36,7 @@ def validate_or_badevent(
     try:
         validate_json(parsed_dict, schema)
     except (ValidationError, SchemaError) as e:
-        logger.warn("Error validating event: {}".format(str(e)))
+        logger.warn(f"Error validating event: {str(e)}")
         try:
             return BadEvent.from_dict(parsed_dict)
         except KeyError:
@@ -71,7 +71,7 @@ def verify_or_none(schema):
             try:
                 validate_json(event_dict, schema)
             except (ValidationError, SchemaError) as e:
-                logger.error("Error validating event: {}".format(str(e)))
+                logger.error(f"Error validating event: {str(e)}")
                 return None
 
             return f(*args, **kwargs)
@@ -163,7 +163,7 @@ class BadEvent:
     transaction_id: Optional[str] = field(default=None, init=False)
 
     def __str__(self):
-        return "Bad event of type {}, from {}.".format(self.type, self.sender)
+        return f"Bad event of type {self.type}, from {self.sender}."
 
     @classmethod
     def from_dict(cls, parsed_dict):

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -576,10 +576,8 @@ class RedactedEvent(Event):
     reason: Optional[str] = field()
 
     def __str__(self):
-        reason = ", reason: {}".format(self.reason) if self.reason else ""
-        return "Redacted event of type {}, by {}{}.".format(
-            self.type, self.redacter, reason
-        )
+        reason = f", reason: {self.reason}" if self.reason else ""
+        return f"Redacted event of type {self.type}, by {self.redacter}{reason}."
 
     @property
     def event_type(self):
@@ -1062,7 +1060,7 @@ class RoomMessageFormatted(RoomMessage):
 
     def __str__(self):
         # type: () -> str
-        return "{}: {}".format(self.sender, self.body)
+        return f"{self.sender}: {self.body}"
 
     @staticmethod
     def _validate(parsed_dict):

--- a/nio/events/to_device.py
+++ b/nio/events/to_device.py
@@ -117,8 +117,7 @@ class ToDeviceEvent:
             return OlmEvent.from_dict(event_dict)
 
         logger.warn(
-            "Received an encrypted event with an unknown "
-            "algorithm {}.".format(content["algorithm"])
+            f"Received an encrypted event with an unknown algorithm {content['algorithm']}."
         )
 
         return None

--- a/nio/http.py
+++ b/nio/http.py
@@ -82,8 +82,8 @@ class HttpRequest(TransportRequest):
     def _headers(host, data=None):
         # type (str, bytes) -> List[Tuple[str, str]]
         headers = [
-            ("User-Agent", "{agent}".format(agent=USER_AGENT)),
-            ("Host", "{host}".format(host=host)),
+            ("User-Agent", f"{USER_AGENT}"),
+            ("Host", f"{host}"),
             ("Connection", "keep-alive"),
             ("Accept", "*/*"),
         ]
@@ -91,7 +91,7 @@ class HttpRequest(TransportRequest):
         if data:
             headers.append(("Content-Type", "application/json"))
 
-            headers.append(("Content-length", "{length}".format(length=len(data))))
+            headers.append(("Content-length", f"{len(data)}"))
 
         return headers
 
@@ -135,9 +135,9 @@ class Http2Request(TransportRequest):
     def _headers(host, data=None):
         # type (str, bytes) -> List[Tuple[str, str]]
         headers = [
-            (":authority", "{host}".format(host=host)),
+            (":authority", f"{host}"),
             (":scheme", "https"),
-            ("user-agent", "{agent}".format(agent=USER_AGENT)),
+            ("user-agent", f"{USER_AGENT}"),
         ]
 
         headers.append(("accept", "application/json"))
@@ -145,7 +145,7 @@ class Http2Request(TransportRequest):
         if data:
             headers.append(("content-type", "application/json"))
 
-            headers.append(("content-length", "{length}".format(length=len(data))))
+            headers.append(("content-length", f"{len(data)}"))
 
         return headers
 
@@ -253,7 +253,7 @@ class HttpResponse(TransportResponse):
             name, value = header
             name = name.decode("utf-8")
             value = value.decode("utf-8")
-            logger.debug("Got http header {}: {}".format(name, value))
+            logger.debug(f"Got http header {name}: {value}")
             self.headers[name] = value
 
 
@@ -267,7 +267,7 @@ class Http2Response(TransportResponse):
         # type: (h2.events.ResponseReceived) -> None
         for header in headers:
             name, value = header
-            logger.debug("Got http2 header {}: {}".format(name, value))
+            logger.debug(f"Got http2 header {name}: {value}")
 
             if name == b":status" or name == ":status":
                 self.status_code = int(value)
@@ -434,10 +434,8 @@ class Http2Connection(Connection):
 
         bytes_to_send = min(window_size, request_size)
         logger.debug(
-            "Sending data: stream id: {}; request size: {}; "
-            "window size: {}; max frame size {}".format(
-                stream_id, request_size, window_size, max_frame_size
-            )
+            f"Sending data: stream id: {stream_id}; request size: {request_size}; "
+            f"window size: {window_size}; max frame size {max_frame_size}"
         )
 
         while bytes_to_send > 0:
@@ -463,13 +461,11 @@ class Http2Connection(Connection):
             raise TypeError("Invalid request type for HttpConnection")
 
         logger.debug(
-            "Making Http2 request {} {}.".format(
-                pprint.pformat(request._request), pprint.pformat(request._data)
-            )
+            f"Making Http2 request {pprint.pformat(request._request)} {pprint.pformat(request._data)}."
         )
 
         stream_id = self._connection.get_next_available_stream_id()
-        logger.debug("New stream id {}".format(stream_id))
+        logger.debug(f"New stream id {stream_id}")
 
         self._connection.send_headers(stream_id, request._request)
         self._send_data(stream_id, request._data)
@@ -531,7 +527,7 @@ class Http2Connection(Connection):
     def _handle_events(self, events):
         # type: (h2.events.Event) -> Optional[Http2Response]
         for event in events:
-            logger.info("Handling Http2 event: {}".format(repr(event)))
+            logger.info(f"Handling Http2 event: {repr(event)}")
 
             if isinstance(event, h2.events.ResponseReceived):
                 self._handle_response(event)

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -322,9 +322,7 @@ class FileResponse(Response):
     filename: Optional[str] = field()
 
     def __str__(self):
-        return "{} bytes, content type: {}, filename: {}".format(
-            len(self.body), self.content_type, self.filename
-        )
+        return f"{len(self.body)} bytes, content type: {self.content_type}, filename: {self.filename}"
 
     @classmethod
     def from_data(cls, data, content_type, filename=None):
@@ -347,18 +345,18 @@ class ErrorResponse(Response):
 
     def __str__(self) -> str:
         if self.status_code and self.message:
-            e = "{} {}".format(self.status_code, self.message)
+            e = f"{self.status_code} {self.message}"
         elif self.message:
             e = self.message
         elif self.status_code:
-            e = "{} unknown error".format(self.status_code)
+            e = f"{self.status_code} unknown error"
         else:
             e = "unknown error"
 
         if self.retry_after_ms:
-            e = "{} - retry after {}ms".format(e, self.retry_after_ms)
+            e = f"{e} - retry after {self.retry_after_ms}ms"
 
-        return "{}: {}".format(self.__class__.__name__, e)
+        return f"{self.__class__.__name__}: {e}"
 
     @classmethod
     def from_dict(cls, parsed_dict: Dict[Any, Any]):
@@ -676,10 +674,7 @@ class RegisterResponse(Response):
     access_token: str = field()
 
     def __str__(self) -> str:
-        return "Registered {}, device id {}.".format(
-            self.user_id,
-            self.device_id,
-        )
+        return f"Registered {self.user_id}, device id {self.device_id}."
 
     @classmethod
     @verify(Schemas.register, RegisterErrorResponse)
@@ -715,7 +710,7 @@ class LoginResponse(Response):
     access_token: str = field()
 
     def __str__(self) -> str:
-        return "Logged in as {}, device id: {}.".format(self.user_id, self.device_id)
+        return f"Logged in as {self.user_id}, device id: {self.device_id}."
 
     @classmethod
     @verify(Schemas.login, LoginError)
@@ -1439,11 +1434,7 @@ class ProfileGetResponse(Response):
     other_info: Dict[Any, Any] = field(default_factory=dict)
 
     def __str__(self) -> str:
-        return "Display name: {}, avatar URL: {}, other info: {}".format(
-            self.displayname,
-            self.avatar_url,
-            self.other_info,
-        )
+        return f"Display name: {self.displayname}, avatar URL: {self.avatar_url}, other info: {self.other_info}"
 
     @classmethod
     @verify(Schemas.get_profile, ProfileGetError)
@@ -1472,7 +1463,7 @@ class ProfileGetDisplayNameResponse(Response):
     displayname: Optional[str] = None
 
     def __str__(self) -> str:
-        return "Display name: {}".format(self.displayname)
+        return f"Display name: {self.displayname}"
 
     @classmethod
     @verify(Schemas.get_displayname, ProfileGetDisplayNameError)
@@ -1502,7 +1493,7 @@ class ProfileGetAvatarResponse(Response):
     avatar_url: Optional[str] = None
 
     def __str__(self) -> str:
-        return "Avatar URL: {}".format(self.avatar_url)
+        return f"Avatar URL: {self.avatar_url}"
 
     @classmethod
     @verify(Schemas.get_avatar, ProfileGetAvatarError)
@@ -1668,7 +1659,7 @@ class SyncResponse(Response):
     def __str__(self) -> str:
         result = []
         for room_id, room_info in self.rooms.join.items():
-            room_header = "  Messages for room {}:\n    ".format(room_id)
+            room_header = f"  Messages for room {room_id}:\n    "
             messages = []
             for event in room_info.timeline.events:
                 messages.append(str(event))
@@ -1679,7 +1670,7 @@ class SyncResponse(Response):
         if len(self.to_device_events) > 0:
             result.append("  Device messages:")
             for event in self.to_device_events:
-                result.append("    {}".format(event))
+                result.append(f"    {event}")
 
         body = "\n".join(result)
         string = ("Sync response until batch: {}:\n{}").format(self.next_batch, body)

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -127,17 +127,13 @@ class MatrixRoom:
         names = [self.user_name(u) or u for u in user_ids]
 
         if others:
-            text = "{} and {} other{}".format(
-                ", ".join(names),
-                others,
-                "" if others == 1 else "s",
-            )
+            text = f"{', '.join(names)} and {others} other{'' if others == 1 else 's'}"
         elif len(names) == 0:
             text = ""
         elif len(names) == 1:
             text = names[0]
         else:
-            text = "{} and {}".format(", ".join(names[:-1]), names[-1])
+            text = f"{', '.join(names[:-1])} and {names[-1]}"
 
         if empty and text:
             text = f"Empty Room (had {text})"
@@ -368,9 +364,7 @@ class MatrixRoom:
 
     def handle_event(self, event: Event) -> None:
         logger.info(
-            "Room {} handling event of type {}".format(
-                self.room_id, type(event).__name__
-            )
+            f"Room {self.room_id} handling event of type {type(event).__name__}"
         )
 
         if isinstance(event, RoomCreateEvent):
@@ -412,8 +406,7 @@ class MatrixRoom:
             for user_id, level in self.power_levels.users.items():
                 if user_id in self.users:
                     logger.info(
-                        "Changing power level for user {} from {} to "
-                        "{}".format(user_id, self.users[user_id].power_level, level)
+                        f"Changing power level for user {user_id} from {self.users[user_id].power_level} to {level}"
                     )
                     self.users[user_id].power_level = level
 
@@ -510,9 +503,7 @@ class MatrixInvitedRoom(MatrixRoom):
 
     def handle_event(self, event: Event) -> None:
         logger.info(
-            "Room {} handling event of type {}".format(
-                self.room_id, type(event).__name__
-            )
+            f"Room {self.room_id} handling event of type {type(event).__name__}"
         )
 
         if isinstance(event, InviteMemberEvent):
@@ -558,7 +549,5 @@ class MatrixUser:
     def disambiguated_name(self) -> str:
         # as per https://matrix.org/docs/spec/client_server/r0.4.0.html#id346
         if self.display_name:
-            return "{name} ({user_id})".format(
-                name=self.display_name, user_id=self.user_id
-            )
+            return f"{self.display_name} ({self.user_id})"
         return self.user_id

--- a/nio/store/database.py
+++ b/nio/store/database.py
@@ -132,9 +132,7 @@ class MatrixStore:
         self._update_version(2)
 
     def __post_init__(self):
-        self.database_name = self.database_name or "{}_{}.db".format(
-            self.user_id, self.device_id
-        )
+        self.database_name = self.database_name or f"{self.user_id}_{self.device_id}.db"
         self.database_path = os.path.join(self.store_path, self.database_name)
         self.database = self._create_database()
         self.database.connect()
@@ -637,15 +635,13 @@ class DefaultStore(MatrixStore):
     def __post_init__(self):
         super().__post_init__()
 
-        trust_file_path = "{}_{}.trusted_devices".format(self.user_id, self.device_id)
+        trust_file_path = f"{self.user_id}_{self.device_id}.trusted_devices"
         self.trust_db = KeyStore(os.path.join(self.store_path, trust_file_path))
 
-        blacklist_file_path = "{}_{}.blacklisted_devices".format(
-            self.user_id, self.device_id
-        )
+        blacklist_file_path = f"{self.user_id}_{self.device_id}.blacklisted_devices"
         self.blacklist_db = KeyStore(os.path.join(self.store_path, blacklist_file_path))
 
-        ignore_file_path = "{}_{}.ignored_devices".format(self.user_id, self.device_id)
+        ignore_file_path = f"{self.user_id}_{self.device_id}.ignored_devices"
         self.ignore_db = KeyStore(os.path.join(self.store_path, ignore_file_path))
 
     def blacklist_device(self, device):
@@ -949,7 +945,7 @@ class SqliteStore(MatrixStore):
                 "JOIN accounts ON devicekeys.account_id=accounts.id "
                 "WHERE accounts.id == ? AND "
                 "(devicekeys.user_id, devicekeys.device_id) IN "
-                "(VALUES {})".format(",".join(["(?, ?)"] * (len(data) // 2)))
+                f"(VALUES {','.join(['(?, ?)'] * (len(data) // 2))})"
             )
 
             query = DeviceKeys.raw(query_string, account.id, *data)

--- a/nio/store/file_trustdb.py
+++ b/nio/store/file_trustdb.py
@@ -40,11 +40,9 @@ class Key:
         if isinstance(self, Ed25519Key):
             key_type = "matrix-ed25519"
         else:  # pragma: no cover
-            raise NotImplementedError("Invalid key type {}".format(type(self.key)))
+            raise NotImplementedError(f"Invalid key type {type(self.key)}")
 
-        line = "{} {} {} {}\n".format(
-            self.user_id, self.device_id, key_type, str(self.key)
-        )
+        line = f"{self.user_id} {self.device_id} {key_type} {str(self.key)}\n"
         return line
 
     @classmethod
@@ -82,7 +80,7 @@ class KeyStore:
             yield entry
 
     def __repr__(self) -> str:
-        return "KeyStore object, file: {}".format(self._filename)
+        return f"KeyStore object, file: {self._filename}"
 
     def _load(self, filename: str):
         try:
@@ -140,10 +138,8 @@ class KeyStore:
             ):
                 if existing_key.key != key.key:
                     message = (
-                        "Error: adding existing device to trust store "
-                        "with mismatching fingerprint {} {}".format(
-                            key.key, existing_key.key
-                        )
+                        f"Error: adding existing device to trust store with "
+                        f"mismatching fingerprint {key.key} {existing_key.key}"
                     )
                     logger.error(message)
                     raise OlmTrustError(message)

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -767,9 +767,7 @@ class TestClass:
         assert async_client.logged_in
 
         aioresponse.get(
-            "https://example.org/_matrix/client/r0/sync?access_token={}".format(
-                async_client.access_token
-            ),
+            f"https://example.org/_matrix/client/r0/sync?access_token={async_client.access_token}",
             status=200,
             payload=self.sync_response,
         )
@@ -962,8 +960,7 @@ class TestClass:
             payload={"event_id": "$1555:example.org"},
         )
         aioresponse.get(
-            "https://example.org/_matrix/client/r0/rooms/{}/"
-            "joined_members?access_token=abc123".format(TEST_ROOM_ID),
+            f"https://example.org/_matrix/client/r0/rooms/{TEST_ROOM_ID}/joined_members?access_token=abc123",
             status=200,
             payload=self.joined_members_response,
         )
@@ -1012,12 +1009,7 @@ class TestClass:
         }
 
         aioresponse.get(
-            "{base}/rooms/{room}/event/{event_id}?{query}".format(
-                base=base_url,
-                room=TEST_ROOM_ID,
-                event_id="$15163622445EBvZJ:localhost",
-                query="access_token=abc123",
-            ),
+            f"{base_url}/rooms/{TEST_ROOM_ID}/event/$15163622445EBvZJ:localhost?access_token=abc123",
             status=200,
             payload=response,
         )
@@ -1030,12 +1022,7 @@ class TestClass:
         assert isinstance(resp.event, RoomMessageText)
 
         aioresponse.get(
-            "{base}/rooms/{room}/event/{event_id}?{query}".format(
-                base=base_url,
-                room=TEST_ROOM_ID,
-                event_id="$not-found:localhost",
-                query="access_token=abc123",
-            ),
+            f"{base_url}/rooms/{TEST_ROOM_ID}/event/$not-found:localhost?access_token=abc123",
             status=200,
             payload={"errcode": "M_NOT_FOUND", "error": "Event not found."},
         )
@@ -1055,13 +1042,7 @@ class TestClass:
         # Test when key is set
         state_key = "a-state-key"
         aioresponse.put(
-            "{base}/rooms/{room}/state/{event}/{key}?{query}".format(
-                base=base_url,
-                room=TEST_ROOM_ID,
-                event="org.example.event_type",
-                key=state_key,
-                query="access_token=abc123",
-            ),
+            f"{base_url}/rooms/{TEST_ROOM_ID}/state/org.example.event_type/{state_key}?access_token=abc123",
             status=200,
             payload={"event_id": "$1337stateeventid2342:example.org"},
         )
@@ -1077,12 +1058,7 @@ class TestClass:
 
         # Test when key is empty (and slash is optional)
         aioresponse.put(
-            "{base}/rooms/{room}/state/{event}?{query}".format(
-                base=base_url,
-                room=TEST_ROOM_ID,
-                event="org.example.event_type",
-                query="access_token=abc123",
-            ),
+            f"{base_url}/rooms/{TEST_ROOM_ID}/state/org.example.event_type?access_token=abc123",
             status=200,
             payload={"event_id": "$1337stateeventid2342:example.org"},
         )
@@ -1107,13 +1083,7 @@ class TestClass:
         # Test when state key is set
         state_key = "a-state-key"
         aioresponse.get(
-            "{base}/rooms/{room}/state/{event}/{key}?{query}".format(
-                base=base_url,
-                room=TEST_ROOM_ID,
-                event="m.room.name",
-                key=state_key,
-                query="access_token=abc123",
-            ),
+            f"{base_url}/rooms/{TEST_ROOM_ID}/state/m.room.name/{state_key}?access_token=abc123",
             status=200,
             payload={"name": "Test Room"},
         )
@@ -1125,12 +1095,7 @@ class TestClass:
 
         # without state key
         aioresponse.get(
-            "{base}/rooms/{room}/state/{event}?{query}".format(
-                base=base_url,
-                room=TEST_ROOM_ID,
-                event="m.room.name",
-                query="access_token=abc123",
-            ),
+            f"{base_url}/rooms/{TEST_ROOM_ID}/state/m.room.name?access_token=abc123",
             status=200,
             payload={"name": "Test Room"},
         )
@@ -1150,9 +1115,7 @@ class TestClass:
         base_url = "https://example.org/_matrix/client/r0"
 
         aioresponse.get(
-            "{base}/rooms/{room}/state?{query}".format(
-                base=base_url, room=TEST_ROOM_ID, query="access_token=abc123"
-            ),
+            f"{base_url}/rooms/{TEST_ROOM_ID}/state?access_token=abc123",
             status=200,
             payload=self.room_get_state_response,
         )
@@ -1270,8 +1233,7 @@ class TestClass:
         assert async_client.logged_in
 
         aioresponse.post(
-            "https://example.org/_matrix/client/r0/user/{}/openid/request_token"
-            "?access_token=abc123".format(ALICE_ID),
+            f"https://example.org/_matrix/client/r0/user/{ALICE_ID}/openid/request_token?access_token=abc123",
             status=200,
             payload=self.get_openid_token_response,
         )
@@ -1306,8 +1268,8 @@ class TestClass:
         await async_client.receive_response(resp)
 
         aioresponse.get(
-            "https://example.org/_matrix/client/r0/rooms/{}/"
-            "joined_members?access_token=abc123".format(TEST_ROOM_ID),
+            f"https://example.org/_matrix/client/r0/rooms/{TEST_ROOM_ID}/"
+            "joined_members?access_token=abc123",
             status=200,
             payload=self.joined_members_response,
         )
@@ -1462,8 +1424,7 @@ class TestClass:
         assert async_client.logged_in
 
         aioresponse.post(
-            "https://example.org/_matrix/client/r0/join/{}"
-            "?access_token=abc123".format(TEST_ROOM_ID),
+            f"https://example.org/_matrix/client/r0/join/{TEST_ROOM_ID}?access_token=abc123",
             status=200,
             payload=self.room_id_response(TEST_ROOM_ID),
         )
@@ -1479,8 +1440,7 @@ class TestClass:
         assert async_client.logged_in
 
         aioresponse.post(
-            "https://example.org/_matrix/client/r0/rooms/{}/invite"
-            "?access_token=abc123".format(TEST_ROOM_ID),
+            f"https://example.org/_matrix/client/r0/rooms/{TEST_ROOM_ID}/invite?access_token=abc123",
             status=200,
             payload={},
         )
@@ -1495,8 +1455,7 @@ class TestClass:
         assert async_client.logged_in
 
         aioresponse.post(
-            "https://example.org/_matrix/client/r0/rooms/{}/leave"
-            "?access_token=abc123".format(TEST_ROOM_ID),
+            f"https://example.org/_matrix/client/r0/rooms/{TEST_ROOM_ID}/leave?access_token=abc123",
             status=200,
             payload={},
         )
@@ -1513,8 +1472,7 @@ class TestClass:
         room_id = next(iter(async_client.rooms))
 
         aioresponse.post(
-            "https://example.org/_matrix/client/r0/rooms/{}/forget"
-            "?access_token=abc123".format(room_id),
+            f"https://example.org/_matrix/client/r0/rooms/{room_id}/forget?access_token=abc123",
             status=200,
             payload={},
         )
@@ -1592,8 +1550,7 @@ class TestClass:
         reason = "for no reason"
 
         aioresponse.put(
-            "https://example.org/_matrix/client/r0/rooms/{}/redact/{}/{}"
-            "?access_token=abc123".format(room_id, event_id, tx_id),
+            f"https://example.org/_matrix/client/r0/rooms/{room_id}/redact/{event_id}/{tx_id}?access_token=abc123",
             status=200,
             payload={"event_id": "$90813622447EBvZJ:localhost"},
         )
@@ -1609,8 +1566,7 @@ class TestClass:
 
         await async_client.receive_response(self.encryption_sync_response)
         aioresponse.get(
-            "https://example.org/_matrix/client/r0/rooms/{}/"
-            "context/{}?access_token=abc123".format(TEST_ROOM_ID, event_id),
+            f"https://example.org/_matrix/client/r0/rooms/{TEST_ROOM_ID}/context/{event_id}?access_token=abc123",
             status=200,
             payload=self.context_response,
         )
@@ -1661,8 +1617,7 @@ class TestClass:
         room_id = list(async_client.rooms.keys())[0]
 
         aioresponse.put(
-            "https://example.org/_matrix/client/r0/rooms/{}/typing/{}"
-            "?access_token=abc123".format(room_id, async_client.user_id),
+            f"https://example.org/_matrix/client/r0/rooms/{room_id}/typing/{async_client.user_id}?access_token=abc123",
             status=200,
             payload={},
         )
@@ -1740,8 +1695,7 @@ class TestClass:
         monitor = TransferMonitor(filesize)
 
         aioresponse.post(
-            "https://example.org/_matrix/media/r0/upload"
-            "?access_token=abc123&filename=test.png",
+            "https://example.org/_matrix/media/r0/upload?access_token=abc123&filename=test.png",
             status=200,
             payload=self.upload_response,
             repeat=True,
@@ -1775,8 +1729,7 @@ class TestClass:
         monitor = TransferMonitor(filesize)
 
         aioresponse.post(
-            "https://example.org/_matrix/media/r0/upload"
-            "?access_token=abc123&filename=test.png",
+            "https://example.org/_matrix/media/r0/upload?access_token=abc123&filename=test.png",
             status=200,
             payload=self.upload_response,
             repeat=True,
@@ -1823,8 +1776,7 @@ class TestClass:
         monitor = TransferMonitor(filesize)
 
         aioresponse.post(
-            "https://example.org/_matrix/media/r0/upload"
-            "?access_token=abc123&filename=test.py",
+            "https://example.org/_matrix/media/r0/upload?access_token=abc123&filename=test.py",
             status=200,
             payload=self.upload_response,
             repeat=True,
@@ -1873,15 +1825,13 @@ class TestClass:
         # We make sure to read the data in the first post response to verify
         # that we can read the full file in a subsequent post.
         aioresponse.post(
-            "https://example.org/_matrix/media/r0/upload"
-            "?access_token=abc123&filename=test.py",
+            "https://example.org/_matrix/media/r0/upload?access_token=abc123&filename=test.py",
             status=429,
             payload=self.limit_exceeded_error_response,
             callback=check_content,
         )
         aioresponse.post(
-            "https://example.org/_matrix/media/r0/upload"
-            "?access_token=abc123&filename=test.py",
+            "https://example.org/_matrix/media/r0/upload?access_token=abc123&filename=test.py",
             status=200,
             payload=self.upload_response,
             callback=check_content,
@@ -1912,15 +1862,13 @@ class TestClass:
         monitor = TransferMonitor(filesize)
 
         aioresponse.post(
-            "https://example.org/_matrix/media/r0/upload"
-            "?access_token=abc123&filename=test.png",
+            "https://example.org/_matrix/media/r0/upload?access_token=abc123&filename=test.png",
             status=429,
             payload=self.limit_exceeded_error_response,
         )
 
         aioresponse.post(
-            "https://example.org/_matrix/media/r0/upload"
-            "?access_token=abc123&filename=test.png",
+            "https://example.org/_matrix/media/r0/upload?access_token=abc123&filename=test.png",
             status=200,
             payload=self.upload_response,
             repeat=True,
@@ -2145,11 +2093,7 @@ class TestClass:
         filename = "example&.png"  # has unsafe character to test % encoding
 
         aioresponse.get(
-            "https://example.org/_matrix/media/r0/download/{}/{}"
-            "?allow_remote=true".format(
-                server_name,
-                media_id,
-            ),
+            f"https://example.org/_matrix/media/r0/download/{server_name}/{media_id}?allow_remote=true",
             status=200,
             content_type="image/png",
             body=self.file_response,
@@ -2160,15 +2104,10 @@ class TestClass:
         assert resp.filename is None
 
         aioresponse.get(
-            "https://example.org/_matrix/media/r0/download/{}/{}/{}"
-            "?allow_remote=true".format(
-                server_name,
-                media_id,
-                filename,
-            ),
+            f"https://example.org/_matrix/media/r0/download/{server_name}/{media_id}/{filename}?allow_remote=true",
             status=200,
             content_type="image/png",
-            headers={"content-disposition": 'inline; filename="{}"'.format(filename)},
+            headers={"content-disposition": f'inline; filename="{filename}"'},
             body=self.file_response,
         )
         resp = await async_client.download(server_name, media_id, filename)
@@ -2179,11 +2118,7 @@ class TestClass:
         async_client.config = AsyncClientConfig(max_limit_exceeded=0)
 
         aioresponse.get(
-            "https://example.org/_matrix/media/r0/download/{}/{}"
-            "?allow_remote=true".format(
-                server_name,
-                media_id,
-            ),
+            f"https://example.org/_matrix/media/r0/download/{server_name}/{media_id}?allow_remote=true",
             status=429,
             content_type="application/json",
             body=b'{"errcode": "M_LIMIT_EXCEEDED", "retry_after_ms": 1}',
@@ -2200,14 +2135,8 @@ class TestClass:
         method = ResizingMethod.crop
 
         aioresponse.get(
-            "https://example.org/_matrix/media/r0/thumbnail/{}/{}"
-            "?width={}&height={}&method={}&allow_remote=true".format(
-                server_name,
-                media_id,
-                width,
-                height,
-                method.value,
-            ),
+            f"https://example.org/_matrix/media/r0/thumbnail/{server_name}/{media_id}"
+            f"?width={width}&height={height}&method={method.value}&allow_remote=true",
             status=200,
             content_type="image/png",
             body=self.file_response,
@@ -2221,14 +2150,8 @@ class TestClass:
         async_client.config = AsyncClientConfig(max_limit_exceeded=0)
 
         aioresponse.get(
-            "https://example.org/_matrix/media/r0/thumbnail/{}/{}"
-            "?width={}&height={}&method={}&allow_remote=true".format(
-                server_name,
-                media_id,
-                width,
-                height,
-                method.value,
-            ),
+            f"https://example.org/_matrix/media/r0/thumbnail/{server_name}/{media_id}"
+            f"?width={width}&height={height}&method={method.value}&allow_remote=true",
             status=429,
             content_type="application/json",
             body=b'{"errcode": "M_LIMIT_EXCEEDED", "retry_after_ms": 1}',
@@ -2293,7 +2216,7 @@ class TestClass:
         async_client.user_id = ALICE_ID
 
         aioresponse.get(
-            "{}/profile/{}".format(base_url, async_client.user_id),
+            f"{base_url}/profile/{async_client.user_id}",
             status=200,
             payload=self.get_profile_response(name, avatar),
         )
@@ -2313,14 +2236,14 @@ class TestClass:
         avatar = faker.avatar_url().replace("#auto", "")
 
         base_url = "https://example.org/_matrix/client/r0"
-        url = "{}/profile/{}".format(base_url, user_id)
+        url = f"{base_url}/profile/{user_id}"
 
         aioresponse.get(
             url, status=401, payload=self.get_profile_unauth_error_response()
         )
 
         aioresponse.get(
-            "{}?access_token={}".format(url, token),
+            f"{url}?access_token={token}",
             status=200,
             payload=self.get_profile_response(name, avatar),
         )
@@ -2344,9 +2267,7 @@ class TestClass:
         user_id = "@alice:example.com"
 
         aioresponse.get(
-            "https://example.org/_matrix/client/r0/presence/{}/status?access_token={}".format(
-                user_id, async_client.access_token
-            ),
+            f"https://example.org/_matrix/client/r0/presence/{user_id}/status?access_token={async_client.access_token}",
             status=200,
             payload={"presence": "unavailable", "last_active_ago": 420845},
         )
@@ -2361,9 +2282,7 @@ class TestClass:
         assert not resp.status_msg
 
         aioresponse.get(
-            "https://example.org/_matrix/client/r0/presence/{}/status?access_token={}".format(
-                user_id, async_client.access_token
-            ),
+            f"https://example.org/_matrix/client/r0/presence/{user_id}/status?access_token={async_client.access_token}",
             status=200,
             payload={
                 "presence": "online",
@@ -2390,9 +2309,8 @@ class TestClass:
         assert async_client.logged_in
 
         aioresponse.put(
-            "https://example.org/_matrix/client/r0/presence/{}/status?access_token={}".format(
-                async_client.user_id, async_client.access_token
-            ),
+            f"https://example.org/_matrix/client/r0/presence/{async_client.user_id}/"
+            f"status?access_token={async_client.access_token}",
             status=200,
             payload={},
         )
@@ -2484,9 +2402,7 @@ class TestClass:
         content = {"display_name": "My new device"}
 
         aioresponse.put(
-            "https://example.org/_matrix/client/r0/devices/{}?access_token={}".format(
-                device_id, async_client.access_token
-            ),
+            f"https://example.org/_matrix/client/r0/devices/{device_id}?access_token={async_client.access_token}",
             status=200,
             payload={},
         )
@@ -2502,9 +2418,7 @@ class TestClass:
         assert async_client.logged_in
 
         base_url = "https://example.org/_matrix/client/r0"
-        url = "{}/profile/{}/displayname?access_token={}".format(
-            base_url, async_client.user_id, async_client.access_token
-        )
+        url = f"{base_url}/profile/{async_client.user_id}/displayname?access_token={async_client.access_token}"
         aioresponse.get(url, status=200, payload=self.get_displayname_response(None))
         resp = await async_client.get_displayname()
         assert isinstance(resp, ProfileGetDisplayNameResponse)
@@ -2529,9 +2443,7 @@ class TestClass:
         assert async_client.logged_in
 
         base_url = "https://example.org/_matrix/client/r0"
-        url = "{}/profile/{}/avatar_url?access_token={}".format(
-            base_url, async_client.user_id, async_client.access_token
-        )
+        url = f"{base_url}/profile/{async_client.user_id}/avatar_url?access_token={async_client.access_token}"
 
         aioresponse.get(url, status=200, payload=self.get_avatar_response(None))
         resp = await async_client.get_avatar()
@@ -2564,8 +2476,7 @@ class TestClass:
             LoginResponse.from_dict(self.login_response)
         )
         aioresponse.delete(
-            "https://example.org/_matrix/client/r0/directory/room/%23test%3Aexample.org"
-            "?access_token={}".format(async_client.access_token),
+            f"https://example.org/_matrix/client/r0/directory/room/%23test%3Aexample.org?access_token={async_client.access_token}",
             status=200,
             payload={},
         )
@@ -2579,8 +2490,7 @@ class TestClass:
             LoginResponse.from_dict(self.login_response)
         )
         aioresponse.put(
-            "https://example.org/_matrix/client/r0/directory/room/%23test%3Aexample.org"
-            "?access_token={}".format(async_client.access_token),
+            f"https://example.org/_matrix/client/r0/directory/room/%23test%3Aexample.org?access_token={async_client.access_token}",
             status=200,
             payload={
                 "room_id": "!foobar:example.org",
@@ -4104,13 +4014,12 @@ class TestClass:
         )
 
         alice_to_device_url = re.compile(
-            r"https://example\.org/_matrix/client/r0/sendToDevice/m\.room.encrypted/[0-9]\?access_token=alice_1234",
+            r"https://example\.org/_matrix/client/r0/sendToDevice/m\.room\.encrypted/[0-9]\?access_token=alice_1234",
         )
 
         bob_room_send_url = re.compile(
-            r"https://example\.org/_matrix/client/r0/rooms/{}/send/m\.room\.encrypted/[0-9]\?access_token=bob_1234".format(
-                TEST_ROOM_ID
-            ),
+            rf"https://example\.org/_matrix/client/r0/rooms/{TEST_ROOM_ID}/"
+            rf"send/m\.room\.encrypted/[0-9]\?access_token=bob_1234",
         )
 
         def alice_to_device_cb(url, data, **kwargs):

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -156,7 +156,7 @@ class TestClass:
             headers.append(
                 (
                     "content-disposition",
-                    'inline; filename="{}"'.format(header_filename),
+                    f'inline; filename="{header_filename}"',
                 ),
             )
 

--- a/tests/encryption_test.py
+++ b/tests/encryption_test.py
@@ -416,10 +416,8 @@ class TestClass:
         finally:
             # remove the databases, the known devices store is handled by
             # monkeypatching
-            os.remove(
-                os.path.join(ephemeral_dir, "{}_{}.db".format(AliceId, Alice_device))
-            )
-            os.remove(os.path.join(ephemeral_dir, "{}_{}.db".format(BobId, Bob_device)))
+            os.remove(os.path.join(ephemeral_dir, f"{AliceId}_{Alice_device}.db"))
+            os.remove(os.path.join(ephemeral_dir, f"{BobId}_{Bob_device}.db"))
 
     def test_group_session_sharing(self, monkeypatch):
         def mocksave(self):
@@ -475,8 +473,8 @@ class TestClass:
 
         assert len(sharing_with) == 1
 
-        os.remove(os.path.join(ephemeral_dir, "{}_{}.db".format(AliceId, Alice_device)))
-        os.remove(os.path.join(ephemeral_dir, "{}_{}.db".format(BobId, Bob_device)))
+        os.remove(os.path.join(ephemeral_dir, f"{AliceId}_{Alice_device}.db"))
+        os.remove(os.path.join(ephemeral_dir, f"{BobId}_{Bob_device}.db"))
 
     @ephemeral
     def test_room_key_event(self):
@@ -596,8 +594,8 @@ class TestClass:
         alice.verify_device(bob2_device)
         assert alice.user_fully_verified(BobId)
 
-        os.remove(os.path.join(ephemeral_dir, "{}_{}.db".format(AliceId, Alice_device)))
-        os.remove(os.path.join(ephemeral_dir, "{}_{}.db".format(BobId, Bob_device)))
+        os.remove(os.path.join(ephemeral_dir, f"{AliceId}_{Alice_device}.db"))
+        os.remove(os.path.join(ephemeral_dir, f"{BobId}_{Bob_device}.db"))
 
     @ephemeral
     def test_group_decryption(self):
@@ -730,8 +728,8 @@ class TestClass:
         assert not alice.get_missing_sessions([BobId])
         assert alice.session_store.get(bob_device.curve25519)
 
-        os.remove(os.path.join(ephemeral_dir, "{}_{}.db".format(AliceId, Alice_device)))
-        os.remove(os.path.join(ephemeral_dir, "{}_{}.db".format(BobId, Bob_device)))
+        os.remove(os.path.join(ephemeral_dir, f"{AliceId}_{Alice_device}.db"))
+        os.remove(os.path.join(ephemeral_dir, f"{BobId}_{Bob_device}.db"))
 
     def test_group_session_sharing_new(self, olm_account, bob_account):
         alice = olm_account

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -262,9 +262,7 @@ class TestClass:
             ("m.room.power_levels", "power_levels.json"),
             ("m.room.encryption", "room_encryption.json"),
         ]:
-            parsed_dict = TestClass._load_response(
-                "tests/data/events/{}".format(event_file)
-            )
+            parsed_dict = TestClass._load_response(f"tests/data/events/{event_file}")
             parsed_dict.pop("state_key")
 
             event = Event.parse_event(parsed_dict)
@@ -278,9 +276,7 @@ class TestClass:
             ("m.room.canonical_alias", "alias.json"),
             ("m.room.name", "name.json"),
         ]:
-            parsed_dict = TestClass._load_response(
-                "tests/data/events/{}".format(event_file)
-            )
+            parsed_dict = TestClass._load_response(f"tests/data/events/{event_file}")
             parsed_dict.pop("state_key")
 
             event = InviteEvent.parse_event(parsed_dict)
@@ -293,9 +289,7 @@ class TestClass:
             ("m.room.canonical_alias", "alias.json"),
             ("m.room.name", "name.json"),
         ]:
-            parsed_dict = TestClass._load_response(
-                "tests/data/events/{}".format(event_file)
-            )
+            parsed_dict = TestClass._load_response(f"tests/data/events/{event_file}")
             parsed_dict.pop("type")
 
             event = InviteEvent.parse_event(parsed_dict)
@@ -307,9 +301,7 @@ class TestClass:
             (InviteAliasEvent, "alias.json"),
             (InviteNameEvent, "name.json"),
         ]:
-            parsed_dict = TestClass._load_response(
-                "tests/data/events/{}".format(event_file)
-            )
+            parsed_dict = TestClass._load_response(f"tests/data/events/{event_file}")
             event = InviteEvent.parse_event(parsed_dict)
             assert isinstance(event, event_type)
 
@@ -406,9 +398,7 @@ class TestClass:
             (CallCandidatesEvent, "call_candidates.json"),
             (CallHangupEvent, "call_hangup.json"),
         ]:
-            parsed_dict = TestClass._load_response(
-                "tests/data/events/{}".format(event_file)
-            )
+            parsed_dict = TestClass._load_response(f"tests/data/events/{event_file}")
             parsed_dict["content"].pop("call_id")
             event = CallEvent.parse_event(parsed_dict)
             assert isinstance(event, BadEvent)
@@ -420,9 +410,7 @@ class TestClass:
             (CallCandidatesEvent, "call_candidates.json"),
             (CallHangupEvent, "call_hangup.json"),
         ]:
-            parsed_dict = TestClass._load_response(
-                "tests/data/events/{}".format(event_file)
-            )
+            parsed_dict = TestClass._load_response(f"tests/data/events/{event_file}")
             event = CallEvent.parse_event(parsed_dict)
             assert isinstance(event, event_type)
 
@@ -434,9 +422,7 @@ class TestClass:
             (KeyVerificationMac, "key_mac.json"),
             (KeyVerificationCancel, "key_cancel.json"),
         ]:
-            parsed_dict = TestClass._load_response(
-                "tests/data/events/{}".format(event_file)
-            )
+            parsed_dict = TestClass._load_response(f"tests/data/events/{event_file}")
             event = ToDeviceEvent.parse_event(parsed_dict)
             assert isinstance(event, event_type)
 
@@ -448,9 +434,7 @@ class TestClass:
             (KeyVerificationMac, "key_mac.json"),
             (KeyVerificationCancel, "key_cancel.json"),
         ]:
-            parsed_dict = TestClass._load_response(
-                "tests/data/events/{}".format(event_file)
-            )
+            parsed_dict = TestClass._load_response(f"tests/data/events/{event_file}")
             parsed_dict["content"].pop("transaction_id")
             event = ToDeviceEvent.parse_event(parsed_dict)
             assert isinstance(event, UnknownBadEvent)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -42,12 +42,10 @@ faker = Faker()
 
 class Provider(BaseProvider):
     def mx_id(self):
-        return "@{}:{}".format(faker.user_name(), faker.hostname())
+        return f"@{faker.user_name()}:{faker.hostname()}"
 
     def avatar_url(self):
-        return "mxc://{}/{}#auto".format(
-            faker.hostname(), "".join(choice(ascii_letters) for i in range(24))
-        )
+        return f"mxc://{faker.hostname()}/{''.join(choice(ascii_letters) for i in range(24))}#auto"
 
     def device_id(self):
         return "".join(choice(ascii_uppercase) for i in range(10))

--- a/tests/sas_test.py
+++ b/tests/sas_test.py
@@ -507,7 +507,7 @@ class TestClass:
         assert not bob.canceled
 
         mac_event = KeyVerificationMac.from_dict(alice_mac)
-        mac_event.mac["ed25519:{}".format(alice_device_id)] = "FAKEKEYS"
+        mac_event.mac[f"ed25519:{alice_device_id}"] = "FAKEKEYS"
 
         bob.receive_mac_event(mac_event)
         assert bob.canceled

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -104,9 +104,7 @@ class TestClass:
         fp_key = faker.olm_key_pair()["ed25519"]
         key = Ed25519Key(user_id, device_id, fp_key)
 
-        assert key.to_line() == "{} {} matrix-ed25519 {}\n".format(
-            user_id, device_id, fp_key
-        )
+        assert key.to_line() == f"{user_id} {device_id} matrix-ed25519 {fp_key}\n"
 
         loaded_key = Key.from_line(key.to_line())
         assert isinstance(loaded_key, Ed25519Key)
@@ -119,7 +117,7 @@ class TestClass:
     def test_key_store(self, tempdir):
         store_path = os.path.join(tempdir, "test_store")
         store = KeyStore(os.path.join(tempdir, "test_store"))
-        assert repr(store) == "KeyStore object, file: {}".format(store_path)
+        assert repr(store) == f"KeyStore object, file: {store_path}"
 
         key = faker.ed25519_key()
 


### PR DESCRIPTION
Used `flynt` for most of the cases. Around 60 instances required manual conversion.

Fixes #314.