### PR TITLE
Add room_type to room_create API function to allow for custom room types

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -804,6 +804,7 @@ class Api:
         name=None,  # type: Optional[str]
         topic=None,  # type: Optional[str]
         room_version=None,  # type: Optional[str]
+        room_type=None,  # type: Optional[str]
         federate=True,  # type: bool
         is_direct=False,  # type: bool
         preset=None,  # type: Optional[RoomPreset]
@@ -838,6 +839,12 @@ class Api:
                 If not specified, the homeserver will use its default setting.
                 If a version not supported by the homeserver is specified,
                 a 400 ``M_UNSUPPORTED_ROOM_VERSION`` error will be returned.
+                
+            room_type (str, optional): The room type to set.
+                If not specified, the homeserver will use its default setting.
+                In spec v1.2 the following room types are specified:
+                    - ``m.space``
+                Unspecified room types are permitted through the use of Namespaced Identifiers.
 
             federate (bool): Whether to allow users from other homeservers from
                 joining the room. Defaults to ``True``.
@@ -891,6 +898,9 @@ class Api:
 
         if room_version:
             body["room_version"] = room_version
+            
+        if room_type:
+            body["creation_content"]["type"] = room_type
 
         if preset:
             body["preset"] = preset.value

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -2100,6 +2100,7 @@ class AsyncClient(Client):
         name: Optional[str] = None,
         topic: Optional[str] = None,
         room_version: Optional[str] = None,
+        room_type: Optional[str] = None,
         federate: bool = True,
         is_direct: bool = False,
         preset: Optional[RoomPreset] = None,
@@ -2134,6 +2135,12 @@ class AsyncClient(Client):
                 If not specified, the homeserver will use its default setting.
                 If a version not supported by the homeserver is specified,
                 a 400 ``M_UNSUPPORTED_ROOM_VERSION`` error will be returned.
+                
+            room_type (str, optional): The room type to set.
+                If not specified, the homeserver will use its default setting.
+                In spec v1.2 the following room types are specified:
+                    - ``m.space``
+                Unspecified room types are permitted through the use of Namespaced Identifiers.
 
             federate (bool): Whether to allow users from other homeservers from
                 joining the room. Defaults to ``True``.
@@ -2181,6 +2188,7 @@ class AsyncClient(Client):
             name=name,
             topic=topic,
             room_version=room_version,
+            room_type=room_type,
             federate=federate,
             is_direct=is_direct,
             preset=preset,

--- a/nio/client/http_client.py
+++ b/nio/client/http_client.py
@@ -388,6 +388,7 @@ class HttpClient(Client):
         name=None,  # type: Optional[str]
         topic=None,  # type: Optional[str]
         room_version=None,  # type: Optional[str]
+        room_type=None,  # type: Optional[str]
         federate=True,  # type: bool
         is_direct=False,  # type: bool
         preset=None,  # type: Optional[RoomPreset]
@@ -419,6 +420,12 @@ class HttpClient(Client):
                 If not specified, the homeserver will use its default setting.
                 If a version not supported by the homeserver is specified,
                 a 400 ``M_UNSUPPORTED_ROOM_VERSION`` error will be returned.
+                
+            room_type (str, optional): The room type to set.
+                If not specified, the homeserver will use its default setting.
+                In spec v1.2 the following room types are specified:
+                    - ``m.space``
+                Unspecified room types are permitted through the use of Namespaced Identifiers.
 
             federate (bool): Whether to allow users from other homeservers from
                 joining the room. Defaults to ``True``.
@@ -459,6 +466,7 @@ class HttpClient(Client):
                 name=name,
                 topic=topic,
                 room_version=room_version,
+                room_type=room_type,
                 federate=federate,
                 is_direct=is_direct,
                 preset=preset,

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -621,12 +621,17 @@ class RoomCreateEvent(Event):
         room_version (str): The version of the room. Different room versions
             will have different event formats. Clients shouldn't worry about
             this too much unless they want to perform room upgrades.
+        room_type (str): The type of the room.
+            In spec v1.2 the following room types are specified:
+                - `m.space`
+            Unspecified room types are permitted through the use of Namespaced Identifiers.
 
     """
 
     creator: str = field()
     federate: bool = True
     room_version: str = "1"
+    room_type: str = ""
 
     @classmethod
     @verify(Schemas.room_create)
@@ -635,8 +640,10 @@ class RoomCreateEvent(Event):
         creator = parsed_dict["content"]["creator"]
         federate = parsed_dict["content"]["m.federate"]
         version = parsed_dict["content"]["room_version"]
+        if "type" in parsed_dict["content"]:
+            room_type = parsed_dict["content"]["type"]
 
-        return cls(parsed_dict, creator, federate, version)
+        return cls(parsed_dict, creator, federate, version, room_type)
 
 
 @dataclass

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -76,6 +76,7 @@ class MatrixRoom:
         self.creator = ""             # type: str
         self.federate = True          # type: bool
         self.room_version = "1"       # type: str
+        self.room_type = None         # type: Optional[str]
         self.guest_access = "forbidden"  # type: str
         self.join_rule = "invite"     # type: str
         self.history_visibility = "shared"  # type: str
@@ -371,6 +372,7 @@ class MatrixRoom:
             self.creator = event.creator
             self.federate = event.federate
             self.room_version = event.room_version
+            self.room_type = event.room_type
 
         elif isinstance(event, RoomGuestAccessEvent):
             self.guest_access = event.guest_access

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -776,6 +776,7 @@ class Schemas:
                     "creator": {"type": "string", "format": "user_id"},
                     "m.federate": {"type": "boolean", "default": True},
                     "room_version": {"type": "string", "default": "1"},
+                    "type": {"type": "string", "default": ""},
                     "predecessor": {
                         "type": "object",
                         "properties": {

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1417,6 +1417,34 @@ class TestClass:
         )
         assert isinstance(resp, RoomCreateResponse)
         assert resp.room_id == TEST_ROOM_ID
+        
+    async def test_room_create__typed(self, async_client, aioresponse):
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response)
+        )
+        assert async_client.logged_in
+
+        aioresponse.post(
+            "https://example.org/_matrix/client/r0/createRoom" "?access_token=abc123",
+            status=200,
+            payload=self.room_id_response(TEST_ROOM_ID),
+        )
+
+        resp = await async_client.room_create(
+            visibility=RoomVisibility.public,
+            alias="foo-space",
+            name="bar",
+            topic="Foos and bars space",
+            room_version="9",
+            room_type="nio.matrix.test",
+            preset=RoomPreset.public_chat,
+            invite={ALICE_ID},
+            initial_state=[],
+            power_level_override={},
+            space=True,
+        )
+        assert isinstance(resp, RoomCreateResponse)
+        assert resp.room_id == TEST_ROOM_ID
 
     async def test_join(self, async_client, aioresponse):
         await async_client.receive_response(

--- a/tests/data/events/create_typed.json
+++ b/tests/data/events/create_typed.json
@@ -1,0 +1,16 @@
+{
+    "content": {
+        "creator": "@example:localhost",
+        "m.federate": true,
+        "room_version": "1",
+        "type": "nio.matrix.test"
+    },
+    "event_id": "$151957878228ekrDs:localhost",
+    "origin_server_ts": 1519578782185,
+    "sender": "@example:localhost",
+    "state_key": "",
+    "type": "m.room.create",
+    "unsigned": {
+      "age": 1392989709
+    }
+}

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -94,6 +94,12 @@ class TestClass:
         parsed_dict = TestClass._load_response("tests/data/events/create.json")
         event = RoomCreateEvent.from_dict(parsed_dict)
         assert isinstance(event, RoomCreateEvent)
+        
+    def test_create_event_typed(self):
+        parsed_dict = TestClass._load_response("tests/data/events/create_typed.json")
+        event = RoomCreateEvent.from_dict(parsed_dict)
+        assert isinstance(event, RoomCreateEvent)
+        assert event.room_type == "nio.matrix.test"
 
     def test_guest_access_event(self):
         parsed_dict = TestClass._load_response("tests/data/events/guest_access.json")


### PR DESCRIPTION
I added a `room_type` argument to `Api.room_create` to allow for the creation of rooms with a custom `type`.

The tests pass however I have not tested my changes in the wild yet. 