### PR TITLE
Parse room attributes more carefully

### DIFF
--- a/nio/responses.py
+++ b/nio/responses.py
@@ -1789,26 +1789,26 @@ class SyncResponse(Response):
         left_rooms: Dict[str, RoomInfo] = {}
 
         for room_id, room_dict in parsed_dict.get("invite", {}).items():
-            state = SyncResponse._get_invite_state(room_dict["invite_state"])
+            state = SyncResponse._get_invite_state(room_dict.get("invite_state", {}))
             invite_info = InviteInfo(state)
             invited_rooms[room_id] = invite_info
 
         for room_id, room_dict in parsed_dict.get("leave", {}).items():
-            state = SyncResponse._get_state(room_dict["state"])
-            timeline = SyncResponse._get_timeline(room_dict["timeline"])
+            state = SyncResponse._get_state(room_dict.get("state", {}))
+            timeline = SyncResponse._get_timeline(room_dict.get("timeline", {}))
             leave_info = RoomInfo(timeline, state, [], [])
             left_rooms[room_id] = leave_info
 
         for room_id, room_dict in parsed_dict.get("join", {}).items():
             join_info = SyncResponse._get_join_info(
-                room_dict["state"]["events"],
-                room_dict["timeline"]["events"],
-                room_dict["timeline"].get("prev_batch"),
-                room_dict["timeline"]["limited"],
-                room_dict["ephemeral"]["events"],
+                room_dict.get("state", {}).get("events", []),
+                room_dict.get("timeline", {}).get("events", []),
+                room_dict.get("timeline", {}).get("prev_batch"),
+                room_dict.get("timeline", {}).get("limited", False),
+                room_dict.get("ephemeral", {}).get("events", []),
                 room_dict.get("summary", {}),
                 room_dict.get("unread_notifications", {}),
-                room_dict["account_data"]["events"],
+                room_dict.get("account_data", {}).get("events", []),
             )
 
             joined_rooms[room_id] = join_info


### PR DESCRIPTION
Got the following error while using this library against Conduit homeserver. Conduit does not add empty objects to the sent json and I interpret the matrix documentation as most field are optional and Conduit is not doing anything wrong in this case.

```python3
Traceback (most recent call last):
  File "/config/custom_components/matrix_fix/__init__.py", line 193, in handle_startup
    await self._client.sync_forever(timeout=30_000, loop_sleep_time=1_000)  # milliseconds.
  File "/usr/local/lib/python3.10/site-packages/nio/client/async_client.py", line 1199, in sync_forever
    await self.run_response_callbacks([await response])
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 571, in _wait_for_one
    return f.result()  # May raise f.exception().
  File "/usr/local/lib/python3.10/site-packages/nio/client/async_client.py", line 1046, in sync
    response = await self._send(
  File "/usr/local/lib/python3.10/site-packages/nio/client/async_client.py", line 761, in _send
    resp = await self.create_matrix_response(
  File "/usr/local/lib/python3.10/site-packages/nio/client/async_client.py", line 535, in create_matrix_response
    resp = response_class.from_dict(parsed_dict, *data)
  File "/usr/local/lib/python3.10/site-packages/nio/responses.py", line 182, in wrapper
    return f(cls, parsed_dict, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/nio/responses.py", line 1824, in from_dict
    rooms = SyncResponse._get_room_info(parsed_dict.get("rooms", {}))
  File "/usr/local/lib/python3.10/site-packages/nio/responses.py", line 1774, in _get_room_info
    room_dict["timeline"]["events"],
KeyError: 'timeline'
```