### PR TITLE
Default to the configured request timeout when syncing

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1046,7 +1046,10 @@ class AsyncClient(Client):
         method, path = Api.sync(
             self.access_token,
             since=sync_token or self.loaded_sync_token,
-            timeout=timeout or None,
+            timeout=(
+                int(self.config.request_timeout) * 1000 if timeout is None
+                else timeout or None
+            ),
             filter=sync_filter,
             full_state=full_state,
             set_presence=presence,

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -760,6 +760,16 @@ class TestClass:
         resp4 = await async_client.sync(sync_filter={})
         assert isinstance(resp4, SyncResponse)
 
+        # Test with timeout
+
+        aioresponse.get(
+            re.compile(rf"{url}&since=[\w\d_]*&timeout=60000"),
+            status=200,
+            payload=self.sync_response,
+        )
+        resp5 = await async_client.sync(timeout=None)
+        assert isinstance(resp5, SyncResponse)
+
     async def test_sync_presence(self, async_client, aioresponse):
         """Test if prsences info in sync events are parsed correctly"""
         await async_client.receive_response(


### PR DESCRIPTION
When calling either `sync` or `sync_forever` methods without passing the
`timeout` parameter, the value used for requests timeout is supposed to
be read from the client config.

While this value is correctly passed to the `ClientSession`, it is not
included as a parameter in the URL of the `/sync` API call at all,
making call return immediately, often with an empty response.

This change makes the API call use the `config.request_timeout` value
instead if no timeout was explicitely set.