### PR TITLE
Relax m.push_rules "room.default" event validation

### DIFF
--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1574,7 +1574,7 @@ class Schemas:
         "type": "object",
         "properties": {
             "rule_id": {"type": "string"},
-            "default": {"type": "boolean"},
+            "default": {"type": "boolean", "default": False},
             "enabled": {"type": "boolean"},
             "pattern": {"type": "string"},
             "conditions": {


### PR DESCRIPTION
Default "room.default=False" due to https://github.com/matrix-org/synapse/issues/13837
Fixes #348