### PR TITLE
add support for m.reaction events

### DIFF
--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -1562,11 +1562,11 @@ class StickerEvent(Event):
 
 @dataclass
 class ReactionEvent(Event):
-    """Class representing to a m.reaction event.
+    """An event representing an m.reaction event.
 
     Users sometimes wish to respond to a message using emojis. When such
     responses are grouped visually below the message being reacted to, this
-    provides a (visually) light-weight way for users to react to messages.
+    provides a (visually) lightweight way for users to react to messages.
 
     Attributes:
         reacts_to (str): The event_id of the message the reaction relates to.

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -169,6 +169,8 @@ class Event:
             return Event.parse_encrypted_event(event_dict)
         elif event_dict["type"] == "m.sticker":
             return StickerEvent.from_dict(event_dict)
+        elif event_dict["type"] == "m.reaction":
+            return ReactionEvent.from_dict(event_dict)
         elif event_dict["type"].startswith("m.call"):
             return CallEvent.parse_event(event_dict)
 
@@ -1559,6 +1561,35 @@ class StickerEvent(Event):
 
 
 @dataclass
+class ReactionEvent(Event):
+    """Class representing to a m.reaction event.
+
+    Users sometimes wish to respond to a message using emojis. When such
+    responses are grouped visually below the message being reacted to, this
+    provides a (visually) light-weight way for users to react to messages.
+
+    Attributes:
+        reacts_to (str): The event_id of the message the reaction relates to.
+        key (str): The actual reaction/emoji.
+
+    """
+
+    reacts_to: str = field()
+    key: str = field()
+
+    @classmethod
+    @verify(Schemas.reaction)
+    def from_dict(cls, parsed_dict):
+        content = parsed_dict["content"]["m.relates_to"]
+
+        return cls(
+            parsed_dict,
+            content["event_id"],
+            content["key"],
+        )
+
+
+@dataclass
 class RoomUpgradeEvent(Event):
     """Class representing to an m.room.tombstone event.
 
@@ -1568,7 +1599,6 @@ class RoomUpgradeEvent(Event):
     Attributes:
         body (str): A server-defined message.
         replacement_room (str): The new room the client should be visiting.
-        content (dict): The content of the tombstone event.
     """
 
     body: str = field()

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1087,6 +1087,35 @@ class Schemas:
         "required": ["sender"],
     }
 
+    reaction = {
+        "type": "object",
+        "properties": {
+            "sender": {
+                "type": "string",
+                "format": "user_id",
+            },
+            "content": {
+                "type": "object",
+                "properties": {
+                    "m.relates_to": {
+                        "type": "object",
+                        "properties": {
+                            "rel_type": {
+                                "type": "string",
+                                "const": "m.annotation",
+                            },
+                            "event_id": {"type": "string"},
+                            "key": {"type": "string"},
+                        },
+                        "required": ["rel_type", "event_id", "key"],
+                    },
+                },
+                "required": ["m.relates_to"],
+            },
+        },
+        "required": ["sender", "content"],
+    }
+
     room_resolve_alias = {
         "type": "object",
         "properties": {

--- a/tests/data/events/reaction.json
+++ b/tests/data/events/reaction.json
@@ -1,0 +1,14 @@
+{
+    "type": "m.reaction",
+    "sender": "@example:localhost",
+    "content": {
+        "m.relates_to": {
+            "rel_type": "m.annotation",
+            "event_id": "$B4UkDqYQ7JRC3GEMl7pTyu0x2vLFKgm_wgCR1mEw2CM",
+            "key": "❤️"
+        }
+    },
+    "origin_server_ts": 1520372800469,
+    "unsigned": {"age": 598971425},
+    "event_id": "$152037280074GZeOm:localhost"
+}

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -39,6 +39,7 @@ from nio.events import (
     PushRulesEvent,
     PushSenderNotificationPermission,
     PushUnknownCondition,
+    ReactionEvent,
     Receipt,
     ReceiptEvent,
     RedactedEvent,
@@ -223,6 +224,11 @@ class TestClass:
         parsed_dict = TestClass._load_response("tests/data/events/sticker.json")
         event = StickerEvent.from_dict(parsed_dict)
         assert isinstance(event, StickerEvent)
+
+    def test_reaction(self):
+        parsed_dict = TestClass._load_response("tests/data/events/reaction.json")
+        event = ReactionEvent.from_dict(parsed_dict)
+        assert isinstance(event, ReactionEvent)
 
     def test_empty_event(self):
         parsed_dict = {}


### PR DESCRIPTION
Closes https://github.com/poljar/matrix-nio/issues/174

Adds a `ReactionEvent` with the fields `reacts_to` which gives the `event_id` of the message it reacts to and `key` which stores the reaction (most of the times an emoji but could be any string afaik).
