### PR TITLE
Fix first_sync_filter parameter of AsyncClient.sync_forever

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1166,7 +1166,7 @@ class AsyncClient(Client):
 
         while True:
             try:
-                use_filter = first_sync_filter if first_sync else sync_filter
+                use_filter = first_sync_filter if first_sync and first_sync_filter is not None else sync_filter
                 use_timeout = 0 if first_sync else timeout
 
                 tasks = []


### PR DESCRIPTION
This patch makes the `first_sync_filter` parameter of `AsyncClient.sync_forever` behave as described in the docstring.

Before this change, omitting the `first_sync_filter` parameter (or setting it to `None`) would cause the first sync call to not use a sync filter at all instead of using the sync filter specified in the `sync_filter` parameter.

I have tested this patch in my project.