### PR TITLE
fix: Element exports keys without required fields

### DIFF
--- a/nio/crypto/olm_machine.py
+++ b/nio/crypto/olm_machine.py
@@ -1984,7 +1984,7 @@ class Olm:
         try:
             session_list_all = json.loads(data)
         except JSONDecodeError as e:
-            raise EncryptionError("Error parsing key file: {}".format(str(e)))
+            raise EncryptionError(f"Error parsing key file: {str(e)}")
 
         session_list = []
         count_missing = 0

--- a/nio/crypto/olm_machine.py
+++ b/nio/crypto/olm_machine.py
@@ -1982,9 +1982,22 @@ class Olm:
             raise EncryptionError(e)
 
         try:
-            session_list = json.loads(data)
+            session_list_all = json.loads(data)
         except JSONDecodeError as e:
-            raise EncryptionError(f"Error parsing key file: {str(e)}")
+            raise EncryptionError("Error parsing key file: {}".format(str(e)))
+
+        session_list = []
+        count_missing = 0
+        for session in session_list_all:
+            if 'sender_claimed_keys' in session:
+                session_list.append(session)
+            else:
+                count_missing += 1
+        if count_missing > 0:
+            logger.warning('Warning! Could only import {} from {} keys'.format(
+                count_having,
+                len(session_list_all)
+            ))
 
         try:
             validate_json(session_list, Schemas.megolm_key_import)


### PR DESCRIPTION
When trying to import files from an Element backup, some of the exported keys are missing the "sender_claimed_keys" dictionary key. These entries in the encrypted file have the following shape:

```
{
  'sender_key': '... ~256 bytes ...',
  'room_id': '!room:homeserver',
  'session_id': '... ~256 bytes ...',
  'session_key': '... long value ...',
  'forwarding_curve25519_key_chain': [],
  'org.matrix.msc3061.shared_history': False,
  'algorithm': 'm.megolm.v1.aes-sha2'
}
```

As a result, importing the whole file fails because of the schema validation for `Schemas.megolm_key_import`. This patch silently continues, but warns the user that some of the keys in the file weren't decrypted. I'm not familiar enough with the details of megolm; but this patch correctly works around this issue, instead of hard failing. I hope it is useful for someone!