### PR TITLE
Fix python3.11 compatibility and tests

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -244,7 +244,7 @@ AsyncFile = (AsyncBufferedReader, AsyncTextIOWrapper)
 async def execute_callback(func, *args):
     if asyncio.iscoroutinefunction(func):
         return await func(*args)
-    
+
     return func(*args)
 
 

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -4020,7 +4020,7 @@ class TestClass:
             timeout=ClientTimeout(),
         )
 
-        # Python 3.9 fixes [a bug](https://bugs.python.org/issue46487) for correctly accessing buffer limits
+        # Python 3.9 fixes [a bug](https://github.com/python/cpython/issues/90645) for correctly accessing buffer limits
         # from SSL transport
         ssl_transport = (
             conn.transport

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -4000,7 +4000,9 @@ class TestClass:
         assert event.body == "It's a secret to everybody."
         assert cb_ran
 
-    @pytest.mark.skipif(sys.version_info[0:2] == (3, 11), reason="fails due to cpython bug #99277")
+    @pytest.mark.skipif(
+        sys.version_info[0:2] == (3, 11), reason="fails due to cpython bug #99277"
+    )
     async def test_connect_wrapper(self, async_client, aioresponse):
         domain = "https://example.org"
 

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import math
 import re
+import sys
 import time
 from datetime import datetime, timedelta
 from os import path
@@ -3999,6 +4000,7 @@ class TestClass:
         assert event.body == "It's a secret to everybody."
         assert cb_ran
 
+    @pytest.mark.skipif(sys.version_info[0:2] == (3, 11), reason="fails due to cpython bug #99277")
     async def test_connect_wrapper(self, async_client, aioresponse):
         domain = "https://example.org"
 
@@ -4019,7 +4021,7 @@ class TestClass:
         # Using conn.transport.get_write_buffer_limits() directly raises
         # "AttributeError: _low_water", but the set... method works?
         ssl_transport = conn.transport._ssl_protocol._transport
-        assert ssl_transport.get_write_buffer_limits()[1] == 16 * 1024
+        assert ssl_transport.get_write_buffer_limits() == (4 * 1024, 16 * 1024)
 
     async def test_upload_filter(self, async_client, aioresponse):
         await async_client.receive_response(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -4020,9 +4020,13 @@ class TestClass:
             timeout=ClientTimeout(),
         )
 
-        # Using conn.transport.get_write_buffer_limits() directly raises
-        # "AttributeError: _low_water", but the set... method works?
-        ssl_transport = conn.transport._ssl_protocol._transport
+        # Python 3.9 fixes [a bug](https://bugs.python.org/issue46487) for correctly accessing buffer limits
+        # from SSL transport
+        ssl_transport = (
+            conn.transport
+            if sys.version_info[0:2] >= (3, 9)
+            else conn.transport._ssl_protocol._transport
+        )
         assert ssl_transport.get_write_buffer_limits() == (4 * 1024, 16 * 1024)
 
     async def test_upload_filter(self, async_client, aioresponse):


### PR DESCRIPTION
This PR fixes the compatibility issues with python 3.11, which drops the support for (asyncio.coroutine)[https://docs.python.org/3/whatsnew/3.11.html#removed].
Also the test on buffer limits is skipped for python 3.11 due to a [CPython bug](https://github.com/python/cpython/issues/99277)