### PR TITLE
Bump various dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7.0"
 future = "^0.18.2"
-aiohttp = "^3.7.4"
-aiofiles = "^0.6.0"
+aiohttp = "^3.8.3"
+aiofiles = "^22.1.0"
 dataclasses = { version = "^0.7", python = ">= 3.6, <3.7" }
-h11 = "^0.12.0"
+h11 = "^0.14.0"
 h2 = "^4.0.0"
 logbook = "^1.5.3"
 jsonschema = "^4.4.0"


### PR DESCRIPTION
Partial motivation for this PR is to fix some downstream dependency resolution caused by poetry's `^` operator: e.g. `h11` `0.14.0` is not considered in range by `pip`  based on `h11 = "^0.12.0"`.

Project in question:
https://github.com/home-assistant/core/actions/runs/3581883765/jobs/6025559741
Getting to use `matrix-nio` in such a big project like `home-assistant` would be *huge*, so I'd really like to do whatever I can to get these two projects to play nicely :)

The `aiohttp` bump looks big, but it's only two releases apart: https://pypi.org/project/aiofiles/#history