### PR TITLE
make it easier to mock AsyncClient by matching `logged_in` decorator to async vs non-async

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -219,7 +219,7 @@ from ..responses import (
     WhoamiResponse,
 )
 from . import Client, ClientConfig
-from .base_client import logged_in, store_loaded
+from .base_client import logged_in_async, store_loaded
 
 _ShareGroupSessionT = Union[ShareGroupSessionError, ShareGroupSessionResponse]
 
@@ -989,7 +989,7 @@ class AsyncClient(Client):
 
         return await self._send(LoginResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def logout(
         self, all_devices: bool = False
     ) -> Union[LogoutResponse, LogoutError]:
@@ -1004,7 +1004,7 @@ class AsyncClient(Client):
 
         return await self._send(LogoutResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def sync(
         self,
         timeout: Optional[int] = 0,
@@ -1070,7 +1070,7 @@ class AsyncClient(Client):
 
         return response
 
-    @logged_in
+    @logged_in_async
     async def send_to_device_messages(
         self,
     ) -> List[Union[ToDeviceResponse, ToDeviceError]]:
@@ -1103,7 +1103,7 @@ class AsyncClient(Client):
                 if cb.filter is None or isinstance(response, cb.filter):
                     await execute_callback(cb.func, response)
 
-    @logged_in
+    @logged_in_async
     async def sync_forever(
         self,
         timeout: Optional[int] = None,
@@ -1231,7 +1231,7 @@ class AsyncClient(Client):
 
                 break
 
-    @logged_in
+    @logged_in_async
     @store_loaded
     async def start_key_verification(
         self, device: OlmDevice, tx_id: Optional[str] = None
@@ -1248,7 +1248,7 @@ class AsyncClient(Client):
         message = self.create_key_verification(device)
         return await self.to_device(message, tx_id)
 
-    @logged_in
+    @logged_in_async
     @store_loaded
     async def cancel_key_verification(
         self,
@@ -1288,7 +1288,7 @@ class AsyncClient(Client):
 
         return await self.to_device(message, tx_id)
 
-    @logged_in
+    @logged_in_async
     @store_loaded
     async def accept_key_verification(
         self, transaction_id: str, tx_id: Optional[str] = None
@@ -1313,7 +1313,7 @@ class AsyncClient(Client):
 
         return await self.to_device(message, tx_id)
 
-    @logged_in
+    @logged_in_async
     @store_loaded
     async def confirm_short_auth_string(
         self, transaction_id: str, tx_id: Optional[str] = None
@@ -1330,7 +1330,7 @@ class AsyncClient(Client):
         message = self.confirm_key_verification(transaction_id)
         return await self.to_device(message, tx_id)
 
-    @logged_in
+    @logged_in_async
     async def to_device(
         self,
         message: ToDeviceMessage,
@@ -1358,7 +1358,7 @@ class AsyncClient(Client):
             ToDeviceResponse, method, path, data, response_data=(message,)
         )
 
-    @logged_in
+    @logged_in_async
     @store_loaded
     async def keys_upload(self) -> Union[KeysUploadResponse, KeysUploadError]:
         """Upload the E2E encryption keys.
@@ -1383,7 +1383,7 @@ class AsyncClient(Client):
 
         return await self._send(KeysUploadResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     @store_loaded
     async def keys_query(self) -> Union[KeysQueryResponse, KeysQueryError]:
         """Query the server for user keys.
@@ -1409,7 +1409,7 @@ class AsyncClient(Client):
 
         return await self._send(KeysQueryResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def devices(self) -> Union[DevicesResponse, DevicesError]:
         """Get the list of devices for the current user.
 
@@ -1422,7 +1422,7 @@ class AsyncClient(Client):
 
         return await self._send(DevicesResponse, method, path)
 
-    @logged_in
+    @logged_in_async
     async def update_device(
         self, device_id: str, content: Dict[str, str]
     ) -> Union[UpdateDeviceResponse, UpdateDeviceError]:
@@ -1446,7 +1446,7 @@ class AsyncClient(Client):
 
         return await self._send(UpdateDeviceResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def delete_devices(
         self, devices: List[str], auth: Optional[Dict[str, str]] = None
     ) -> Union[DeleteDevicesResponse, DeleteDevicesError]:
@@ -1485,7 +1485,7 @@ class AsyncClient(Client):
 
         return await self._send(DeleteDevicesResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def joined_members(
         self, room_id: str
     ) -> Union[JoinedMembersResponse, JoinedMembersError]:
@@ -1506,7 +1506,7 @@ class AsyncClient(Client):
             JoinedMembersResponse, method, path, response_data=(room_id,)
         )
 
-    @logged_in
+    @logged_in_async
     async def joined_rooms(
         self,
     ) -> Union[JoinedRoomsResponse, JoinedRoomsError]:
@@ -1521,7 +1521,7 @@ class AsyncClient(Client):
 
         return await self._send(JoinedRoomsResponse, method, path)
 
-    @logged_in
+    @logged_in_async
     async def room_send(
         self,
         room_id: str,
@@ -1600,7 +1600,7 @@ class AsyncClient(Client):
 
         return await self._send(RoomSendResponse, method, path, data, (room_id,))
 
-    @logged_in
+    @logged_in_async
     async def room_get_event(
         self, room_id: str, event_id: str
     ) -> Union[RoomGetEventResponse, RoomGetEventError]:
@@ -1619,7 +1619,7 @@ class AsyncClient(Client):
 
         return await self._send(RoomGetEventResponse, method, path)
 
-    @logged_in
+    @logged_in_async
     async def room_put_state(
         self,
         room_id: str,
@@ -1657,7 +1657,7 @@ class AsyncClient(Client):
             response_data=(room_id,),
         )
 
-    @logged_in
+    @logged_in_async
     async def room_get_state(
         self,
         room_id: str,
@@ -1685,7 +1685,7 @@ class AsyncClient(Client):
             response_data=(room_id,),
         )
 
-    @logged_in
+    @logged_in_async
     async def room_get_state_event(
         self, room_id: str, event_type: str, state_key: str = ""
     ) -> Union[RoomGetStateEventResponse, RoomGetStateEventError]:
@@ -1718,7 +1718,7 @@ class AsyncClient(Client):
             ),
         )
 
-    @logged_in
+    @logged_in_async
     async def room_redact(
         self,
         room_id: str,
@@ -1781,7 +1781,7 @@ class AsyncClient(Client):
             response_data=(room_alias,),
         )
 
-    @logged_in
+    @logged_in_async
     async def room_delete_alias(
         self,
         room_alias: str,
@@ -1809,7 +1809,7 @@ class AsyncClient(Client):
             response_data=(room_alias,),
         )
 
-    @logged_in
+    @logged_in_async
     async def room_put_alias(
         self,
         room_alias: str,
@@ -1865,7 +1865,7 @@ class AsyncClient(Client):
             response_data=(room_id,),
         )
 
-    @logged_in
+    @logged_in_async
     @store_loaded
     async def keys_claim(
         self, user_set: Dict[str, Iterable[str]]
@@ -1890,7 +1890,7 @@ class AsyncClient(Client):
 
         return await self._send(KeysClaimResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     @store_loaded
     async def share_group_session(
         self,
@@ -1979,7 +1979,7 @@ class AsyncClient(Client):
 
         return ShareGroupSessionResponse(room_id, shared_with)
 
-    @logged_in
+    @logged_in_async
     @store_loaded
     async def request_room_key(
         self,
@@ -2099,7 +2099,7 @@ class AsyncClient(Client):
             if self.olm.inbound_group_store.add(session):
                 self.store.save_inbound_group_session(session)
 
-    @logged_in
+    @logged_in_async
     async def room_create(
         self,
         visibility: RoomVisibility = RoomVisibility.private,
@@ -2200,7 +2200,7 @@ class AsyncClient(Client):
 
         return await self._send(RoomCreateResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def join(self, room_id: str) -> Union[JoinResponse, JoinError]:
         """Join a room.
 
@@ -2218,7 +2218,7 @@ class AsyncClient(Client):
         method, path, data = Api.join(self.access_token, room_id)
         return await self._send(JoinResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def room_invite(
         self,
         room_id: str,
@@ -2243,7 +2243,7 @@ class AsyncClient(Client):
         )
         return await self._send(RoomInviteResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def room_leave(
         self, room_id: str
     ) -> Union[RoomLeaveResponse, RoomLeaveError]:
@@ -2263,7 +2263,7 @@ class AsyncClient(Client):
         method, path, data = Api.room_leave(self.access_token, room_id)
         return await self._send(RoomLeaveResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def room_forget(
         self, room_id: str
     ) -> Union[RoomForgetResponse, RoomForgetError]:
@@ -2286,7 +2286,7 @@ class AsyncClient(Client):
             RoomForgetResponse, method, path, data, response_data=(room_id,)
         )
 
-    @logged_in
+    @logged_in_async
     async def room_kick(
         self,
         room_id: str,
@@ -2318,7 +2318,7 @@ class AsyncClient(Client):
         )
         return await self._send(RoomKickResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def room_ban(
         self,
         room_id: str,
@@ -2352,7 +2352,7 @@ class AsyncClient(Client):
         )
         return await self._send(RoomBanResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def room_unban(
         self,
         room_id: str,
@@ -2380,7 +2380,7 @@ class AsyncClient(Client):
         )
         return await self._send(RoomUnbanResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def room_context(
         self,
         room_id: str,
@@ -2410,7 +2410,7 @@ class AsyncClient(Client):
             RoomContextResponse, method, path, response_data=(room_id,)
         )
 
-    @logged_in
+    @logged_in_async
     async def room_messages(
         self,
         room_id: str,
@@ -2469,7 +2469,7 @@ class AsyncClient(Client):
             RoomMessagesResponse, method, path, response_data=(room_id,)
         )
 
-    @logged_in
+    @logged_in_async
     async def room_typing(
         self,
         room_id: str,
@@ -2501,7 +2501,7 @@ class AsyncClient(Client):
             RoomTypingResponse, method, path, data, response_data=(room_id,)
         )
 
-    @logged_in
+    @logged_in_async
     async def update_receipt_marker(
         self,
         room_id: str,
@@ -2537,7 +2537,7 @@ class AsyncClient(Client):
             "{}",
         )
 
-    @logged_in
+    @logged_in_async
     async def room_read_markers(
         self, room_id: str, fully_read_event: str, read_event: Optional[str] = None
     ):
@@ -2582,7 +2582,7 @@ class AsyncClient(Client):
             RoomReadMarkersResponse, method, path, data, response_data=(room_id,)
         )
 
-    @logged_in
+    @logged_in_async
     async def content_repository_config(
         self,
     ) -> Union[ContentRepositoryConfigResponse, ContentRepositoryConfigError]:
@@ -2642,7 +2642,7 @@ class AsyncClient(Client):
             else:
                 yield await self._process_data_chunk(value, monitor)
 
-    @logged_in
+    @logged_in_async
     async def upload(
         self,
         data_provider: DataProvider,
@@ -3029,7 +3029,7 @@ class AsyncClient(Client):
             path,
         )
 
-    @logged_in
+    @logged_in_async
     async def set_displayname(self, displayname: str) -> _ProfileSetDisplayNameT:
         """Set user's display name.
 
@@ -3084,7 +3084,7 @@ class AsyncClient(Client):
             path,
         )
 
-    @logged_in
+    @logged_in_async
     async def set_avatar(
         self, avatar_url: str
     ) -> Union[ProfileSetAvatarResponse, ProfileSetAvatarError]:
@@ -3113,7 +3113,7 @@ class AsyncClient(Client):
             data,
         )
 
-    @logged_in
+    @logged_in_async
     async def get_openid_token(
         self, user_id: str
     ) -> Union[GetOpenIDTokenResponse, GetOpenIDTokenError]:
@@ -3132,7 +3132,7 @@ class AsyncClient(Client):
 
         return await self._send(GetOpenIDTokenResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def upload_filter(
         self,
         user_id: Optional[str] = None,
@@ -3196,7 +3196,7 @@ class AsyncClient(Client):
         method, path = Api.whoami(self.access_token)
         return await self._send(WhoamiResponse, method, path)
 
-    @logged_in
+    @logged_in_async
     async def set_pushrule(
         self,
         scope: str,
@@ -3290,7 +3290,7 @@ class AsyncClient(Client):
 
         return await self._send(SetPushRuleResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def delete_pushrule(
         self,
         scope: str,
@@ -3324,7 +3324,7 @@ class AsyncClient(Client):
 
         return await self._send(DeletePushRuleResponse, method, path)
 
-    @logged_in
+    @logged_in_async
     async def enable_pushrule(
         self,
         scope: str,
@@ -3362,7 +3362,7 @@ class AsyncClient(Client):
 
         return await self._send(EnablePushRuleResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def set_pushrule_actions(
         self,
         scope: str,
@@ -3405,7 +3405,7 @@ class AsyncClient(Client):
 
         return await self._send(SetPushRuleActionsResponse, method, path, data)
 
-    @logged_in
+    @logged_in_async
     async def room_update_aliases(
         self,
         room_id: str,
@@ -3469,7 +3469,7 @@ class AsyncClient(Client):
             return RoomUpdateAliasError("Failed to put m.room.canonical_alias")
         return RoomUpdateAliasResponse()
 
-    @logged_in
+    @logged_in_async
     async def room_upgrade(
         self,
         old_room_id: str,
@@ -3597,7 +3597,7 @@ class AsyncClient(Client):
 
         return RoomUpgradeResponse(new_room.room_id)
 
-    @logged_in
+    @logged_in_async
     async def update_room_topic(
         self,
         room_id: str,
@@ -3621,7 +3621,7 @@ class AsyncClient(Client):
             content={"topic": topic},
         )
 
-    @logged_in
+    @logged_in_async
     async def has_event_permission(
         self, room_id: str, event_name: str, event_type: str = "event"
     ) -> Union[bool, ErrorResponse]:

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -103,6 +103,16 @@ def logged_in(func):
     return wrapper
 
 
+def logged_in_async(func):
+    @wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        if not self.logged_in:
+            raise LocalProtocolError("Not logged in.")
+        return await func(self, *args, **kwargs)
+
+    return wrapper
+
+
 def store_loaded(fn):
     @wraps(fn)
     def inner(self, *args, **kwargs):

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import json
 import math
 import re
@@ -8,6 +9,7 @@ from datetime import datetime, timedelta
 from os import path
 from pathlib import Path
 from typing import Tuple
+from unittest.mock import AsyncMock
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -4206,3 +4208,14 @@ class TestClass:
             [tweak],
         )
         assert isinstance(resp, SetPushRuleActionsResponse)
+
+    async def test_async_mockable(self):
+        mock = AsyncMock(spec=AsyncClient)
+
+        assert inspect.iscoroutinefunction(
+            mock.room_send
+        ), "logged_in method should be awaitable"
+
+        assert not inspect.iscoroutinefunction(
+            mock.restore_login
+        ), "not logged_in method should not be awaitable"


### PR DESCRIPTION
`unitest.mock`'s `AsyncMock` tries to match the return value of method calls based upon async vs non-async when a `spec` is defined. The `client.base_client.logged_in` decorator is non-async and throws off `AsyncMock` making it return non-async `MagicMock`s for all method calls.

This PR duplicates the `logged_in` decorator with an async version.