### PR TITLE
upgrade pre-commit's black version to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
checked in version of `black` conflicts with some version of `click`.  
```
Fix End of Files.........................................................Passed                                                                                                                                                                                                                                                                                                                               
Trim Trailing Whitespace.................................................Passed                                                                                                                                                                                                                                                                                                                               
black....................................................................Failed                                                                                                                                                                                                                                                                                                                               
- hook id: black                                                                                                                                                                                                                                                                                                                                                                                              
- exit code: 1                                                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                              
Traceback (most recent call last):                                                                                                                                                                                                                                                                                                                                                                            
  File "/home/self/.cache/pre-commit/repom568h4je/py_env-python3.10/bin/black", line 8, in <module>                                                                                                                                                                                                                                                                                                           
    sys.exit(patched_main())                                                                                                                                                                                                                                                                                                                                                                                  
  File "/home/self/.cache/pre-commit/repom568h4je/py_env-python3.10/lib/python3.10/site-packages/black/__init__.py", line 1372, in patched_main                                                                                                                                                                                                                                                               
    patch_click()                                                                                                                                                                                                                                                                                                                                                                                             
  File "/home/self/.cache/pre-commit/repom568h4je/py_env-python3.10/lib/python3.10/site-packages/black/__init__.py", line 1358, in patch_click                                                                                                                                                                                                                                                                
    from click import _unicodefun                                                                                                                                                                                                                                                                                                                                                                             
ImportError: cannot import name '_unicodefun' from 'click' (/home/self/.cache/pre-commit/repom568h4je/py_env-python3.10/lib/python3.10/site-packages/click/__init__.py)
```

[per SO](https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click), the solution is upgrading.