### PR TITLE
Chunked downloads

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -202,6 +202,8 @@ from ..responses import (
     SetPushRuleResponse,
     ShareGroupSessionError,
     ShareGroupSessionResponse,
+    StreamError,
+    StreamResponse,
     SyncError,
     SyncResponse,
     ThumbnailError,
@@ -525,6 +527,10 @@ class AsyncClient(Client):
         elif issubclass(response_class, FileResponse):
             body = await transport_response.read()
             resp = response_class.from_data(body, content_type, name)
+
+        elif issubclass(response_class, StreamResponse):
+            resp = response_class.from_reader(transport_response.content)
+
         elif (
             issubclass(response_class, RoomGetStateEventResponse)
             and transport_response.status == 404
@@ -2800,6 +2806,53 @@ class AsyncClient(Client):
         # is True, decryption_dict will have been updated from inside the
         # self._encrypted_data_generator().
         return (response, decryption_dict if encrypt else None)
+
+    @client_session
+    async def stream(
+        self,
+        mxc: str,
+        filename: Optional[str] = None,
+        allow_remote: bool = True,
+    ) -> Union[StreamResponse, StreamError]:
+        """Stream the content of a file from the content repository.
+
+        This method has the same functionality as `download()`, but it does not
+        load the entire file into memory.
+
+        This method ignores `AsyncClient.config.request_timeout` and uses `0`.
+
+        Calls `receive_response()` to update the client state if necessary.
+
+        Returns either a `StreamResponse` if the request was successful or
+        a `StreamError` if there was an error with the request.
+
+        Args:
+            mxc (str): The mxc:// URI.
+            filename (str, optional): A filename to be returned in the response
+                by the server. If None (default), the original name of the
+                file will be returned instead, if there is one.
+            allow_remote (bool): Indicates to the server that it should not
+                attempt to fetch the media if it is deemed remote.
+                This is to prevent routing loops where the server contacts
+                itself.
+        """
+        url = urlparse(mxc)
+        server_name = url.netloc
+        media_id = url.path.replace("/", "")
+
+        http_method, path = Api.download(
+            server_name,
+            media_id,
+            filename,
+            allow_remote,
+        )
+
+        return await self._send(
+            StreamResponse,
+            http_method,
+            path,
+            timeout=0,
+        )
 
     @client_session
     async def download(

--- a/nio/crypto/__init__.py
+++ b/nio/crypto/__init__.py
@@ -18,6 +18,7 @@ from .attachments import decrypt_attachment, encrypt_attachment
 if sys.version_info >= (3, 5):
     from .async_attachments import (
         AsyncDataT,
+        async_decrypt_attachment,
         async_encrypt_attachment,
         async_generator_from_data,
     )

--- a/nio/crypto/async_attachments.py
+++ b/nio/crypto/async_attachments.py
@@ -17,11 +17,13 @@
 
 import asyncio
 import io
+from binascii import Error as BinAsciiError
 from functools import partial
 from pathlib import Path
 from typing import Any, AsyncGenerator, AsyncIterable, Dict, Iterable, Union
 
 import aiofiles
+import unpaddedbase64
 from aiofiles.threadpool.binary import AsyncBufferedReader
 from Crypto import Random  # nosec
 from Crypto.Cipher import AES  # nosec
@@ -29,6 +31,7 @@ from Crypto.Hash import SHA256  # nosec
 from Crypto.Util import Counter  # nosec
 
 from .attachments import _get_decryption_info_dict
+from ..exceptions import EncryptionError
 
 AsyncDataT = Union[
     str,
@@ -41,6 +44,57 @@ AsyncDataT = Union[
 ]
 
 _EncryptedReturnT = AsyncGenerator[Union[bytes, Dict[str, Any]], None]
+_DecryptedReturnT = AsyncGenerator[bytes, None]
+
+
+async def async_decrypt_attachment(
+    ciphertext_generator: AsyncGenerator[bytes, None],
+    key: str,
+    hash: str,
+    iv: str,
+) -> _DecryptedReturnT:
+    """Async generator to decrypt an attachment.
+
+    This function lazily decrypts and yields data. It can decrypt large files
+    without fully loading them into memory.
+
+    Args:
+        ciphertext_generator (AsyncGenerator[bytes, None]): An async generator
+            that yields the data to decrypt.
+
+    Yields:
+        The decrypted bytes for each chunk of data.
+    """
+
+    try:
+        byte_key: bytes = unpaddedbase64.decode_base64(key)
+    except (BinAsciiError, TypeError):
+        raise EncryptionError("Error decoding key.")
+
+    try:
+        byte_iv: bytes = unpaddedbase64.decode_base64(iv)
+    except (BinAsciiError, TypeError):
+        raise EncryptionError("Error decoding initial values.")
+
+    prefix: bytes = byte_iv[:8]
+    cnt: int = int.from_bytes(byte_iv[8:], "big")
+    ctr = Counter.new(64, prefix=prefix, initial_value=cnt)
+
+    try:
+        cipher = AES.new(byte_key, AES.MODE_CTR, counter=ctr)
+    except ValueError as e:
+        raise EncryptionError(e)
+
+    h = SHA256.new()
+
+    async for chunk in ciphertext_generator:
+        decrypted_chunk = cipher.decrypt(chunk)
+        h.update(chunk)
+        yield decrypted_chunk
+
+    expected_hash = unpaddedbase64.decode_base64(hash)
+    if h.digest() != expected_hash:
+        raise EncryptionError("Mismatched SHA-256 digest.")
 
 
 async def async_encrypt_attachment(data: AsyncDataT) -> _EncryptedReturnT:

--- a/tests/async_attachment_test.py
+++ b/tests/async_attachment_test.py
@@ -7,7 +7,7 @@ import unpaddedbase64
 from Crypto import Random  # nosec
 
 from nio import EncryptionError
-from nio.crypto import async_encrypt_attachment, decrypt_attachment
+from nio.crypto import async_decrypt_attachment, async_encrypt_attachment
 
 FILEPATH = "tests/data/test_bytes"
 
@@ -22,15 +22,20 @@ class TestClass:
         *chunks, keys = [i async for i in async_encrypt_attachment(data)]
         return (data, b"".join(chunks), keys)
 
+    async def _generate(self, ciphertext):
+        for i in range(0, len(ciphertext), 4):
+            yield ciphertext[i : i + 4]
+
     async def test_encrypt(self, data=b"Test bytes", large=False):
         _, ciphertext, keys = await self._get_data_cypher_keys(data)
 
-        plaintext = decrypt_attachment(
-            ciphertext,
+        plaintext_generator = async_decrypt_attachment(
+            self._generate(ciphertext),
             keys["key"]["k"],
             keys["hashes"]["sha256"],
             keys["iv"],
         )
+        plaintext = b"".join([i async for i in plaintext_generator])
 
         assert plaintext == b"Test bytes" * (16384 if large else 1)
 
@@ -68,56 +73,61 @@ class TestClass:
     async def test_hash_verification(self):
         data, ciphertext, keys = await self._get_data_cypher_keys()
 
+        plaintext_generator = async_decrypt_attachment(
+            self._generate(ciphertext),
+            keys["key"]["k"],
+            "Fake hash",
+            keys["iv"],
+        )
         with pytest.raises(EncryptionError):
-            decrypt_attachment(
-                ciphertext,
-                keys["key"]["k"],
-                "Fake hash",
-                keys["iv"],
-            )
+            [i async for i in plaintext_generator]
 
     async def test_invalid_key(self):
         data, ciphertext, keys = await self._get_data_cypher_keys()
 
+        plaintext_generator = async_decrypt_attachment(
+            self._generate(ciphertext),
+            "Fake key",
+            keys["hashes"]["sha256"],
+            keys["iv"],
+        )
         with pytest.raises(EncryptionError):
-            decrypt_attachment(
-                ciphertext,
-                "Fake key",
-                keys["hashes"]["sha256"],
-                keys["iv"],
-            )
+            [i async for i in plaintext_generator]
 
     async def test_invalid_iv(self):
         data, ciphertext, keys = await self._get_data_cypher_keys()
 
+        plaintext_generator = async_decrypt_attachment(
+            self._generate(ciphertext),
+            keys["key"]["k"],
+            keys["hashes"]["sha256"],
+            "Fake iv",
+        )
         with pytest.raises(EncryptionError):
-            decrypt_attachment(
-                ciphertext,
-                keys["key"]["k"],
-                keys["hashes"]["sha256"],
-                "Fake iv",
-            )
+            [i async for i in plaintext_generator]
 
     async def test_short_key(self):
         data, ciphertext, keys = await self._get_data_cypher_keys()
 
+        plaintext_generator = async_decrypt_attachment(
+            self._generate(ciphertext),
+            unpaddedbase64.encode_base64(b"Fake key", urlsafe=True),
+            keys["hashes"]["sha256"],
+            keys["iv"],
+        )
         with pytest.raises(EncryptionError):
-            decrypt_attachment(
-                ciphertext,
-                unpaddedbase64.encode_base64(b"Fake key", urlsafe=True),
-                keys["hashes"]["sha256"],
-                keys["iv"],
-            )
+            [i async for i in plaintext_generator]
 
     async def test_short_iv(self):
         data, ciphertext, keys = await self._get_data_cypher_keys()
 
-        plaintext = decrypt_attachment(
-            ciphertext,
+        plaintext_generator = async_decrypt_attachment(
+            self._generate(ciphertext),
             keys["key"]["k"],
             keys["hashes"]["sha256"],
             unpaddedbase64.encode_base64(b"F" + b"\x00" * 8),
         )
+        plaintext = b"".join([i async for i in plaintext_generator])
         assert plaintext != data
 
     async def test_fake_key(self):
@@ -125,10 +135,11 @@ class TestClass:
 
         fake_key = Random.new().read(32)
 
-        plaintext = decrypt_attachment(
-            ciphertext,
+        plaintext_generator = async_decrypt_attachment(
+            self._generate(ciphertext),
             unpaddedbase64.encode_base64(fake_key, urlsafe=True),
             keys["hashes"]["sha256"],
             keys["iv"],
         )
+        plaintext = b"".join([i async for i in plaintext_generator])
         assert plaintext != data


### PR DESCRIPTION
Before this change, whenever the user would download an attachment, the client (Pantalaimon) would store all the data in memory while processing it. This causes significant memory usage spikes when downloading multiple large files at once. The high memory usage is a major problem when running Pantalaimon in a memory-constrained setting.

This change adds a function for lazily decrypting files (an analogue to the one for lazily encrypting files, which already exists), and a new client function for using the chunked data.

(There will also be a follow-up PR in the Pantalaimon repository.)