### PR TITLE
Fix build failure caused by tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ isolated_build = True
 [testenv]
 deps = -r test-requirements.txt
 
-passenv = TOXENV CI
+passenv =
+    TOXENV
+    CI
 commands = pytest --benchmark-disable
 
 [testenv:coverage]


### PR DESCRIPTION
As of tox 4, passenv can no longer use space as a separator. This change uses a syntax valid in both tox 3 and 4.

See https://tox.wiki/en/4.2.2/upgrading.html#changed-ini-rules for more details.