### PR TITLE
fix schema for call events

### DIFF
--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1377,7 +1377,7 @@ class Schemas:
                 "properties": {
                     "call_id": {"type": "string"},
                     "lifetime": {"type": "integer"},
-                    "version": {"type": "integer"},
+                    "version": {"type": "string"},
                     "offer": {
                         "type": "object",
                         "properties": {
@@ -1409,7 +1409,7 @@ class Schemas:
                 "type": "object",
                 "properties": {
                     "call_id": {"type": "string"},
-                    "version": {"type": "integer"},
+                    "version": {"type": "string"},
                     "answer": {
                         "type": "object",
                         "properties": {
@@ -1440,7 +1440,7 @@ class Schemas:
                 "type": "object",
                 "properties": {
                     "call_id": {"type": "string"},
-                    "version": {"type": "integer"},
+                    "version": {"type": "string"},
                 },
                 "required": [
                     "call_id",
@@ -1462,7 +1462,7 @@ class Schemas:
                 "type": "object",
                 "properties": {
                     "call_id": {"type": "string"},
-                    "version": {"type": "integer"},
+                    "version": {"type": "string"},
                     "candidates": {
                         "type": "array",
                         "items": {

--- a/tests/data/events/call_answer.json
+++ b/tests/data/events/call_answer.json
@@ -6,7 +6,7 @@
         },
         "call_id": "12345",
         "lifetime": 60000,
-        "version": 0
+        "version": "0"
     },
     "event_id": "$143273582443PhrSn:example.org",
     "origin_server_ts": 1432735824653,

--- a/tests/data/events/call_candidates.json
+++ b/tests/data/events/call_candidates.json
@@ -8,7 +8,7 @@
                 "sdpMid": "audio"
             }
         ],
-        "version": 0
+        "version": "0"
     },
     "event_id": "$143273582443PhrSn:example.org",
     "origin_server_ts": 1432735824653,

--- a/tests/data/events/call_hangup.json
+++ b/tests/data/events/call_hangup.json
@@ -1,7 +1,7 @@
 {
     "content": {
         "call_id": "12345",
-        "version": 0
+        "version": "0"
     },
     "event_id": "$143273582443PhrSn:example.org",
     "origin_server_ts": 1432735824653,

--- a/tests/data/events/call_invite.json
+++ b/tests/data/events/call_invite.json
@@ -6,7 +6,7 @@
             "sdp": "v=0\r\no=- 6584580628695956864 2 IN IP4 127.0.0.1[...]",
             "type": "offer"
         },
-        "version": 0
+        "version": "0"
     },
     "event_id": "$143273582443PhrSn:example.org",
     "origin_server_ts": 1432735824653,


### PR DESCRIPTION
Assuming Element client behaves according to specs, the event schema of NIO is not correct. It expects 'version' attribute to be an integer, while Element sends it as string. As a result incoming call from Element are parsed into BadEvents. This patch fixes the issue I think.