### PR TITLE
Update type hints

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -238,7 +238,15 @@ SynchronousFile = (
     io.BytesIO,
     io.FileIO,
 )
+SynchronousFileType = Union[
+    io.TextIOBase,
+    io.BufferedReader,
+    io.BufferedRandom,
+    io.BytesIO,
+    io.FileIO,
+]
 AsyncFile = (AsyncBufferedReader, AsyncTextIOWrapper)
+AsyncFileType = Union[AsyncBufferedReader, AsyncTextIOWrapper]
 
 
 async def execute_callback(func, *args):
@@ -2645,7 +2653,7 @@ class AsyncClient(Client):
     @logged_in
     async def upload(
         self,
-        data_provider: DataProvider,
+        data_provider: Union[DataProvider, SynchronousFileType, AsyncFileType],
         content_type: str = "application/octet-stream",
         filename: Optional[str] = None,
         encrypt: bool = False,


### PR DESCRIPTION
`AsyncClient.upload()` also supports passing file-like objects but the type hint didn't indicate that. So I corrected it.

Otherwise in PyCharm, passing a file-like object will emit type errors like this:

> Expected type '(int, int) -> str | Path | bytes | Iterable[bytes] | AsyncIterable[bytes] | BufferedIOBase | AsyncBufferedReader', got 'BytesIO' instead 