### PR TITLE
Export Whoami{Response,Error} from responses.py.

### DIFF
--- a/nio/responses.py
+++ b/nio/responses.py
@@ -170,6 +170,8 @@ __all__ = [
     "UploadFilterResponse",
     "UpdateReceiptMarkerError",
     "UpdateReceiptMarkerResponse",
+    "WhoamiError",
+    "WhoamiResponse",
 ]
 
 


### PR DESCRIPTION
This small change adds `WhoamiResponse` and `WhoamiError` into the `__all__` variable of `responses.py`.

This helps users to check if `AsyncClient.whoami` has returned an error or a success. Closes https://github.com/poljar/matrix-nio/issues/391.