### PR TITLE
Fix test coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands = pytest --benchmark-disable
 [testenv:coverage]
 commands =
     coverage erase
-    py.test --cov=nio --cov-report term-missing --benchmark-disable
+    pytest --cov={envsitepackagesdir}/nio --cov-report term-missing --benchmark-disable
     coverage xml
     coverage report --show-missing
     codecov -e TOXENV


### PR DESCRIPTION
Notice that in previous, otherwise-successful runs, the test coverage is 0%.
This should fix that.