### PR TITLE
Support m.space.parent and m.space.child events

### DIFF
--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -841,7 +841,7 @@ class RoomSpaceParentEvent(Event):
 
 @dataclass
 class RoomSpaceChildEvent(Event):
-    """Event holding the child space of a room.
+    """Event holding the child rooms of a space.
 
     Attributes:
         state_key (str): The child room of a space

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -815,6 +815,48 @@ class RoomAvatarEvent(Event):
 
 
 @dataclass
+class RoomSpaceParentEvent(Event):
+    """Event holding the parent space of a room.
+
+    Attributes:
+        state_key (str): The parent space's room
+
+    """
+
+    state_key: str = field()
+    canonical: bool = False
+
+    @classmethod
+    @verify(Schemas.room_space_parent)
+    def from_dict(cls, parsed_dict):
+        content_dict = parsed_dict["content"]
+        return cls(
+            parsed_dict, parsed_dict["state_key"], content_dict.get("canonical", False)
+        )
+
+
+@dataclass
+class RoomSpaceChildEvent(Event):
+    """Event holding the child space of a room.
+
+    Attributes:
+        state_key (str): The child room of a space
+
+    """
+
+    state_key: str = field()
+    suggested: bool = False
+
+    @classmethod
+    @verify(Schemas.room_space_child)
+    def from_dict(cls, parsed_dict):
+        content_dict = parsed_dict["content"]
+        return cls(
+            parsed_dict, parsed_dict["state_key"], content_dict.get("suggested", False)
+        )
+
+
+@dataclass
 class RoomMessage(Event):
     """Abstract room message class.
 

--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -161,6 +161,10 @@ class Event:
             return RedactionEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.tombstone":
             return RoomUpgradeEvent.from_dict(event_dict)
+        elif event_dict["type"] == "m.space.parent":
+            return RoomSpaceParentEvent.from_dict(event_dict)
+        elif event_dict["type"] == "m.space.child":
+            return RoomSpaceChildEvent.from_dict(event_dict)
         elif event_dict["type"] == "m.room.encrypted":
             return Event.parse_encrypted_event(event_dict)
         elif event_dict["type"] == "m.sticker":

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -20,7 +20,7 @@ from __future__ import unicode_literals
 from builtins import super
 from collections import defaultdict
 from enum import Enum
-from typing import Any, DefaultDict, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, DefaultDict, Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
 from jsonschema.exceptions import SchemaError, ValidationError
 from logbook import Logger
@@ -46,6 +46,8 @@ from .events import (
     RoomJoinRulesEvent,
     RoomMemberEvent,
     RoomNameEvent,
+    RoomSpaceChildEvent,
+    RoomSpaceParentEvent,
     RoomTopicEvent,
     RoomUpgradeEvent,
     TagEvent,
@@ -82,6 +84,8 @@ class MatrixRoom:
         self.canonical_alias = None   # type: Optional[str]
         self.topic = None             # type: Optional[str]
         self.name = None              # type: Optional[str]
+        self.parent = None            # type: Optional[str]
+        self.children = set()         # type: Set[str]
         self.users = dict()           # type: Dict[str, MatrixUser]
         self.invited_users = dict()   # type: Dict[str, MatrixUser]
         self.names = defaultdict(list)  # type: DefaultDict[str, List[str]]
@@ -408,6 +412,12 @@ class MatrixRoom:
                         f"Changing power level for user {user_id} from {self.users[user_id].power_level} to {level}"
                     )
                     self.users[user_id].power_level = level
+
+        elif isinstance(event, RoomSpaceParentEvent):
+            self.parent = event.state_key
+
+        elif isinstance(event, RoomSpaceChildEvent):
+            self.children.add(event.state_key)
 
     def handle_account_data(self, event: AccountDataEvent) -> None:
         if isinstance(event, FullyReadEvent):

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -84,7 +84,7 @@ class MatrixRoom:
         self.canonical_alias = None   # type: Optional[str]
         self.topic = None             # type: Optional[str]
         self.name = None              # type: Optional[str]
-        self.parent = None            # type: Optional[str]
+        self.parent = set()           # type: Set[str]
         self.children = set()         # type: Set[str]
         self.users = dict()           # type: Dict[str, MatrixUser]
         self.invited_users = dict()   # type: Dict[str, MatrixUser]
@@ -414,7 +414,7 @@ class MatrixRoom:
                     self.users[user_id].power_level = level
 
         elif isinstance(event, RoomSpaceParentEvent):
-            self.parent = event.state_key
+            self.parent.add(event.state_key)
 
         elif isinstance(event, RoomSpaceChildEvent):
             self.children.add(event.state_key)

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -414,7 +414,7 @@ class MatrixRoom:
                     self.users[user_id].power_level = level
 
         elif isinstance(event, RoomSpaceParentEvent):
-            self.parent.add(event.state_key)
+            self.parents.add(event.state_key)
 
         elif isinstance(event, RoomSpaceChildEvent):
             self.children.add(event.state_key)

--- a/nio/rooms.py
+++ b/nio/rooms.py
@@ -84,7 +84,7 @@ class MatrixRoom:
         self.canonical_alias = None   # type: Optional[str]
         self.topic = None             # type: Optional[str]
         self.name = None              # type: Optional[str]
-        self.parent = set()           # type: Set[str]
+        self.parents = set()           # type: Set[str]
         self.children = set()         # type: Set[str]
         self.users = dict()           # type: Dict[str, MatrixUser]
         self.invited_users = dict()   # type: Dict[str, MatrixUser]

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -924,6 +924,43 @@ class Schemas:
         "required": ["type", "sender", "content", "state_key"],
     }
 
+    room_space_parent = {
+        "type": "object",
+        "properties": {
+            "sender": {"type": "string", "format": "user_id"},
+            "state_key": {"type": "string"},
+            "type": {"type": "string"},
+            "content": {
+                "type": "object",
+                "properties": {
+                    "canonical": {"type": "boolean", "default": False},
+                    "via": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["via"],
+            },
+        },
+        "required": ["type", "sender", "content", "state_key"],
+    }
+
+    room_space_child = {
+        "type": "object",
+        "properties": {
+            "sender": {"type": "string", "format": "user_id"},
+            "state_key": {"type": "string"},
+            "type": {"type": "string"},
+            "content": {
+                "type": "object",
+                "properties": {
+                    "suggested": {"type": "boolean", "default": False},
+                    "via": {"type": "array", "items": {"type": "string"}},
+                    "order": {"type": "string"},
+                },
+                "required": ["via"],
+            },
+        },
+        "required": ["type", "sender", "content", "state_key"],
+    }
+
     room_avatar = {
         "type": "object",
         "properties": {

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -489,7 +489,7 @@ class TestClass:
 
     def test_space_child(self):
         room = self.test_room
-        assert room.children == []
+        assert room.children == set()
         room.handle_event(
             RoomSpaceChildEvent(
                 {"event_id": "event_id", "sender": BOB_ID, "origin_server_ts": 0},

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -478,14 +478,14 @@ class TestClass:
 
     def test_space_parent(self):
         room = self.test_room
-        assert not room.parent
+        assert room.parent == set()
         room.handle_event(
             RoomSpaceParentEvent(
                 {"event_id": "event_id", "sender": BOB_ID, "origin_server_ts": 0},
                 "!X:example.org",
             )
         )
-        assert room.parent == "!X:example.org"
+        assert "!X:example.org" in room.parent
 
     def test_space_child(self):
         room = self.test_room

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -478,14 +478,14 @@ class TestClass:
 
     def test_space_parent(self):
         room = self.test_room
-        assert room.parent == set()
+        assert room.parents == set()
         room.handle_event(
             RoomSpaceParentEvent(
                 {"event_id": "event_id", "sender": BOB_ID, "origin_server_ts": 0},
                 "!X:example.org",
             )
         )
-        assert "!X:example.org" in room.parent
+        assert "!X:example.org" in room.parents
 
     def test_space_child(self):
         room = self.test_room

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -30,6 +30,8 @@ from nio.events import (
     RoomJoinRulesEvent,
     RoomMemberEvent,
     RoomNameEvent,
+    RoomSpaceChildEvent,
+    RoomSpaceParentEvent,
     RoomUpgradeEvent,
     TypingNoticeEvent,
 )
@@ -473,6 +475,28 @@ class TestClass:
             )
         )
         assert room.name == "test name"
+
+    def test_space_parent(self):
+        room = self.test_room
+        assert not room.parent
+        room.handle_event(
+            RoomSpaceParentEvent(
+                {"event_id": "event_id", "sender": BOB_ID, "origin_server_ts": 0},
+                "!X:example.org",
+            )
+        )
+        assert room.parent == "!X:example.org"
+
+    def test_space_child(self):
+        room = self.test_room
+        assert room.children == []
+        room.handle_event(
+            RoomSpaceChildEvent(
+                {"event_id": "event_id", "sender": BOB_ID, "origin_server_ts": 0},
+                "!X:example.org",
+            )
+        )
+        assert "!X:example.org" in room.children
 
     def test_room_avatar_event(self):
         room = self.test_room


### PR DESCRIPTION
Add support to handle `m.space.parent` and `m.space.child`, also add support for getting the parent / children in `MatrixRoom`.

Closes #371 