### PR TITLE
Fixed bug in Event Callbacks

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -611,7 +611,7 @@ class AsyncClient(Client):
 
                 for cb in self.event_callbacks:
                     if cb.filter is None or isinstance(event, cb.filter):
-                        await execute_callback(cb.func, room, event)
+                        await execute_callback(cb.func, room_id, event)
 
             # Replace the Megolm events with decrypted ones
             for index, event in decrypted_events:

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -589,7 +589,7 @@ class AsyncClient(Client):
 
                 for cb in self.event_callbacks:
                     if cb.filter is None or isinstance(event, cb.filter):
-                        await execute_callback(cb.func, room, event)
+                        await execute_callback(cb.func, room_id, event)
 
     async def _handle_joined_rooms(self, response: SyncResponse) -> None:
         encrypted_rooms: Set[str] = set()
@@ -622,14 +622,14 @@ class AsyncClient(Client):
 
                 for cb in self.ephemeral_callbacks:
                     if cb.filter is None or isinstance(event, cb.filter):
-                        await execute_callback(cb.func, room, event)
+                        await execute_callback(cb.func, room_id, event)
 
             for event in join_info.account_data:
                 room.handle_account_data(event)
 
                 for cb in self.room_account_data_callbacks:
                     if cb.filter is None or isinstance(event, cb.filter):
-                        await execute_callback(cb.func, room, event)
+                        await execute_callback(cb.func, room_id, event)
 
             if room.encrypted and self.olm is not None:
                 self.olm.update_tracked_users(room)

--- a/nio/client/base_client.py
+++ b/nio/client/base_client.py
@@ -692,7 +692,7 @@ class Client:
 
                 for cb in self.event_callbacks:
                     if cb.filter is None or isinstance(event, cb.filter):
-                        cb.func(room, event)
+                        cb.func(room_id, event)
 
     def _handle_joined_state(
         self, room_id: str, join_info: RoomInfo, encrypted_rooms: Set[str]
@@ -775,7 +775,7 @@ class Client:
 
                 for cb in self.event_callbacks:
                     if cb.filter is None or isinstance(event, cb.filter):
-                        cb.func(room, event)
+                        cb.func(room_id, event)
 
             # Replace the Megolm events with decrypted ones
             for index, event in decrypted_events:
@@ -786,14 +786,14 @@ class Client:
 
                 for cb in self.ephemeral_callbacks:
                     if cb.filter is None or isinstance(event, cb.filter):
-                        cb.func(room, event)
+                        cb.func(room_id, event)
 
             for event in join_info.account_data:
                 room.handle_account_data(event)
 
                 for cb in self.room_account_data_callbacks:
                     if cb.filter is None or isinstance(event, cb.filter):
-                        cb.func(room, event)
+                        cb.func(room_id, event)
 
             if room.encrypted and self.olm is not None:
                 self.olm.update_tracked_users(room)

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -2185,6 +2185,19 @@ class TestClass:
             await async_client.receive_response(
                 SyncResponse.from_dict(self.sync_response)
             )
+            
+    async def test_event_callback_arguments(self, async_client):
+        class CallbackException(Exception):
+            pass 
+            
+        async def cb(room, _):
+            if isinstance(room, str):
+                raise CallbackException()
+            
+        async_client.add_event_callback(cb, (RoomMemberEvent, RoomEncryptionEvent))    
+            
+        with pytest.raises(CallbackException):
+            await async_client.receive_response(self.encryption_sync_response)
 
     async def test_handle_account_data(self, async_client):
         await async_client.receive_response(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -2159,9 +2159,10 @@ class TestClass:
         class CallbackException(Exception):
             pass
 
-        async def cb(_, event):
+        async def cb(room, event):
             if isinstance(event, RoomMemberEvent):
-                raise CallbackException()
+                if instance(room, str):
+                    raise CallbackException()
 
         async_client.add_event_callback(cb, (RoomMemberEvent, RoomEncryptionEvent))
 
@@ -2185,19 +2186,7 @@ class TestClass:
             await async_client.receive_response(
                 SyncResponse.from_dict(self.sync_response)
             )
-            
-    async def test_event_callback_arguments(self, async_client):
-        class CallbackException(Exception):
-            pass 
-            
-        async def cb(room, _):
-            if isinstance(room, str):
-                raise CallbackException()
-            
-        async_client.add_event_callback(cb, (RoomMemberEvent, RoomEncryptionEvent))    
-            
-        with pytest.raises(CallbackException):
-            await async_client.receive_response(self.encryption_sync_response)
+
 
     async def test_handle_account_data(self, async_client):
         await async_client.receive_response(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -2160,9 +2160,8 @@ class TestClass:
             pass
 
         async def cb(room, event):
-            if isinstance(event, RoomMemberEvent):
-                if instance(room, str):
-                    raise CallbackException()
+            if isinstance(event, RoomMemberEvent) or isinstance(room, str):
+                raise CallbackException()
 
         async_client.add_event_callback(cb, (RoomMemberEvent, RoomEncryptionEvent))
 
@@ -2186,7 +2185,6 @@ class TestClass:
             await async_client.receive_response(
                 SyncResponse.from_dict(self.sync_response)
             )
-
 
     async def test_handle_account_data(self, async_client):
         await async_client.receive_response(

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1075,6 +1075,20 @@ class TestClass:
         with pytest.raises(CallbackException):
             client.receive_response(self.sync_response)
 
+    def test_event_callback_arguments(self, client):
+        class CallbackException(Exception):
+            pass
+
+        def cb(room, _):
+            print(type(room))
+            if isinstance(room, str):
+                raise CallbackException()
+
+        client.add_event_callback(cb, (RoomMemberEvent, RoomEncryptionEvent))
+
+        with pytest.raises(CallbackException):
+            client.receive_response(self.sync_response)
+
     def test_to_device_cb(self, client):
         client.receive_response(self.login_response)
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1068,21 +1068,8 @@ class TestClass:
 
         def cb(room, event):
             if isinstance(event, RoomMemberEvent):
-                raise CallbackException()
-
-        client.add_event_callback(cb, (RoomMemberEvent, RoomEncryptionEvent))
-
-        with pytest.raises(CallbackException):
-            client.receive_response(self.sync_response)
-
-    def test_event_callback_arguments(self, client):
-        class CallbackException(Exception):
-            pass
-
-        def cb(room, _):
-            print(type(room))
-            if isinstance(room, str):
-                raise CallbackException()
+                if instance(room, str):
+                    raise CallbackException()
 
         client.add_event_callback(cb, (RoomMemberEvent, RoomEncryptionEvent))
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1067,9 +1067,8 @@ class TestClass:
             pass
 
         def cb(room, event):
-            if isinstance(event, RoomMemberEvent):
-                if instance(room, str):
-                    raise CallbackException()
+            if isinstance(event, RoomMemberEvent) or isinstance(room, str):
+                raise CallbackException()
 
         client.add_event_callback(cb, (RoomMemberEvent, RoomEncryptionEvent))
 


### PR DESCRIPTION
Initially, `execute_callback` took one `room` argument, which was a `MatrixRoom`. Methods like `room_send` need the `room_id` to be a string to get it from `AsyncClient.rooms`. Since the `room_id` was a `MatrixRoom`, a `KeyError` was raised.