### PR TITLE
Drop support for EOL `python3.7`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,10 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7.0"
+python = "^3.8.0"
 future = "^0.18.2"
 aiohttp = "^3.8.3"
 aiofiles = "^23.1.0"
-dataclasses = { version = "^0.7", python = ">= 3.6, <3.7" }
 h11 = "^0.14.0"
 h2 = "^4.0.0"
 jsonschema = "^4.4.0"

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -13,6 +13,5 @@ aiohttp; python_version >= '3.5'
 aiohttp_socks
 aioresponses; python_version >= '3.5'
 aiofiles; python_version >= '3.5'
-dataclasses; python_version < '3.7'
 m2r2
 sphinx_rtd_theme


### PR DESCRIPTION
`python3.7` will no longer receive security updates after June 27, 2023.
We should no longer continue to actively support it nor develop in a backwards-compatible manner for it.

https://devguide.python.org/versions/
![image](https://github.com/poljar/matrix-nio/assets/20485810/92c0876a-7d94-425e-90a1-be989be51cc7)
