### PR TITLE
Add .readthedocs.yaml to support ReadTheDocs migration

### DIFF
--- a/.readthedocs.yaml 
+++ b/.readthedocs.yaml 
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: rtd-requirements.txt


### PR DESCRIPTION
This PR fixes #424 by adding a `.readthedocs.yaml` file