### PR TITLE
Adds Space Hierarchy Request

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -566,6 +566,47 @@ class Api:
         return ("PUT", Api._build_path(path, query_parameters), Api.to_json(body))
 
     @staticmethod
+    def space_get_hierarchy(
+        access_token: str,
+        space_id: str,
+        from_page: Optional[str] = None,
+        limit: Optional[int] = None,
+        max_depth: Optional[int] = None,
+        suggested_only: bool = False,
+    ) -> Tuple[str, str]:
+        """Get rooms/spaces that are a part of the provided space.
+
+        Returns the HTTP method and HTTP path for the request.
+
+        Args:
+            access_token (str): The access token to be used with the request.
+            space_id (str): The ID of the space to get the hierarchy for.
+            from_page (str, optional): Pagination token from a previous request
+                to this endpoint.
+            limit (int, optional): The maximum number of rooms to return.
+            max_depth (int, optional): The maximum depth of the returned tree.
+            suggested_only (bool, optional): Whether or not to only return
+                rooms that are considered suggested. Defaults to False.
+        """
+        query_parameters = {"access_token": access_token}
+
+        if from_page:
+            query_parameters["from"] = from_page
+
+        if limit:
+            query_parameters["limit"] = limit
+
+        if max_depth:
+            query_parameters["max_depth"] = max_depth
+
+        if suggested_only:
+            query_parameters["suggested_only"] = suggested_only
+
+        path = ["rooms", space_id, "hierarchy"]
+
+        return ("GET", Api._build_path(path, query_parameters, "/_matrix/client/v1"))
+
+    @staticmethod
     def room_get_event(
         access_token: str, room_id: str, event_id: str
     ) -> Tuple[str, str]:

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -198,6 +198,8 @@ from ..responses import (
     SetPushRuleResponse,
     ShareGroupSessionError,
     ShareGroupSessionResponse,
+    SpaceGetHierarchyError,
+    SpaceGetHierarchyResponse,
     SyncError,
     SyncResponse,
     ThumbnailError,
@@ -1523,6 +1525,42 @@ class AsyncClient(Client):
         )
 
         return await self._send(DeleteDevicesResponse, method, path, data)
+
+    @logged_in_async
+    async def space_get_hierarchy(
+        self,
+        space_id: str,
+        from_page: Optional[str] = None,
+        limit: Optional[int] = None,
+        max_depth: Optional[int] = None,
+        suggested_only: bool = False,
+    ) -> Union[SpaceGetHierarchyResponse, SpaceGetHierarchyError]:
+        """Gets the space's room hierarchy.
+
+        Calls receive_response() to update the client state if necessary.
+
+        Returns either a `SpaceGetHierarchyResponse` if the request was successful
+        or a `SpaceGetHierarchyError` if there was an error with the request.
+
+        Args:
+            space_id (str): The ID of the space to get the hierarchy for.
+            from_page (str, optional): Pagination token from a previous request
+                to this endpoint.
+            limit (int, optional): The maximum number of rooms to return.
+            max_depth (int, optional): The maximum depth of the returned tree.
+            suggested_only (bool, optional): Whether or not to only return
+                rooms that are considered suggested. Defaults to False.
+        """
+        method, path = Api.space_get_hierarchy(
+            self.access_token,
+            space_id,
+            from_page=from_page,
+            limit=limit,
+            max_depth=max_depth,
+            suggested_only=suggested_only,
+        )
+
+        return await self._send(SpaceGetHierarchyResponse, method, path)
 
     @logged_in_async
     async def joined_members(

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -175,6 +175,8 @@ __all__ = [
     "UpdateReceiptMarkerResponse",
     "WhoamiError",
     "WhoamiResponse",
+    "SpaceGetHierarchyResponse",
+    "SpaceGetHierarchyError",
 ]
 
 
@@ -553,6 +555,10 @@ class RoomForgetError(_ErrorWithRoomId):
 
 
 class RoomMessagesError(_ErrorWithRoomId):
+    pass
+
+
+class SpaceGetHierarchyError(ErrorResponse):
     pass
 
 
@@ -1123,6 +1129,33 @@ class RoomGetVisibilityResponse(Response):
         # type: (...) -> Union[RoomGetVisibilityResponse, ErrorResponse]
         visibility = parsed_dict["visibility"]
         return cls(room_id, visibility)
+
+
+@dataclass
+class SpaceGetHierarchyResponse(Response):
+    """A response indicating successful space get hierarchy request.
+
+    Attributes:
+        next_batch: The token to supply in the from parameter of the next call.
+        rooms: The rooms in the space.
+    """
+
+    next_batch: str = field()
+    rooms: List = field()
+
+    @classmethod
+    @verify(
+        Schemas.space_hierarchy,
+        SpaceGetHierarchyError,
+        pass_arguments=False,
+    )
+    def from_dict(
+        cls, parsed_dict: Dict[str, Any]
+    ) -> Union["SpaceGetHierarchyResponse", SpaceGetHierarchyError]:
+        next_batch = parsed_dict.get("next_batch")
+        rooms = parsed_dict["rooms"]
+        resp = cls(next_batch, rooms)
+        return resp
 
 
 class EmptyResponse(Response):

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1924,3 +1924,65 @@ class Schemas:
             "state_key",
         ],
     }
+
+    space_hierarchy = {
+        "type": "object",
+        "properties": {
+            "next_batch": {"type": "string"},
+            "rooms": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "avatar_url": {"type": "string"},
+                        "canonical_alias": {"type": "string"},
+                        "children_state": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "content": {
+                                        "type": "object",
+                                        "properties": {
+                                            "via": {
+                                                "type": "array",
+                                                "items": {"type": "string"},
+                                            },
+                                        },
+                                        "required": ["via"],
+                                    },
+                                    "origin_server_ts": {"type": "integer"},
+                                    "sender": {"type": "string"},
+                                    "state_key": {"type": "string"},
+                                    "type": {"type": "string"},
+                                },
+                                "required": [
+                                    "content",
+                                    "origin_server_ts",
+                                    "sender",
+                                    "state_key",
+                                    "type",
+                                ],
+                            },
+                        },
+                        "guest_can_join": {"type": "boolean"},
+                        "join_rule": {"type": "string"},
+                        "name": {"type": "string"},
+                        "num_joined_members": {"type": "integer"},
+                        "room_id": {"type": "string"},
+                        "room_type": {"type": "string"},
+                        "topic": {"type": "string"},
+                        "world_readable": {"type": "boolean"},
+                    },
+                    "required": [
+                        "children_state",
+                        "guest_can_join",
+                        "num_joined_members",
+                        "room_id",
+                        "world_readable",
+                    ],
+                },
+            },
+        },
+        "required": ["rooms"],
+    }

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -112,6 +112,8 @@ from nio import (
     SetPushRuleActionsResponse,
     SetPushRuleResponse,
     ShareGroupSessionResponse,
+    SpaceGetHierarchyError,
+    SpaceGetHierarchyResponse,
     SyncResponse,
     ThumbnailError,
     ThumbnailResponse,
@@ -166,6 +168,10 @@ class TestClass:
     @property
     def login_response(self):
         return self._load_response("tests/data/login_response.json")
+
+    @property
+    def hierarchy_response(self):
+        return self._load_response("tests/data/get_hierarchy_response.json")
 
     @property
     def logout_response(self):
@@ -4260,3 +4266,65 @@ class TestClass:
         assert not asyncio.iscoroutinefunction(
             mock.restore_login
         ), "not logged_in method should not be awaitable"
+
+    async def test_space_get_hierarchy(self, async_client, aioresponse):
+        await async_client.receive_response(
+            LoginResponse.from_dict(self.login_response),
+        )
+        assert async_client.logged_in
+
+        base_url = "https://example.org/_matrix/client/v1"
+
+        aioresponse.get(
+            f"{base_url}/rooms/{TEST_ROOM_ID}/hierarchy?access_token=abc123",
+            status=200,
+            payload=self.hierarchy_response,
+        )
+
+        resp = await async_client.space_get_hierarchy(TEST_ROOM_ID)
+
+        assert isinstance(resp, SpaceGetHierarchyResponse)
+        assert isinstance(resp.rooms, list)
+
+        aioresponse.get(
+            f"{base_url}/rooms/{TEST_ROOM_ID}/hierarchy?access_token=abc123",
+            status=403,
+            payload={
+                "errcode": "M_FORBIDDEN",
+                "error": "You are not allowed to view this room.",
+            },
+        )
+
+        resp = await async_client.space_get_hierarchy(TEST_ROOM_ID)
+
+        assert isinstance(resp, SpaceGetHierarchyError)
+
+        aioresponse.get(
+            f"{base_url}/rooms/{TEST_ROOM_ID}/hierarchy?access_token=abc123&from=invalid",
+            status=400,
+            payload={
+                "errcode": "M_INVALID_PARAM",
+                "error": "suggested_only and max_depth cannot change on paginated requests",
+            },
+        )
+
+        resp = await async_client.space_get_hierarchy(TEST_ROOM_ID, from_page="invalid")
+
+        assert isinstance(resp, SpaceGetHierarchyError)
+
+        async_client.config = AsyncClientConfig(max_limit_exceeded=0)
+
+        aioresponse.get(
+            f"{base_url}/rooms/{TEST_ROOM_ID}/hierarchy?access_token=abc123",
+            status=429,
+            payload={
+                "errcode": "M_LIMIT_EXCEEDED",
+                "error": "Too many requests",
+                "retry_after_ms": 1,
+            },
+            repeat=True,
+        )
+
+        resp = await async_client.space_get_hierarchy(TEST_ROOM_ID)
+
+        assert isinstance(resp, SpaceGetHierarchyError)

--- a/tests/data/get_hierarchy_response.json
+++ b/tests/data/get_hierarchy_response.json
@@ -1,0 +1,30 @@
+{
+  "next_batch": "next_batch_token",
+  "rooms": [
+    {
+      "avatar_url": "mxc://example.org/abcdef",
+      "canonical_alias": "#general:example.org",
+      "children_state": [
+        {
+          "content": {
+            "via": [
+              "example.org"
+            ]
+          },
+          "origin_server_ts": 1629413349153,
+          "sender": "@alice:example.org",
+          "state_key": "!a:example.org",
+          "type": "m.space.child"
+        }
+      ],
+      "guest_can_join": false,
+      "join_rule": "public",
+      "name": "The First Space",
+      "num_joined_members": 42,
+      "room_id": "!space:example.org",
+      "room_type": "m.space",
+      "topic": "No other spaces were created first, ever",
+      "world_readable": true
+    }
+  ]
+}

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -39,6 +39,7 @@ from nio.responses import (
     RoomLeaveResponse,
     RoomMessagesResponse,
     RoomTypingResponse,
+    SpaceGetHierarchyResponse,
     SyncError,
     SyncResponse,
     ThumbnailError,
@@ -280,3 +281,8 @@ class TestClass:
         parsed_dict = _load_response("tests/data/login_info.json")
         response = LoginInfoResponse.from_dict(parsed_dict)
         assert isinstance(response, LoginInfoResponse)
+
+    def test_space_get_hierarchy(self):
+        parsed_dict = _load_response("tests/data/get_hierarchy_response.json")
+        response = SpaceGetHierarchyResponse.from_dict(parsed_dict)
+        assert isinstance(response, SpaceGetHierarchyResponse)


### PR DESCRIPTION
Adds the ability to request a space's hierarchy as described in the [Matrix spec](https://spec.matrix.org/latest/client-server-api/#discovering-rooms-within-spaces). I've also written some tests around using the new method.

In addition to the change above, I added a way to run the linters (isort & black) so that you can simply run `make lint` and it'll run both of them.