### PR TITLE
Support for Token-Authenticated Registration

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -326,6 +326,7 @@ class Api:
         password=None,  # type: str
         device_name="",  # type: Optional[str]
         device_id="",  # type: Optional[str]
+        auth_dict=None,  # type: Optional[dict[str, Any]]
     ):
         """Register a new user.
 
@@ -338,13 +339,26 @@ class Api:
             device_id (str): ID of the client device. If this does not
                 correspond to a known client device, a new device will be
                 created.
+            auth_dict (Dict[str, Any, optional): The authentication dictionary
+                containing the elements for a particular registration flow.
+                If not provided, then m.login.dummy is used.
+                See the example below and here
+                https://spec.matrix.org/latest/client-server-api/#account-registration-and-management
+                for detailed documentation
+
+                Example:
+                        >>> auth_dict = {
+                        >>>     "type": "m.login.registration_token",
+                        >>>     "registration_token": "REGISTRATIONTOKEN",
+                        >>>     "session": "session-id-from-homeserver"
+                        >>> }
         """
         path = Api._build_path(["register"])
 
         content_dict = {
-            "auth": {"type": "m.login.dummy"},
             "username": user,
             "password": password,
+            "auth": auth_dict or {"type": "m.login.dummy"},
         }
 
         if device_id:

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -142,8 +142,6 @@ from ..responses import (
     ProfileSetAvatarResponse,
     ProfileSetDisplayNameError,
     ProfileSetDisplayNameResponse,
-    PutAliasError,
-    PutAliasResponse,
     RegisterErrorResponse,
     RegisterInteractiveError,
     RegisterInteractiveResponse,

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -142,6 +142,11 @@ from ..responses import (
     ProfileSetAvatarResponse,
     ProfileSetDisplayNameError,
     ProfileSetDisplayNameResponse,
+    PutAliasError,
+    PutAliasResponse,
+    RegisterErrorResponse,
+    RegisterInteractiveError,
+    RegisterInteractiveResponse,
     RegisterResponse,
     Response,
     RoomBanError,
@@ -923,7 +928,93 @@ class AsyncClient(Client):
 
         return await self._send(LoginResponse, method, path, data)
 
-    async def register(self, username, password, device_name=""):
+    async def register_interactive(
+        self,
+        username: str,
+        password: str,
+        auth_dict: Dict[str, Any],
+        device_name: str = "",
+    ) -> Union[RegisterInteractiveResponse, RegisterInteractiveError]:
+        """Makes a request to the register endpoint using the provided
+        auth dictionary. This is allows for interactive registration flows
+        from the homeserver.
+
+        Calls receive_response() to update the client state if necessary.
+
+        Args:
+            username (str): Username to register the new user as.
+            password (str): New password for the user.
+            auth_dict (dict): The auth dictionary.
+            device_name (str): A display name to assign to a newly-created
+                device. Ignored if the logged in device corresponds to a
+                known device.
+
+        Returns a 'RegisterInteractiveResponse' if successful.
+        """
+        method, path, data = Api.register(
+            user=username,
+            password=password,
+            device_name=device_name,
+            device_id=self.device_id,
+            auth_dict=auth_dict,
+        )
+
+        return await self._send(RegisterInteractiveResponse, method, path, data)
+
+    async def register_with_token(
+        self,
+        username: str,
+        password: str,
+        registration_token: str,
+        device_name: str = "",
+    ) -> Union[RegisterResponse, RegisterErrorResponse]:
+        """Registers a user using a registration token.
+        See https://spec.matrix.org/latest/client-server-api/#token-authenticated-registration
+
+        Returns either a `RegisterResponse` if the request was successful or
+        a `RegisterErrorResponse` if there was an error with the request.
+
+        """
+        # must first register without token to get a session token
+        resp = await self.register_interactive(
+            username,
+            password,
+            auth_dict={"initial_device_display_name": self.device_id or "matrix-nio"},
+        )
+        if isinstance(resp, RegisterInteractiveError):
+            return RegisterErrorResponse(
+                resp.message, resp.status_code, resp.retry_after_ms, resp.soft_logout
+            )
+
+        # use session token to register with token
+        session_token = resp.session
+        resp = await self.register_interactive(
+            username,
+            password,
+            auth_dict={
+                "type": "m.login.registration_token",
+                "token": registration_token,
+                "session": session_token,
+            },
+        )
+        if isinstance(resp, RegisterInteractiveError):
+            return RegisterErrorResponse(
+                resp.message, resp.status_code, resp.retry_after_ms, resp.soft_logout
+            )
+
+        # finally call register with dummy auth with original session token
+        # to complete registration and acquire access token
+        return await self.register(
+            username, password, device_name=device_name, session_token=session_token
+        )
+
+    async def register(
+        self,
+        username: str,
+        password: str,
+        device_name: str = "",
+        session_token: Optional[str] = None,
+    ) -> Union[RegisterResponse, RegisterErrorResponse]:
         """Register with homeserver.
 
         Calls receive_response() to update the client state if necessary.
@@ -931,17 +1022,25 @@ class AsyncClient(Client):
         Args:
             username (str): Username to register the new user as.
             password (str): New password for the user.
-            device_name (str): A display name to assign to a newly-created
-                device. Ignored if the logged in device corresponds to a
-                known device.
+            device_name (str, optional): A display name to assign to a
+                newly-created device. Ignored if the logged in device
+                corresponds to a known device.
+            session_token (str, optional): The session token the server
+                provided during interactive registration. If not provided,
+                the session token is not added to the request's auth dict.
 
         Returns a 'RegisterResponse' if successful.
         """
+        auth_dict = {"type": "m.login.dummy"}
+        if session_token is not None:
+            auth_dict["session"] = session_token
+
         method, path, data = Api.register(
             user=username,
             password=password,
             device_name=device_name,
             device_id=self.device_id,
+            auth_dict=auth_dict,
         )
 
         return await self._send(RegisterResponse, method, path, data)

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -726,6 +726,39 @@ class RegisterResponse(Response):
 
 
 @dataclass
+class RegisterInteractiveError(ErrorResponse):
+    pass
+
+
+@dataclass
+class RegisterInteractiveResponse(Response):
+    stages: List[str] = field()
+    params: Dict[str, Any] = field()
+    session: str = field()
+    completed: List[str] = field()
+    user_id: str = field()
+    device_id: str = field()
+    access_token: str = field()
+
+    @classmethod
+    @verify(Schemas.register_flows, RegisterInteractiveError)
+    def from_dict(cls, parsed_dict: Dict[Any, Any]):
+        # type: (...) -> Union[RegisterInteractiveResponse, RegisterInteractiveError]
+        for flow in parsed_dict["flows"]:
+            stages = [stage for stage in flow["stages"]]
+
+        return cls(
+            stages,
+            parsed_dict["params"],
+            parsed_dict["session"],
+            parsed_dict.get("completed"),
+            parsed_dict.get("user_id"),
+            parsed_dict.get("device_id"),
+            parsed_dict.get("access_token"),
+        )
+
+
+@dataclass
 class LoginInfoError(ErrorResponse):
     pass
 

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -246,6 +246,32 @@ class Schemas:
         "required": ["user_id", "device_id", "access_token"],
     }
 
+    register_flows = {
+        "type": "object",
+        "properties": {
+            "flows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "stages": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        }
+                    },
+                    "required": ["stages"],
+                },
+            },
+            "params": {"type": "object"},
+            "session": {"type": "string"},
+            "completed": {"type": "array", "items": {"type": "string"}},
+            "user_id": {"type": "string", "format": "user_id"},
+            "device_id": {"type": "string"},
+            "access_token": {"type": "string"},
+        },
+        "required": ["flows", "params", "session"],
+    }
+
     login = {
         "type": "object",
         "properties": {

--- a/tests/data/register_interactive_response.json
+++ b/tests/data/register_interactive_response.json
@@ -1,0 +1,14 @@
+{
+    "flows": [{
+        "stages": [
+            "m.login.registration_token",
+            "m.login.dummy"
+        ]
+       }
+    ],
+    "session": "abc123",
+    "params": {},
+    "completed": [
+        "m.login.registration_token"
+    ]
+}

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -284,13 +284,11 @@ class TestClass:
         assert isinstance(response, LoginInfoResponse)
 
     def test_register(self):
-        parsed_dict = TestClass._load_response("tests/data/register_response.json")
+        parsed_dict = _load_response("tests/data/register_response.json")
         response = RegisterResponse.from_dict(parsed_dict)
         assert isinstance(response, RegisterResponse)
 
     def test_register_interactive(self):
-        parsed_dict = TestClass._load_response(
-            "tests/data/register_interactive_response.json"
-        )
+        parsed_dict = _load_response("tests/data/register_interactive_response.json")
         response = RegisterInteractiveResponse.from_dict(parsed_dict)
         assert isinstance(response, RegisterInteractiveResponse)

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -29,6 +29,8 @@ from nio.responses import (
     ProfileGetAvatarResponse,
     ProfileGetDisplayNameResponse,
     ProfileGetResponse,
+    RegisterInteractiveResponse,
+    RegisterResponse,
     RoomContextError,
     RoomContextResponse,
     RoomCreateResponse,
@@ -280,3 +282,15 @@ class TestClass:
         parsed_dict = _load_response("tests/data/login_info.json")
         response = LoginInfoResponse.from_dict(parsed_dict)
         assert isinstance(response, LoginInfoResponse)
+
+    def test_register(self):
+        parsed_dict = TestClass._load_response("tests/data/register_response.json")
+        response = RegisterResponse.from_dict(parsed_dict)
+        assert isinstance(response, RegisterResponse)
+
+    def test_register_interactive(self):
+        parsed_dict = TestClass._load_response(
+            "tests/data/register_interactive_response.json"
+        )
+        response = RegisterInteractiveResponse.from_dict(parsed_dict)
+        assert isinstance(response, RegisterInteractiveResponse)


### PR DESCRIPTION
This pull request introduces functionality for token-authenticated registration in accordance with the [Matrix spec](https://spec.matrix.org/latest/client-server-api/#token-authenticated-registration). The changes cater to registration scenarios where a Matrix server requires a registration token and a session token, facilitating an interactive registration flow.

## Key Enhancements:

**Interactive Registration**: Introduced a register_interactive method. This method supports registering with a custom auth dictionary, adhering to the [specifications outlined by Matrix](https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3register).

**Session Token in Standard Registration**: The conventional register method has been extended to accept an optional session_token. This modification ensures that users can finalize the registration process after an interactive flow. A session token, once obtained, needs to be consistently used throughout this flow.

**Convenient Token-Based Registration**: For ease of use, a dedicated register_with_token method has been added. This method encapsulates the entire token-authenticated registration process, making it simpler for the end-users.

## Testing:
Added tests for the register_with_token method to ensure functionality and compatibility.