### PR TITLE
Fix jsonschema deprecations

### DIFF
--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -44,9 +44,10 @@ def extend_with_default(validator_class):
 
 
 Validator = extend_with_default(Draft4Validator)
+Checker = FormatChecker()
 
 
-@FormatChecker.cls_checks("user_id", ValueError)
+@Checker.checks("user_id", ValueError)
 def check_user_id(value: str) -> bool:
     if not value.startswith("@"):
         raise ValueError("UserIDs start with @")
@@ -57,7 +58,7 @@ def check_user_id(value: str) -> bool:
     return True
 
 
-@FormatChecker.cls_checks("http_url", ValueError)
+@Checker.checks("http_url", ValueError)
 def check_http_url(value: str) -> bool:
     if not re.match(r"^https?://.+", value):
         raise ValueError("Must be http://... or https://... URL")
@@ -66,7 +67,7 @@ def check_http_url(value: str) -> bool:
 
 
 def validate_json(instance, schema):
-    Validator(schema, format_checker=FormatChecker()).validate(instance)
+    Validator(schema, format_checker=Checker).validate(instance)
 
 
 class Schemas:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ aiohttp = "^3.8.3"
 aiofiles = "^23.1.0"
 h11 = "^0.14.0"
 h2 = "^4.0.0"
-jsonschema = "^4.4.0"
+jsonschema = "^4.14.0"
 unpaddedbase64 = "^2.1.0"
 pycryptodome = "^3.10.1"
 python-olm = { version = "^3.1.3", optional = true }


### PR DESCRIPTION
Fix deprecation from `jsonschema>=4.14.0`.
https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst#v4140

```
nio/schemas.py:49
  /.../matrix-nio/nio/schemas.py:49: DeprecationWarning:
      FormatChecker.cls_checks is deprecated. Call FormatChecker.checks on a specific FormatChecker instance instead.
    @FormatChecker.cls_checks("user_id", ValueError)

nio/schemas.py:60
  /.../matrix-nio/nio/schemas.py:60: DeprecationWarning:
      FormatChecker.cls_checks is deprecated. Call FormatChecker.checks on a specific FormatChecker instance instead.
    @FormatChecker.cls_checks("http_url", ValueError)
```