### PR TITLE
Remove future dependency

### DIFF
--- a/contrib/archlinux/pkgbuild/PKGBUILD.git
+++ b/contrib/archlinux/pkgbuild/PKGBUILD.git
@@ -15,7 +15,7 @@ conflicts=('python-matrix-nio')
 provides=('python-matrix-nio')
 depends=('python' 'python-olm' 'python-h11' 'python-h2'
        'python-jsonschema' 'python-logbook'
-       'python-peewee' 'python-atomicwrites' 'python-future'
+       'python-peewee' 'python-atomicwrites'
        'python-pycryptodome' 'python-unpaddedbase64')
 checkdepends=()
 source=("$pkgbase-$pkgver.tar.gz")

--- a/nio/crypto/sas.py
+++ b/nio/crypto/sas.py
@@ -19,11 +19,11 @@ from __future__ import unicode_literals
 from builtins import bytes, super
 from datetime import datetime, timedelta
 from enum import Enum
+from itertools import zip_longest
 from typing import List, Optional, Tuple
 from uuid import uuid4
 
 import olm
-from future.moves.itertools import zip_longest
 
 from ..api import Api
 from ..event_builders import ToDeviceMessage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8.0"
-future = "^0.18.2"
 aiohttp = "^3.8.3"
 aiofiles = "^23.1.0"
 h11 = "^0.14.0"

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -1,4 +1,3 @@
-future
 peewee
 aiohttp
 h11


### PR DESCRIPTION
The project already requires Python 3.8 or newer. There is no reason to keep the `future` dependency any longer.
This will be necessary to provide support for Python 3.12, as `future` doesn't seem to be updated any longer and the current version will be incompatible with 3.12. https://github.com/PythonCharmers/python-future/issues/246

https://github.com/poljar/matrix-nio/blob/5354a4d5c03b9b85f36f0b8e5c153a6fe5dec8f9/pyproject.toml#L19

```
venv/lib/python3.11/site-packages/future/standard_library/__init__.py:65
  /.../venv/lib/python3.11/site-packages/future/standard_library/__init__.py:65: DeprecationWarning:
      the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp
```

Fixes #435