### PR TITLE
Project.toml (make peewee mandatory requirement)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ h2 = "^4.0.0"
 jsonschema = "^4.14.0"
 unpaddedbase64 = "^2.1.0"
 pycryptodome = "^3.10.1"
+peewee = { version = "^3.14.4"}
 python-olm = { version = "^3.1.3", optional = true }
-peewee = { version = "^3.14.4", optional = true }
 cachetools = { version = "^4.2.1", optional = true }
 atomicwrites = { version = "^1.4.0", optional = true }
 aiohttp-socks = "^0.7.0"


### PR DESCRIPTION
As dabase.py in store depends on this.