### PR TITLE
Introduce the DM room account data (`m.direct`)

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -627,7 +627,7 @@ class Api:
         """
         query_parameters = {"access_token": access_token}
 
-        path = ["users", user_id, "account_data", "m.direct"]
+        path = ["user", user_id, "account_data", "m.direct"]
 
         return ("GET", Api._build_path(path, query_parameters))
 

--- a/nio/api.py
+++ b/nio/api.py
@@ -616,6 +616,22 @@ class Api:
         return ("GET", Api._build_path(path, query_parameters, "/_matrix/client/v1"))
 
     @staticmethod
+    def direct_room_list(access_token: str, user_id: str) -> Tuple[str, str]:
+        """Lists all rooms flagged as direct the client is participating in.
+
+        Returns the HTTP method and HTTP path for the request.
+
+        Args:
+            access_token (str): The access token to be used within the request
+            user_id (str): The user id of the user to get the direct rooms for
+        """
+        query_parameters = {"access_token": access_token}
+
+        path = ["users", user_id, "account_data", "m.direct"]
+
+        return ("GET", Api._build_path(path, query_parameters))
+
+    @staticmethod
     def room_get_event(
         access_token: str, room_id: str, event_id: str
     ) -> Tuple[str, str]:

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -215,7 +215,7 @@ from ..responses import (
     UploadFilterResponse,
     UploadResponse,
     WhoamiError,
-    WhoamiResponse,
+    WhoamiResponse, DirectRoomListResponse,
 )
 from . import Client, ClientConfig
 from .base_client import logged_in_async, store_loaded
@@ -1771,6 +1771,18 @@ class AsyncClient(Client):
         )
 
         return await self._send(RoomSendResponse, method, path, data, (room_id,))
+
+    @logged_in_async
+    @client_session
+    async def direct_room_list(self) -> Dict[str, List[str]]:
+        """
+        Lists all rooms flagged with m.direct that the client is participating in.
+
+        This returns a dictionary of {user_id: [!room_id]}.
+        for example, {"@username:example.com": ["!ROOM_ID:example.com"]}
+        """
+        method, path = Api.direct_room_list(self.access_token, self.user_id)
+        return await self._send(DirectRoomListResponse, method, path)
 
     @logged_in_async
     async def room_get_event(

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -97,6 +97,7 @@ from ..responses import (
     DeletePushRuleResponse,
     DevicesError,
     DevicesResponse,
+    DirectRoomListResponse,
     DiscoveryInfoError,
     DiscoveryInfoResponse,
     DiskDownloadResponse,
@@ -215,7 +216,7 @@ from ..responses import (
     UploadFilterResponse,
     UploadResponse,
     WhoamiError,
-    WhoamiResponse, DirectRoomListResponse,
+    WhoamiResponse,
 )
 from . import Client, ClientConfig
 from .base_client import logged_in_async, store_loaded

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -1775,12 +1775,11 @@ class AsyncClient(Client):
 
     @logged_in_async
     @client_session
-    async def direct_room_list(self) -> Dict[str, List[str]]:
+    async def direct_room_list(self) -> Union[DirectRoomListResponse, DirectRoomListErrorResponse]:
         """
         Lists all rooms flagged with m.direct that the client is participating in.
 
-        This returns a dictionary of {user_id: [!room_id]}.
-        for example, {"@username:example.com": ["!ROOM_ID:example.com"]}
+        Returns a DirectRoomListResponse if the request was successful, or DirectRoomListErrorResponse if there was an error, or the current user has never marked any rooms marked with m.direct
         """
         method, path = Api.direct_room_list(self.access_token, self.user_id)
         return await self._send(DirectRoomListResponse, method, path)

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -97,7 +97,8 @@ from ..responses import (
     DeletePushRuleResponse,
     DevicesError,
     DevicesResponse,
-    DirectRoomListResponse,
+    DirectRoomsErrorResponse,
+    DirectRoomsResponse,
     DiscoveryInfoError,
     DiscoveryInfoResponse,
     DiskDownloadResponse,
@@ -1775,14 +1776,16 @@ class AsyncClient(Client):
 
     @logged_in_async
     @client_session
-    async def direct_room_list(self) -> Union[DirectRoomListResponse, DirectRoomListErrorResponse]:
+    async def list_direct_rooms(
+        self,
+    ) -> Union[DirectRoomsResponse, DirectRoomsErrorResponse]:
         """
         Lists all rooms flagged with m.direct that the client is participating in.
 
         Returns a DirectRoomListResponse if the request was successful, or DirectRoomListErrorResponse if there was an error, or the current user has never marked any rooms marked with m.direct
         """
         method, path = Api.direct_room_list(self.access_token, self.user_id)
-        return await self._send(DirectRoomListResponse, method, path)
+        return await self._send(DirectRoomsResponse, method, path)
 
     @logged_in_async
     async def room_get_event(

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -1002,7 +1002,7 @@ class DirectRoomsResponse(Response):
     def from_dict(
         cls,
         parsed_dict: Dict[Any, Any],
-    ) -> Union["DirectRoomsResponse", DirectRoomsErrorResponse]:
+    ) -> Union[DirectRoomsResponse, DirectRoomsErrorResponse]:
         if parsed_dict.get("errcode") is not None:
             # This user has no DM rooms that have been marked with m.direct.
             return DirectRoomsErrorResponse.from_dict(parsed_dict)

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -1002,7 +1002,7 @@ class DirectRoomsResponse(Response):
     def from_dict(
         cls,
         parsed_dict: Dict[Any, Any],
-    ) -> Union[DirectRoomsResponse, DirectRoomsErrorResponse]:
+    ) -> Union["DirectRoomsResponse", DirectRoomsErrorResponse]:
         if parsed_dict.get("errcode") is not None:
             # This user has no DM rooms that have been marked with m.direct.
             return DirectRoomsErrorResponse.from_dict(parsed_dict)

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -174,6 +174,8 @@ __all__ = [
     "WhoamiResponse",
     "SpaceGetHierarchyResponse",
     "SpaceGetHierarchyError",
+    "DirectRoomListResponse",
+    "DirectRoomListErrorResponse"
 ]
 
 
@@ -982,6 +984,10 @@ class RoomSendResponse(RoomEventIdResponse):
         return RoomSendError.from_dict(parsed_dict, room_id)
 
 
+class DirectRoomListErrorResponse(ErrorResponse):
+    pass
+
+
 @dataclass
 class DirectRoomListResponse(Response):
     """A response containing a list of direct rooms.
@@ -996,7 +1002,10 @@ class DirectRoomListResponse(Response):
     def from_dict(
         cls,
         parsed_dict: Dict[Any, Any],
-    ) -> Union[DirectRoomListResponse, ErrorResponse]:
+    ) -> Union[DirectRoomListResponse, DirectRoomListErrorResponse]:
+        if parsed_dict.get("errcode") == "M_UNRECOGNIZED":
+            # This user has no DM rooms that have been marked with m.direct.
+            return DirectRoomListErrorResponse.from_dict(parsed_dict)
         return cls(parsed_dict)
 
 

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -174,8 +174,8 @@ __all__ = [
     "WhoamiResponse",
     "SpaceGetHierarchyResponse",
     "SpaceGetHierarchyError",
-    "DirectRoomListResponse",
-    "DirectRoomListErrorResponse",
+    "DirectRoomsResponse",
+    "DirectRoomsErrorResponse",
 ]
 
 
@@ -984,12 +984,12 @@ class RoomSendResponse(RoomEventIdResponse):
         return RoomSendError.from_dict(parsed_dict, room_id)
 
 
-class DirectRoomListErrorResponse(ErrorResponse):
+class DirectRoomsErrorResponse(ErrorResponse):
     pass
 
 
 @dataclass
-class DirectRoomListResponse(Response):
+class DirectRoomsResponse(Response):
     """A response containing a list of direct rooms.
 
     Attributes:
@@ -1002,10 +1002,10 @@ class DirectRoomListResponse(Response):
     def from_dict(
         cls,
         parsed_dict: Dict[Any, Any],
-    ) -> Union[DirectRoomListResponse, DirectRoomListErrorResponse]:
-        if parsed_dict.get("errcode") == "M_UNRECOGNIZED":
+    ) -> Union[DirectRoomsResponse, DirectRoomsErrorResponse]:
+        if parsed_dict.get("errcode") is not None:
             # This user has no DM rooms that have been marked with m.direct.
-            return DirectRoomListErrorResponse.from_dict(parsed_dict)
+            return DirectRoomsErrorResponse.from_dict(parsed_dict)
         return cls(parsed_dict)
 
 

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -175,7 +175,7 @@ __all__ = [
     "SpaceGetHierarchyResponse",
     "SpaceGetHierarchyError",
     "DirectRoomListResponse",
-    "DirectRoomListErrorResponse"
+    "DirectRoomListErrorResponse",
 ]
 
 

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -983,6 +983,24 @@ class RoomSendResponse(RoomEventIdResponse):
 
 
 @dataclass
+class DirectRoomListResponse(Response):
+    """A response containing a list of direct rooms.
+
+    Attributes:
+        rooms (List[str]): The rooms joined by the account.
+    """
+
+    rooms: Dict[str, List[str]] = field()
+
+    @classmethod
+    def from_dict(
+        cls,
+        parsed_dict: Dict[Any, Any],
+    ) -> Union[DirectRoomListResponse, ErrorResponse]:
+        return cls(parsed_dict)
+
+
+@dataclass
 class RoomGetStateResponse(Response):
     """A response containing the state of a room.
 

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -34,6 +34,8 @@ from nio import (
     DeviceList,
     DeviceOneTimeKeyCount,
     DevicesResponse,
+    DirectRoomsErrorResponse,
+    DirectRoomsResponse,
     DiscoveryInfoError,
     DiscoveryInfoResponse,
     DownloadError,
@@ -124,8 +126,6 @@ from nio import (
     UpdateReceiptMarkerResponse,
     UploadFilterResponse,
     UploadResponse,
-    DirectRoomsResponse,
-    DirectRoomsErrorResponse
 )
 from nio.api import EventFormat, ResizingMethod, RoomPreset, RoomVisibility
 from nio.client.async_client import connect_wrapper, on_request_chunk_sent


### PR DESCRIPTION
This PR aims to introduce the changes needed to implement & close #421, by calling the account_data/m.direct endpoint and returning a list of DM rooms.
From the [matrix spec](https://spec.matrix.org/v1.8/client-server-api/#mdirect), `m.direct` holds:
> A map of which rooms are considered ‘direct’ rooms for specific users is kept in account_data in an event of type m.direct. The content of this event is an object where the keys are the user IDs and values are lists of room ID strings of the ‘direct’ rooms for that user ID.

Using this endpoint should allow for a clear distinction between traditional rooms and rooms that've been flagged as "direct", without needing to use hacky workarounds like [checking for the optional `is_direct` in Invite events](https://github.com/nexy7574/niobot/blob/7bdb5e047b78fb096e8cf95807a32fc51c6cec8d/src/niobot/client.py#L154-L164)

## Example usage of the new function
```python
>>> client = AsyncClient(...)
>>> response = await client.direct_room_list()
>>> print(response.rooms)
{"@user:example.com": ["!JiiOHXrIUCtcOJsZCa:matrix.org"]}
```
or, in the event the user does not have any DM rooms (flagged), this will return DirectRoomListErrorResponse instead, in line with the rest of the library.

---

As I lost the original code twice due to git/hub being flaky, this has been rushed in, but tested & functional. Suggestions and edits are welcome :)