### PR TITLE
Fix schemas for m.room.avatar and m.room.canonical_alias

### DIFF
--- a/nio/events/room_events.py
+++ b/nio/events/room_events.py
@@ -748,7 +748,7 @@ class RoomAliasEvent(Event):
 
     """
 
-    canonical_alias: str = field()
+    canonical_alias: Optional[str] = field()
 
     @classmethod
     @verify(Schemas.room_canonical_alias)
@@ -819,14 +819,14 @@ class RoomAvatarEvent(Event):
 
     """
 
-    avatar_url: str = field()
+    avatar_url: Optional[str] = field()
 
     @classmethod
     @verify(Schemas.room_avatar)
     def from_dict(
         cls, parsed_dict: Dict[Any, Any]
     ) -> Union[RoomAvatarEvent, BadEventType]:
-        room_avatar_url = parsed_dict["content"]["url"]
+        room_avatar_url = parsed_dict["content"].get("url")
 
         return cls(parsed_dict, room_avatar_url)
 

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -898,7 +898,7 @@ class Schemas:
             "type": {"type": "string"},
             "content": {
                 "type": "object",
-                "properties": {"alias": {"type": "string"}},
+                "properties": {"alias": {"type": ["string", "null"]}},
                 "required": [],
             },
         },
@@ -1000,7 +1000,7 @@ class Schemas:
                     },
                     "url": {"type": "string"},
                 },
-                "required": ["url"],
+                "required": [],
             },
         },
         "required": ["type", "sender", "content", "state_key"],

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -128,7 +128,7 @@ class TestClass:
         parsed_dict = TestClass._load_response("tests/data/events/room_avatar.json")
         parsed_dict["content"].pop("url")
         event = RoomAvatarEvent.from_dict(parsed_dict)
-        assert isinstance(event, BadEvent)
+        assert isinstance(event, RoomAvatarEvent)
 
     def test_tag_event(self):
         parsed_dict = TestClass._load_response("tests/data/events/tag.json")


### PR DESCRIPTION
[m.room.avatar](https://spec.matrix.org/v1.8/client-server-api/#mroomavatar) doesn't require `url`, and [m.room.canonical_alias](https://spec.matrix.org/v1.8/client-server-api/#mroomcanonical_alias) can have `alias` be null