### PR TITLE
[docs] Update the nio-bot description

### DIFF
--- a/doc/built-with-nio.rst
+++ b/doc/built-with-nio.rst
@@ -23,6 +23,6 @@ Projects built with nio
 - `matrix-webhook <https://github.com/nim65s/matrix-webhook>`_
 - `matrix-asgi <https://github.com/nim65s/matrix-asgi>`_
 - `opsdroid <https://github.com/opsdroid/opsdroid>`_
-- `niobot <https://github.com/EEKIM10/niobot>`_ - A bot-focused framework built on matrix-nio
+- `niobot <https://pypi.org/project/nio-bot>`_ - An extensive framework for building powerful Matrix bots with ease
 
 Are we missing a project? Submit a pull request and we'll get you added! Just edit ``doc/built-with-nio.rst``


### PR DESCRIPTION
The description, and link, on the built-with-nio.rst page are both outdated, with the latter also being a dead link (I changed my username - it still works, but that's only because I parked the old one).

It would be nice to get this updated to properly reflect the state of the library, and also refresh the link.

If the description is too long or there's an issue with the link being to PyPi instead of a GitHub repository let me know and I can work something out.