### PR TITLE
Changing room_messages to conform to MSC3567 + fixing type hints on update_receipt_marker

### DIFF
--- a/nio/api.py
+++ b/nio/api.py
@@ -1061,7 +1061,7 @@ class Api:
     def room_messages(
         access_token: str,
         room_id: str,
-        start: str,
+        start: Optional[str] = None,
         end: Optional[str] = None,
         direction: MessageDirection = MessageDirection.back,
         limit: int = 10,
@@ -1086,9 +1086,11 @@ class Api:
         """
         query_parameters = {
             "access_token": access_token,
-            "from": start,
             "limit": limit,
         }
+
+        if start:
+            query_parameters["from"] = start
 
         if end:
             query_parameters["to"] = end

--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -211,6 +211,7 @@ from ..responses import (
     ToDeviceResponse,
     UpdateDeviceError,
     UpdateDeviceResponse,
+    UpdateReceiptMarkerError,
     UpdateReceiptMarkerResponse,
     UploadError,
     UploadFilterError,
@@ -2629,7 +2630,7 @@ class AsyncClient(Client):
     async def room_messages(
         self,
         room_id: str,
-        start: str,
+        start: Optional[str] = None,
         end: Optional[str] = None,
         direction: MessageDirection = MessageDirection.back,
         limit: int = 10,
@@ -2673,7 +2674,7 @@ class AsyncClient(Client):
         method, path = Api.room_messages(
             self.access_token,
             room_id,
-            start,
+            start=start,
             end=end,
             direction=direction,
             limit=limit,
@@ -2722,7 +2723,7 @@ class AsyncClient(Client):
         room_id: str,
         event_id: str,
         receipt_type: str = "m.read",
-    ) -> None:
+    ) -> Union[UpdateReceiptMarkerResponse, UpdateReceiptMarkerError]:
         """Update the marker of given the `receipt_type` to specified `event_id`.
 
         Calls receive_response() to update the client state if necessary.

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1746,7 +1746,7 @@ class TestClass:
             no_start_param_url + '&filter={"room":{"state":{"limit":1}}}',
             status=200,
             payload=self.messages_response,
-            )
+        )
         resp = await async_client.room_messages(
             TEST_ROOM_ID,
             message_filter={"room": {"state": {"limit": 1}}},

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1735,6 +1735,24 @@ class TestClass:
         )
         assert isinstance(resp, RoomMessagesResponse)
 
+        # Dict filter no start token (MSC3567)
+
+        no_start_param_url = (
+            f"https://example.org/_matrix/client/r0/rooms/{TEST_ROOM_ID}/"
+            "messages?access_token=abc123"
+            "&dir=b&limit=10"
+        )
+        aioresponse.get(
+            no_start_param_url + '&filter={"room":{"state":{"limit":1}}}',
+            status=200,
+            payload=self.messages_response,
+            )
+        resp = await async_client.room_messages(
+            TEST_ROOM_ID,
+            message_filter={"room": {"state": {"limit": 1}}},
+        )
+        assert isinstance(resp, RoomMessagesResponse)
+
     async def test_room_typing(self, async_client, aioresponse):
         await async_client.receive_response(
             LoginResponse.from_dict(self.login_response)


### PR DESCRIPTION
See: https://github.com/poljar/matrix-nio/issues/469

* MSC3567 allows an empty start param when getting messages via `room_messages`. This works fine against synapse but the nio library does not allow it. Added a test to ensure nio allows MSC3567
* Also fixed type hints for `update_receipt_marker`

Let me know if you want me to make any changes to conform to contributing guidelines or testing best practices