### PR TITLE
Fix print for FileResponse when download is saved to file

### DIFF
--- a/src/nio/responses.py
+++ b/src/nio/responses.py
@@ -327,7 +327,10 @@ class FileResponse(Response):
     filename: Optional[str] = field()
 
     def __str__(self):
-        return f"{len(self.body)} bytes, content type: {self.content_type}, filename: {self.filename}"
+        if isinstance(self.body, bytes):
+            return f"{len(self.body)} bytes, content type: {self.content_type}, filename: {self.filename}"
+        else:
+            return f"content type: {self.content_type}, location: {self.body}"
 
     @classmethod
     def from_data(


### PR DESCRIPTION
With the `download` method in `AsyncClient` there is the option to save the data directly to disk (https://github.com/AntonMulder/matrix-nio/blob/71ea7ba3380ea4f0d4fc831a215a2c88c99f9679/src/nio/client/async_client.py#L3209-L3209)

When this is done, `body` in `FileResponse` will have the type `os.pathLike` (https://github.com/AntonMulder/matrix-nio/blob/71ea7ba3380ea4f0d4fc831a215a2c88c99f9679/src/nio/responses.py#L325-L325)

Within `__str__` the package calls `len()` on `self.body`, but this will raise an exception as `PosixPath` has no len:

```
    return f"{len(self.body)} bytes, content type: {self.content_type}, filename: {self.filename}"
              ~~~^^^^^^^^^^^
TypeError: object of type 'PosixPath' has no len()
```

With this change this issue will be fixed and the output will be like this:

Example:
```
content type: image/jpeg, location: /example.jpg
```