### PR TITLE
Move .flattened() to a base class of Event, BadEvent, UnknownBadEvent

### DIFF
--- a/src/nio/events/room_events.py
+++ b/src/nio/events/room_events.py
@@ -21,11 +21,18 @@ from typing import Any, Dict, List, Optional, Union
 
 from ..event_builders import RoomKeyRequestMessage
 from ..schemas import Schemas
-from .misc import BadEvent, BadEventType, UnknownBadEvent, validate_or_badevent, verify
+from .misc import (
+    BadEvent,
+    BadEventType,
+    BaseEvent,
+    UnknownBadEvent,
+    validate_or_badevent,
+    verify,
+)
 
 
 @dataclass
-class Event:
+class Event(BaseEvent):
     """Matrix Event class.
 
     This is the base event class, most events inherit from this class.
@@ -69,33 +76,6 @@ class Event:
         self.event_id = self.source["event_id"]
         self.sender = self.source["sender"]
         self.server_timestamp = self.source["origin_server_ts"]
-
-    def flattened(
-        self,
-        _prefix: str = "",
-        _source: Optional[Dict[str, Any]] = None,
-        _flat: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-        """Return a flattened version of the ``source`` dict with dotted keys.
-
-        Example:
-            >>> event.source
-            {"content": {"body": "foo"}, "m.test": {"key": "bar"}}
-            >>> event.source.flattened()
-            {"content.body": "foo", "m.test.key": "bar"}
-
-        """
-
-        source = self.source if _source is None else _source
-        flat = {} if _flat is None else _flat
-
-        for key, value in source.items():
-            if isinstance(value, dict):
-                self.flattened(f"{_prefix}{key}.", value, flat)
-            else:
-                flat[f"{_prefix}{key}"] = value
-
-        return flat
 
     @classmethod
     def from_dict(cls, parsed_dict: Dict[Any, Any]) -> Union[Event, BadEventType]:


### PR DESCRIPTION
It's useful for me to have `.flattened()` accessible in `BadEvent`s and `UnknownBadEvent`s, not just `Event`s. This patch creates a new `BaseEvent` class which all other event classes inherit from, and moves `.flattened()` there.