### PR TITLE
Support room version 12

### DIFF
--- a/src/nio/api.py
+++ b/src/nio/api.py
@@ -1014,6 +1014,7 @@ class Api:
         power_level_override: Optional[Dict[str, Any]] = None,
         predecessor: Optional[Dict[str, Any]] = None,
         space: bool = False,
+        additional_creators: Optional[List[str]] = None,
     ) -> Tuple[str, str, str]:
         """Create a new room.
 
@@ -1077,6 +1078,11 @@ class Api:
                 ``m.room.power_levels`` event before it is sent to the room.
 
             space (bool): Create as a Space (defaults to False).
+
+            additional_creators (list): a list of user id to give the same
+                (infinite) power level as the sender of the event.
+                Applicable to room versions >= 12.
+
         """
         path = ["createRoom"]
         query_parameters = {"access_token": access_token}
@@ -1119,6 +1125,9 @@ class Api:
 
         if space:
             body["creation_content"]["type"] = "m.space"
+
+        if additional_creators:
+            body["creation_content"]["additional_creators"] = additional_creators
 
         return "POST", Api._build_path(path, query_parameters), Api.to_json(body)
 

--- a/src/nio/client/async_client.py
+++ b/src/nio/client/async_client.py
@@ -3945,7 +3945,6 @@ class AsyncClient(Client):
         ],
         room_upgrade_message: str = "This room has been replaced",
         room_power_level_overwrite: Optional[Dict[str, Any]] = None,
-        include_predecessor_event_id: bool = True,
     ) -> Union[RoomUpgradeResponse, RoomUpgradeError]:
         """Upgrade an existing room.
 
@@ -3991,7 +3990,7 @@ class AsyncClient(Client):
             "room_id": old_room_id,
         }
 
-        if include_predecessor_event_id:
+        if not MatrixRoom._supports_room_version_12(new_room_version):
             # Get last known event from the old room
             old_room_event = await self.room_messages(
                 start="", room_id=old_room_id, limit=1
@@ -4085,6 +4084,12 @@ class AsyncClient(Client):
         self, room_id: str, event_name: str, event_type: str = "event"
     ) -> Union[bool, ErrorResponse]:
         who_am_i = await self.whoami()
+
+        # TODO: why does this function use whoami instead of self.user_id?
+        # Does that also mean that it shouldn't use self.creators?
+        if who_am_i.user_id in self.creators:
+            return True
+
         power_levels = await self.room_get_state_event(room_id, "m.room.power_levels")
 
         try:
@@ -4112,6 +4117,12 @@ class AsyncClient(Client):
         self, room_id: str, permission_type: str
     ) -> Union[bool, ErrorResponse]:
         who_am_i = await self.whoami()
+
+        # TODO: why does this function use whoami instead of self.user_id?
+        # Does that also mean that it shouldn't use self.creators?
+        if who_am_i.user_id in self.creators:
+            return True
+
         power_levels = await self.room_get_state_event(room_id, "m.room.power_levels")
 
         try:

--- a/src/nio/client/async_client.py
+++ b/src/nio/client/async_client.py
@@ -3972,7 +3972,10 @@ class AsyncClient(Client):
                 ``m.room.power_levels`` event before it is sent to the room.
         """
         # Check if we are allowed to tombstone a room
-        if not await self.has_event_permission(old_room_id, "m.room.tombstone", "state"):
+        tombstone_permission = await self.has_event_permission(
+            old_room_id, "m.room.tombstone", "state"
+        )
+        if tombstone_permission is not True:
             return RoomUpgradeError("Not allowed to upgrade room")
 
         # Get state events for the old room

--- a/src/nio/client/async_client.py
+++ b/src/nio/client/async_client.py
@@ -4105,7 +4105,7 @@ class AsyncClient(Client):
             user_power_level = power_levels.content["users"][who_am_i.user_id]
         except KeyError:
             user_power_level = power_levels.content.get("users_default", 0)
-        except:
+        except Exception:
             return ErrorResponse("Couldn't get user power levels")
 
         try:
@@ -4117,7 +4117,7 @@ class AsyncClient(Client):
                 event_power_level = power_levels.content.get("state_default", 50)
             else:
                 return ErrorResponse(f"event_type {event_type} unknown")
-        except:
+        except Exception:
             return ErrorResponse("Couldn't get event power levels")
 
         return user_power_level >= event_power_level
@@ -4139,7 +4139,7 @@ class AsyncClient(Client):
             user_power_level = power_levels.content["users"][who_am_i.user_id]
         except KeyError:
             user_power_level = power_levels.content.get("users_default", 0)
-        except:
+        except Exception:
             return ErrorResponse("Couldn't get user power levels")
 
         try:

--- a/src/nio/client/async_client.py
+++ b/src/nio/client/async_client.py
@@ -2444,6 +2444,7 @@ class AsyncClient(Client):
         power_level_override: Optional[Dict[str, Any]] = None,
         predecessor: Optional[Dict[str, Any]] = None,
         space: bool = False,
+        additional_creators: Optional[List[str]] = None,
     ) -> Union[RoomCreateResponse, RoomCreateError]:
         """Create a new room.
 
@@ -2514,6 +2515,10 @@ class AsyncClient(Client):
                 ``room_id``: ``!oldroom:example.org``
 
             space (bool): Create as a Space (defaults to False).
+
+            additional_creators (list): a list of user id to give the same
+                (infinite) power level as the sender of the event.
+                Applicable to room versions >= 12.
         """
 
         method, path, data = Api.room_create(
@@ -2532,6 +2537,7 @@ class AsyncClient(Client):
             power_level_override=power_level_override,
             predecessor=predecessor,
             space=space,
+            additional_creators=additional_creators,
         )
 
         return await self._send(RoomCreateResponse, method, path, data)

--- a/src/nio/client/async_client.py
+++ b/src/nio/client/async_client.py
@@ -4119,6 +4119,7 @@ class AsyncClient(Client):
 
         return user_power_level >= event_power_level
 
+    @logged_in_async
     async def has_permission(
         self, room_id: str, permission_type: str
     ) -> Union[bool, ErrorResponse]:
@@ -4126,7 +4127,7 @@ class AsyncClient(Client):
 
         # TODO: why does this function use whoami instead of self.user_id?
         # Does that also mean that it shouldn't use self.creators?
-        if who_am_i.user_id in self.creators:
+        if who_am_i.user_id in self.rooms[room_id].creators:
             return True
 
         power_levels = await self.room_get_state_event(room_id, "m.room.power_levels")
@@ -4134,8 +4135,8 @@ class AsyncClient(Client):
         try:
             user_power_level = power_levels.content["users"][who_am_i.user_id]
         except KeyError:
-            user_power_level = power_levels.content["users_default"]
-        else:
+            user_power_level = power_levels.content.get("users_default", 0)
+        except:
             return ErrorResponse("Couldn't get user power levels")
 
         try:

--- a/src/nio/client/async_client.py
+++ b/src/nio/client/async_client.py
@@ -3975,10 +3975,9 @@ class AsyncClient(Client):
         tombstone_permission = await self.has_event_permission(
             old_room_id, "m.room.tombstone", "state"
         )
-        if (
-            not isinstance(tombstone_permission, ErrorResponse)
-            and not tombstone_permission
-        ):
+        if isinstance(tombstone_permission, ErrorResponse):
+            return RoomUpgradeError("Could not determine if allowed to upgrade room")
+        if not tombstone_permission:
             return RoomUpgradeError("Not allowed to upgrade room")
 
         # Get state events for the old room

--- a/src/nio/client/async_client.py
+++ b/src/nio/client/async_client.py
@@ -3975,7 +3975,10 @@ class AsyncClient(Client):
         tombstone_permission = await self.has_event_permission(
             old_room_id, "m.room.tombstone", "state"
         )
-        if tombstone_permission is not True:
+        if (
+            not isinstance(tombstone_permission, ErrorResponse)
+            and not tombstone_permission
+        ):
             return RoomUpgradeError("Not allowed to upgrade room")
 
         # Get state events for the old room
@@ -4095,7 +4098,7 @@ class AsyncClient(Client):
         who_am_i = await self.whoami()
 
         # TODO: why does this function use whoami instead of self.user_id?
-        # Does that also mean that it shouldn't use self.creators?
+        # Does that also mean that it shouldn't use MatrixRoom.creators?
         if who_am_i.user_id in self.rooms[room_id].creators:
             return True
 
@@ -4129,7 +4132,7 @@ class AsyncClient(Client):
         who_am_i = await self.whoami()
 
         # TODO: why does this function use whoami instead of self.user_id?
-        # Does that also mean that it shouldn't use self.creators?
+        # Does that also mean that it shouldn't use MatrixRoom.creators?
         if who_am_i.user_id in self.rooms[room_id].creators:
             return True
 

--- a/src/nio/client/async_client.py
+++ b/src/nio/client/async_client.py
@@ -4001,7 +4001,11 @@ class AsyncClient(Client):
             "room_id": old_room_id,
         }
 
-        if not MatrixRoom._supports_room_version_12(new_room_version):
+        if MatrixRoom._supports_room_version_12(new_room_version):
+            who_am_i = await self.whoami()
+            if who_am_i.user_id in old_room_power_levels["users"]:
+                del old_room_power_levels["users"][who_am_i.user_id]
+        else:
             # Get last known event from the old room
             old_room_event = await self.room_messages(
                 start="", room_id=old_room_id, limit=1

--- a/src/nio/events/room_events.py
+++ b/src/nio/events/room_events.py
@@ -628,12 +628,15 @@ class RoomCreateEvent(Event):
             In spec v1.2 the following room types are specified:
                 - `m.space`
             Unspecified room types are permitted through the use of Namespaced Identifiers.
+        additional_creators (list):
+            List of additional creators of the room, for room versions 12 and higher.
 
     """
 
     federate: bool = True
     room_version: str = "1"
     room_type: str = ""
+    additional_creators: List[str] = field(default_factory=list)
 
     @classmethod
     @verify(Schemas.room_create)
@@ -642,10 +645,10 @@ class RoomCreateEvent(Event):
     ) -> Union[RoomCreateEvent, BadEventType]:
         federate = parsed_dict["content"]["m.federate"]
         version = parsed_dict["content"]["room_version"]
-        if "type" in parsed_dict["content"]:
-            room_type = parsed_dict["content"]["type"]
+        room_type = parsed_dict["content"].get("type", "")
+        additional_creators = parsed_dict["content"].get("additional_creators", [])
 
-        return cls(parsed_dict, federate, version, room_type)
+        return cls(parsed_dict, federate, version, room_type, additional_creators)
 
 
 @dataclass

--- a/src/nio/events/room_events.py
+++ b/src/nio/events/room_events.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from ..event_builders import RoomKeyRequestMessage
 from ..schemas import Schemas
@@ -1277,8 +1277,9 @@ class PowerLevels:
             from user_id to power level for that user.
         events (dict): The level required to send specific event types. This is
             a mapping from event type to power level required.
-        creators (set): The user_ids that created the room and should have
+        creators (dict): The user_ids that created the room and should have
             infinite power. This should be empty for room versions < 12.
+            Values in the dict are always True.
 
     """
 
@@ -1287,7 +1288,7 @@ class PowerLevels:
     events: Dict[str, int] = field(default_factory=dict)
     # TODO: does it make sense to put a creators field here? It's not part of
     # the event. But can_user_... will not be correct without it.
-    creators: Set[str] = field(default_factory=set)
+    creators: Dict[str, Literal[True]] = field(default_factory=dict)
 
     def get_state_event_required_level(self, event_type: str) -> int:
         """Get required power level to send a certain type of state event.

--- a/src/nio/rooms.py
+++ b/src/nio/rooms.py
@@ -430,7 +430,6 @@ class MatrixRoom:
 
             # Update the power levels of the joined users
             for user_id, level in self.power_levels.users.items():
-                # TODO: What about room creators?
                 if user_id in self.users:
                     logger.info(
                         f"Changing power level for user {user_id} from {self.users[user_id].power_level} to {level}"

--- a/src/nio/rooms.py
+++ b/src/nio/rooms.py
@@ -98,6 +98,19 @@ class MatrixRoom:
         self.creators: Set[str] = set()
         # yapf: enable
 
+    # TODO: where should this function go? It's also needed in AsyncClient.
+    @staticmethod
+    def _supports_room_version_12(room_version):
+        try:
+            return int(room_version) >= 12
+        except ValueError:
+            # TODO: what about other/unknown non-int room versions? Assume v1?
+            return room_version == "org.matrix.hydra.11"
+
+    @property
+    def supports_room_version_12(self):
+        return self._supports_room_version_12(self.room_version)
+
     @property
     def display_name(self) -> str:
         """Calculate display name for a room.
@@ -380,7 +393,10 @@ class MatrixRoom:
             self.federate = event.federate
             self.room_version = event.room_version
             self.room_type = event.room_type
-            self.creators = set(event.sender) | set(event.additional_creators)
+            if self.supports_room_version_12:
+                # < v12 can be considered equivalent to v12 with "no creators"
+                self.creators = set(event.sender) | set(event.additional_creators)
+                self.power_levels.creators = self.creators
 
         elif isinstance(event, RoomGuestAccessEvent):
             self.guest_access = event.guest_access

--- a/src/nio/rooms.py
+++ b/src/nio/rooms.py
@@ -95,6 +95,7 @@ class MatrixRoom:
         self.unread_highlights: int = 0
         self.members_synced: bool = False
         self.replacement_room: Union[str, None] = None
+        self.creators: Set[str] = set()
         # yapf: enable
 
     @property
@@ -379,6 +380,7 @@ class MatrixRoom:
             self.federate = event.federate
             self.room_version = event.room_version
             self.room_type = event.room_type
+            self.creators = set(event.sender) | set(event.additional_creators)
 
         elif isinstance(event, RoomGuestAccessEvent):
             self.guest_access = event.guest_access

--- a/src/nio/rooms.py
+++ b/src/nio/rooms.py
@@ -396,7 +396,7 @@ class MatrixRoom:
             if self.supports_room_version_12:
                 # < v12 can be considered equivalent to v12 with "no creators"
                 self.creators = {event.sender} | set(event.additional_creators)
-                self.power_levels.creators = self.creators
+                self.power_levels.creators = dict.fromkeys(self.creators, True)
 
         elif isinstance(event, RoomGuestAccessEvent):
             self.guest_access = event.guest_access

--- a/src/nio/rooms.py
+++ b/src/nio/rooms.py
@@ -395,7 +395,7 @@ class MatrixRoom:
             self.room_type = event.room_type
             if self.supports_room_version_12:
                 # < v12 can be considered equivalent to v12 with "no creators"
-                self.creators = set(event.sender) | set(event.additional_creators)
+                self.creators = {event.sender} | set(event.additional_creators)
                 self.power_levels.creators = self.creators
 
         elif isinstance(event, RoomGuestAccessEvent):

--- a/src/nio/rooms.py
+++ b/src/nio/rooms.py
@@ -430,6 +430,7 @@ class MatrixRoom:
 
             # Update the power levels of the joined users
             for user_id, level in self.power_levels.users.items():
+                # TODO: What about room creators?
                 if user_id in self.users:
                     logger.info(
                         f"Changing power level for user {user_id} from {self.users[user_id].power_level} to {level}"

--- a/src/nio/schemas.py
+++ b/src/nio/schemas.py
@@ -18,7 +18,7 @@ import re
 
 from jsonschema import Draft4Validator, FormatChecker, validators
 
-RoomRegex = "^!.+:.+$"
+RoomRegex = "^!.+$"
 UserIdRegex = "^@.*:.+$"
 EventTypeRegex = r"^.+\..+"
 Base64Regex = r"[^-A-Za-z0-9+/=]|=[^=]|={3,}$"
@@ -799,13 +799,14 @@ class Schemas:
                     "m.federate": {"type": "boolean", "default": True},
                     "room_version": {"type": "string", "default": "1"},
                     "type": {"type": "string", "default": ""},
+                    "additional_creators": {"type": "array", "items": {"type": "string"}},
                     "predecessor": {
                         "type": "object",
                         "properties": {
                             "event_id": {"type": "string"},
                             "room_id": {"type": "string", "format": "room_id"},
                         },
-                        "required": ["event_id", "room_id"],
+                        "required": ["room_id"],
                     },
                 },
                 "required": [],

--- a/src/nio/schemas.py
+++ b/src/nio/schemas.py
@@ -799,7 +799,10 @@ class Schemas:
                     "m.federate": {"type": "boolean", "default": True},
                     "room_version": {"type": "string", "default": "1"},
                     "type": {"type": "string", "default": ""},
-                    "additional_creators": {"type": "array", "items": {"type": "string"}},
+                    "additional_creators": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
                     "predecessor": {
                         "type": "object",
                         "properties": {

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -152,6 +152,7 @@ BASE_MEDIA_URL = f"https://example.org{MATRIX_MEDIA_API_PATH}"
 BASE_LEGACY_MEDIA_URL = f"https://example.org{MATRIX_LEGACY_MEDIA_API_PATH}"
 TEST_ROOM_ID = "!testroom:example.org"
 TEST_ROOM_ID2 = "!testroom2:example.org"
+TEST_ROOM_ID_V12 = "$5hdALbO+xIhzcLTxCkspx5uqry9wO8322h/OI9ApnHE"
 
 ALICE_ID = "@alice:example.org"
 ALICE_DEVICE_ID = "JLAFKJWSCS"
@@ -1682,7 +1683,7 @@ class TestClass:
                 is None
             )
             return CallbackResult(
-                status=200, payload=self.room_id_response(TEST_ROOM_ID2)
+                status=200, payload=self.room_id_response(TEST_ROOM_ID_V12)
             )
 
         aioresponse.post(f"{BASE_URL_V3}/createRoom" "", callback=room_create_cb)
@@ -1692,7 +1693,7 @@ class TestClass:
             alias="foo",
             name="bar",
             topic="Foos and bars",
-            room_version="5",
+            room_version="12",
             preset=RoomPreset.trusted_private_chat,
             invite={ALICE_ID},
             initial_state=[],
@@ -1700,7 +1701,7 @@ class TestClass:
             predecessor={"room_id": TEST_ROOM_ID},
         )
         assert isinstance(resp, RoomCreateResponse)
-        assert resp.room_id == TEST_ROOM_ID2
+        assert resp.room_id == TEST_ROOM_ID_V12
 
     async def test_room_create__additional_creators(self, async_client, aioresponse):
         def room_create_cb(url, data, **kwargs):
@@ -1713,7 +1714,7 @@ class TestClass:
                 ALICE_ID
             ]
             return CallbackResult(
-                status=200, payload=self.room_id_response(TEST_ROOM_ID)
+                status=200, payload=self.room_id_response(TEST_ROOM_ID_V12)
             )
 
         aioresponse.post(f"{BASE_URL_V3}/createRoom" "", callback=room_create_cb)
@@ -1723,7 +1724,7 @@ class TestClass:
             alias="foo",
             name="bar",
             topic="Foos and bars",
-            room_version="5",
+            room_version="12",
             preset=RoomPreset.trusted_private_chat,
             invite={ALICE_ID},
             initial_state=[],
@@ -1731,7 +1732,7 @@ class TestClass:
             additional_creators=[ALICE_ID],
         )
         assert isinstance(resp, RoomCreateResponse)
-        assert resp.room_id == TEST_ROOM_ID
+        assert resp.room_id == TEST_ROOM_ID_V12
 
     async def test_join(self, async_client, aioresponse):
         aioresponse.post(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -1633,14 +1633,21 @@ class TestClass:
                 data = data.decode(encoding="utf-8")
             if isinstance(data, str):
                 data = json.loads(data)
-            assert data.get("creation_content", {}).get("predecessor", {}).get("room_id", "") == TEST_ROOM_ID
-            assert data.get("creation_content", {}).get("predecessor", {}).get("event_id") == "event_id_1"
-            return CallbackResult(status=200, payload=self.room_id_response(TEST_ROOM_ID2))
+            assert (
+                data.get("creation_content", {})
+                .get("predecessor", {})
+                .get("room_id", "")
+                == TEST_ROOM_ID
+            )
+            assert (
+                data.get("creation_content", {}).get("predecessor", {}).get("event_id")
+                == "event_id_1"
+            )
+            return CallbackResult(
+                status=200, payload=self.room_id_response(TEST_ROOM_ID2)
+            )
 
-        aioresponse.post(
-            f"{BASE_URL_V3}/createRoom" "",
-            callback=room_create_cb
-        )
+        aioresponse.post(f"{BASE_URL_V3}/createRoom" "", callback=room_create_cb)
 
         resp = await async_client.room_create(
             visibility=RoomVisibility.public,
@@ -1652,10 +1659,7 @@ class TestClass:
             invite={ALICE_ID},
             initial_state=[],
             power_level_override={},
-            predecessor={
-                "room_id": TEST_ROOM_ID,
-                "event_id": "event_id_1"
-            }
+            predecessor={"room_id": TEST_ROOM_ID, "event_id": "event_id_1"},
         )
         assert isinstance(resp, RoomCreateResponse)
         assert resp.room_id == TEST_ROOM_ID2
@@ -1667,14 +1671,21 @@ class TestClass:
                 data = data.decode(encoding="utf-8")
             if isinstance(data, str):
                 data = json.loads(data)
-            assert data.get("creation_content", {}).get("predecessor", {}).get("room_id", "") == TEST_ROOM_ID
-            assert data.get("creation_content", {}).get("predecessor", {}).get("event_id") is None
-            return CallbackResult(status=200, payload=self.room_id_response(TEST_ROOM_ID2))
+            assert (
+                data.get("creation_content", {})
+                .get("predecessor", {})
+                .get("room_id", "")
+                == TEST_ROOM_ID
+            )
+            assert (
+                data.get("creation_content", {}).get("predecessor", {}).get("event_id")
+                is None
+            )
+            return CallbackResult(
+                status=200, payload=self.room_id_response(TEST_ROOM_ID2)
+            )
 
-        aioresponse.post(
-            f"{BASE_URL_V3}/createRoom" "",
-            callback=room_create_cb
-        )
+        aioresponse.post(f"{BASE_URL_V3}/createRoom" "", callback=room_create_cb)
 
         resp = await async_client.room_create(
             visibility=RoomVisibility.public,
@@ -1686,9 +1697,7 @@ class TestClass:
             invite={ALICE_ID},
             initial_state=[],
             power_level_override={},
-            predecessor={
-                "room_id": TEST_ROOM_ID
-            }
+            predecessor={"room_id": TEST_ROOM_ID},
         )
         assert isinstance(resp, RoomCreateResponse)
         assert resp.room_id == TEST_ROOM_ID2
@@ -1700,13 +1709,14 @@ class TestClass:
                 data = data.decode(encoding="utf-8")
             if isinstance(data, str):
                 data = json.loads(data)
-            assert data.get("creation_content", {}).get("additional_creators", []) == [ALICE_ID]
-            return CallbackResult(status=200, payload=self.room_id_response(TEST_ROOM_ID))
+            assert data.get("creation_content", {}).get("additional_creators", []) == [
+                ALICE_ID
+            ]
+            return CallbackResult(
+                status=200, payload=self.room_id_response(TEST_ROOM_ID)
+            )
 
-        aioresponse.post(
-            f"{BASE_URL_V3}/createRoom" "",
-            callback=room_create_cb
-        )
+        aioresponse.post(f"{BASE_URL_V3}/createRoom" "", callback=room_create_cb)
 
         resp = await async_client.room_create(
             visibility=RoomVisibility.public,
@@ -1718,7 +1728,7 @@ class TestClass:
             invite={ALICE_ID},
             initial_state=[],
             power_level_override={},
-            additional_creators=[ALICE_ID]
+            additional_creators=[ALICE_ID],
         )
         assert isinstance(resp, RoomCreateResponse)
         assert resp.room_id == TEST_ROOM_ID
@@ -4563,96 +4573,34 @@ class TestClass:
 
         assert isinstance(resp, SpaceGetHierarchyError)
 
-    async def test_has_event_permission__creator_can_tombstone(self, async_client, aioresponse):
-        room_create_event = RoomCreateEvent.from_dict({
-            "event_id": "create_event_id",
-            "origin_server_ts": 1,
-            "type": "m.room.create",
-            "sender": ALICE_ID,
-            "state_key": "",
-            "content": {
-                "room_version": "11"
+    async def test_has_event_permission__creator_can_tombstone(
+        self, async_client, aioresponse
+    ):
+        room_create_event = RoomCreateEvent.from_dict(
+            {
+                "event_id": "create_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.create",
+                "sender": ALICE_ID,
+                "state_key": "",
+                "content": {"room_version": "11"},
             }
-        })
+        )
         power_levels_event_content = {
             "users": {
                 ALICE_ID: 100,
             }
         }
-        power_levels_event = PowerLevelsEvent.from_dict({
-            "event_id": "power_levels_event_id",
-            "origin_server_ts": 1,
-            "type": "m.room.power_levels",
-            "sender": ALICE_ID,
-            "state_key": "",
-            "content": power_levels_event_content,
-        })
-        # I am Alice.
-        aioresponse.get(
-            f"{BASE_URL_V3}/account/whoami",
-            status=200,
-            payload={
-                "device_id": ALICE_DEVICE_ID,
-                "user_id": ALICE_ID,
-            },
-            repeat=True,
-        )
-        # Default power levels.
-        aioresponse.get(
-            f"{BASE_URL_V3}/rooms/{TEST_ROOM_ID}/state/m.room.power_levels",
-            status=200,
-            payload=power_levels_event_content,
-            repeat=True,
-        )
-        # I am joined in the TEST_ROOM
-        await async_client.receive_response(SyncResponse(
-            next_batch="sync_next_batch",
-            rooms=Rooms(
-                invite={},
-                join={TEST_ROOM_ID: RoomInfo(
-                    timeline=Timeline(events=[], limited=False, prev_batch="room_prev_batch"),
-                    state=[
-                        room_create_event,
-                        power_levels_event,
-                    ],
-                    ephemeral=[],
-                    account_data=[],
-                )},
-                leave={},
-            ),
-            device_key_count=DeviceOneTimeKeyCount(curve25519=None, signed_curve25519=None),
-            device_list=DeviceList(changed=[], left=[]),
-            to_device_events=[],
-            presence_events=[],
-        ))
-
-        response = await async_client.has_event_permission(TEST_ROOM_ID, "m.room.tombstone", "state")
-        assert response is True
-
-    async def test_has_event_permission__creator_can_tombstone__roomv12(self, async_client, aioresponse):
-        room_create_event = RoomCreateEvent.from_dict({
-            "event_id": "create_event_id",
-            "origin_server_ts": 1,
-            "type": "m.room.create",
-            "sender": ALICE_ID,
-            "state_key": "",
-            "content": {
-                "room_version": "12"
-            },
-        })
-        power_levels_event_content = {
-            "events": {
-                "m.room.tombstone": 150
+        power_levels_event = PowerLevelsEvent.from_dict(
+            {
+                "event_id": "power_levels_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.power_levels",
+                "sender": ALICE_ID,
+                "state_key": "",
+                "content": power_levels_event_content,
             }
-        }
-        power_levels_event = PowerLevelsEvent.from_dict({
-            "event_id": "power_levels_event_id",
-            "origin_server_ts": 1,
-            "type": "m.room.power_levels",
-            "sender": ALICE_ID,
-            "state_key": "",
-            "content": power_levels_event_content,
-        })
+        )
         # I am Alice.
         aioresponse.get(
             f"{BASE_URL_V3}/account/whoami",
@@ -4671,57 +4619,147 @@ class TestClass:
             repeat=True,
         )
         # I am joined in the TEST_ROOM
-        await async_client.receive_response(SyncResponse(
-            next_batch="sync_next_batch",
-            rooms=Rooms(
-                invite={},
-                join={TEST_ROOM_ID: RoomInfo(
-                    timeline=Timeline(events=[], limited=False, prev_batch="room_prev_batch"),
-                    state=[
-                        room_create_event,
-                        power_levels_event,
-                    ],
-                    ephemeral=[],
-                    account_data=[],
-                )},
-                leave={},
-            ),
-            device_key_count=DeviceOneTimeKeyCount(curve25519=None, signed_curve25519=None),
-            device_list=DeviceList(changed=[], left=[]),
-            to_device_events=[],
-            presence_events=[],
-        ))
+        await async_client.receive_response(
+            SyncResponse(
+                next_batch="sync_next_batch",
+                rooms=Rooms(
+                    invite={},
+                    join={
+                        TEST_ROOM_ID: RoomInfo(
+                            timeline=Timeline(
+                                events=[], limited=False, prev_batch="room_prev_batch"
+                            ),
+                            state=[
+                                room_create_event,
+                                power_levels_event,
+                            ],
+                            ephemeral=[],
+                            account_data=[],
+                        )
+                    },
+                    leave={},
+                ),
+                device_key_count=DeviceOneTimeKeyCount(
+                    curve25519=None, signed_curve25519=None
+                ),
+                device_list=DeviceList(changed=[], left=[]),
+                to_device_events=[],
+                presence_events=[],
+            )
+        )
 
-        response = await async_client.has_event_permission(TEST_ROOM_ID, "m.room.tombstone", "state")
+        response = await async_client.has_event_permission(
+            TEST_ROOM_ID, "m.room.tombstone", "state"
+        )
         assert response is True
 
-    async def test_has_event_permission__admin_cannot_tombstone__roomv12(self, async_client, aioresponse):
-        room_create_event = RoomCreateEvent.from_dict({
-            "event_id": "create_event_id",
-            "origin_server_ts": 1,
-            "type": "m.room.create",
-            "sender": CAROL_ID,
-            "state_key": "",
-            "content": {
-                "room_version": "12"
+    async def test_has_event_permission__creator_can_tombstone__roomv12(
+        self, async_client, aioresponse
+    ):
+        room_create_event = RoomCreateEvent.from_dict(
+            {
+                "event_id": "create_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.create",
+                "sender": ALICE_ID,
+                "state_key": "",
+                "content": {"room_version": "12"},
+            }
+        )
+        power_levels_event_content = {"events": {"m.room.tombstone": 150}}
+        power_levels_event = PowerLevelsEvent.from_dict(
+            {
+                "event_id": "power_levels_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.power_levels",
+                "sender": ALICE_ID,
+                "state_key": "",
+                "content": power_levels_event_content,
+            }
+        )
+        # I am Alice.
+        aioresponse.get(
+            f"{BASE_URL_V3}/account/whoami",
+            status=200,
+            payload={
+                "device_id": ALICE_DEVICE_ID,
+                "user_id": ALICE_ID,
             },
-        })
+            repeat=True,
+        )
+        # Default power levels.
+        aioresponse.get(
+            f"{BASE_URL_V3}/rooms/{TEST_ROOM_ID}/state/m.room.power_levels",
+            status=200,
+            payload=power_levels_event_content,
+            repeat=True,
+        )
+        # I am joined in the TEST_ROOM
+        await async_client.receive_response(
+            SyncResponse(
+                next_batch="sync_next_batch",
+                rooms=Rooms(
+                    invite={},
+                    join={
+                        TEST_ROOM_ID: RoomInfo(
+                            timeline=Timeline(
+                                events=[], limited=False, prev_batch="room_prev_batch"
+                            ),
+                            state=[
+                                room_create_event,
+                                power_levels_event,
+                            ],
+                            ephemeral=[],
+                            account_data=[],
+                        )
+                    },
+                    leave={},
+                ),
+                device_key_count=DeviceOneTimeKeyCount(
+                    curve25519=None, signed_curve25519=None
+                ),
+                device_list=DeviceList(changed=[], left=[]),
+                to_device_events=[],
+                presence_events=[],
+            )
+        )
+
+        response = await async_client.has_event_permission(
+            TEST_ROOM_ID, "m.room.tombstone", "state"
+        )
+        assert response is True
+
+    async def test_has_event_permission__admin_cannot_tombstone__roomv12(
+        self, async_client, aioresponse
+    ):
+        room_create_event = RoomCreateEvent.from_dict(
+            {
+                "event_id": "create_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.create",
+                "sender": CAROL_ID,
+                "state_key": "",
+                "content": {"room_version": "12"},
+            }
+        )
         power_levels_event_content = {
             "events": {
                 "m.room.tombstone": 150,
             },
             "users": {
                 ALICE_ID: 100,
-            }
+            },
         }
-        power_levels_event = PowerLevelsEvent.from_dict({
-            "event_id": "power_levels_event_id",
-            "origin_server_ts": 1,
-            "type": "m.room.power_levels",
-            "sender": CAROL_ID,
-            "state_key": "",
-            "content": power_levels_event_content,
-        })
+        power_levels_event = PowerLevelsEvent.from_dict(
+            {
+                "event_id": "power_levels_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.power_levels",
+                "sender": CAROL_ID,
+                "state_key": "",
+                "content": power_levels_event_content,
+            }
+        )
         # I am Alice.
         aioresponse.get(
             f"{BASE_URL_V3}/account/whoami",
@@ -4740,55 +4778,67 @@ class TestClass:
             repeat=True,
         )
         # I am joined in the TEST_ROOM
-        await async_client.receive_response(SyncResponse(
-            next_batch="sync_next_batch",
-            rooms=Rooms(
-                invite={},
-                join={TEST_ROOM_ID: RoomInfo(
-                    timeline=Timeline(events=[], limited=False, prev_batch="room_prev_batch"),
-                    state=[
-                        room_create_event,
-                        power_levels_event,
-                    ],
-                    ephemeral=[],
-                    account_data=[],
-                )},
-                leave={},
-            ),
-            device_key_count=DeviceOneTimeKeyCount(curve25519=None, signed_curve25519=None),
-            device_list=DeviceList(changed=[], left=[]),
-            to_device_events=[],
-            presence_events=[],
-        ))
+        await async_client.receive_response(
+            SyncResponse(
+                next_batch="sync_next_batch",
+                rooms=Rooms(
+                    invite={},
+                    join={
+                        TEST_ROOM_ID: RoomInfo(
+                            timeline=Timeline(
+                                events=[], limited=False, prev_batch="room_prev_batch"
+                            ),
+                            state=[
+                                room_create_event,
+                                power_levels_event,
+                            ],
+                            ephemeral=[],
+                            account_data=[],
+                        )
+                    },
+                    leave={},
+                ),
+                device_key_count=DeviceOneTimeKeyCount(
+                    curve25519=None, signed_curve25519=None
+                ),
+                device_list=DeviceList(changed=[], left=[]),
+                to_device_events=[],
+                presence_events=[],
+            )
+        )
 
-        response = await async_client.has_event_permission(TEST_ROOM_ID, "m.room.tombstone", "state")
+        response = await async_client.has_event_permission(
+            TEST_ROOM_ID, "m.room.tombstone", "state"
+        )
         assert response is False
 
     async def test_has_permission(self, async_client, aioresponse):
-        room_create_event = RoomCreateEvent.from_dict({
-            "event_id": "create_event_id",
-            "origin_server_ts": 1,
-            "type": "m.room.create",
-            "sender": CAROL_ID,
-            "state_key": "",
-            "content": {
-                "room_version": "11"
+        room_create_event = RoomCreateEvent.from_dict(
+            {
+                "event_id": "create_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.create",
+                "sender": CAROL_ID,
+                "state_key": "",
+                "content": {"room_version": "11"},
             }
-        })
+        )
         power_levels_event_content = {
             "users": {
                 CAROL_ID: 100,
             },
             "kick": 50,
         }
-        power_levels_event = PowerLevelsEvent.from_dict({
-            "event_id": "power_levels_event_id",
-            "origin_server_ts": 1,
-            "type": "m.room.power_levels",
-            "sender": CAROL_ID,
-            "state_key": "",
-            "content": power_levels_event_content,
-        })
+        power_levels_event = PowerLevelsEvent.from_dict(
+            {
+                "event_id": "power_levels_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.power_levels",
+                "sender": CAROL_ID,
+                "state_key": "",
+                "content": power_levels_event_content,
+            }
+        )
         # I am Alice.
         aioresponse.get(
             f"{BASE_URL_V3}/account/whoami",
@@ -4807,52 +4857,64 @@ class TestClass:
             repeat=True,
         )
         # I am joined in the TEST_ROOM
-        await async_client.receive_response(SyncResponse(
-            next_batch="sync_next_batch",
-            rooms=Rooms(
-                invite={},
-                join={TEST_ROOM_ID: RoomInfo(
-                    timeline=Timeline(events=[], limited=False, prev_batch="room_prev_batch"),
-                    state=[
-                        room_create_event,
-                        power_levels_event,
-                    ],
-                    ephemeral=[],
-                    account_data=[],
-                )},
-                leave={},
-            ),
-            device_key_count=DeviceOneTimeKeyCount(curve25519=None, signed_curve25519=None),
-            device_list=DeviceList(changed=[], left=[]),
-            to_device_events=[],
-            presence_events=[],
-        ))
+        await async_client.receive_response(
+            SyncResponse(
+                next_batch="sync_next_batch",
+                rooms=Rooms(
+                    invite={},
+                    join={
+                        TEST_ROOM_ID: RoomInfo(
+                            timeline=Timeline(
+                                events=[], limited=False, prev_batch="room_prev_batch"
+                            ),
+                            state=[
+                                room_create_event,
+                                power_levels_event,
+                            ],
+                            ephemeral=[],
+                            account_data=[],
+                        )
+                    },
+                    leave={},
+                ),
+                device_key_count=DeviceOneTimeKeyCount(
+                    curve25519=None, signed_curve25519=None
+                ),
+                device_list=DeviceList(changed=[], left=[]),
+                to_device_events=[],
+                presence_events=[],
+            )
+        )
 
         response = await async_client.has_permission(TEST_ROOM_ID, "kick")
         assert response is False
 
-    async def test_has_permission__roomv12_creator_does(self, async_client, aioresponse):
-        room_create_event = RoomCreateEvent.from_dict({
-            "event_id": "create_event_id",
-            "origin_server_ts": 1,
-            "type": "m.room.create",
-            "sender": ALICE_ID,
-            "state_key": "",
-            "content": {
-                "room_version": "12"
+    async def test_has_permission__roomv12_creator_does(
+        self, async_client, aioresponse
+    ):
+        room_create_event = RoomCreateEvent.from_dict(
+            {
+                "event_id": "create_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.create",
+                "sender": ALICE_ID,
+                "state_key": "",
+                "content": {"room_version": "12"},
             }
-        })
+        )
         power_levels_event_content = {
             "kick": 50,
         }
-        power_levels_event = PowerLevelsEvent.from_dict({
-            "event_id": "power_levels_event_id",
-            "origin_server_ts": 1,
-            "type": "m.room.power_levels",
-            "sender": ALICE_ID,
-            "state_key": "",
-            "content": power_levels_event_content,
-        })
+        power_levels_event = PowerLevelsEvent.from_dict(
+            {
+                "event_id": "power_levels_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.power_levels",
+                "sender": ALICE_ID,
+                "state_key": "",
+                "content": power_levels_event_content,
+            }
+        )
         # I am Alice.
         aioresponse.get(
             f"{BASE_URL_V3}/account/whoami",
@@ -4871,26 +4933,34 @@ class TestClass:
             repeat=True,
         )
         # I am joined in the TEST_ROOM
-        await async_client.receive_response(SyncResponse(
-            next_batch="sync_next_batch",
-            rooms=Rooms(
-                invite={},
-                join={TEST_ROOM_ID: RoomInfo(
-                    timeline=Timeline(events=[], limited=False, prev_batch="room_prev_batch"),
-                    state=[
-                        room_create_event,
-                        power_levels_event,
-                    ],
-                    ephemeral=[],
-                    account_data=[],
-                )},
-                leave={},
-            ),
-            device_key_count=DeviceOneTimeKeyCount(curve25519=None, signed_curve25519=None),
-            device_list=DeviceList(changed=[], left=[]),
-            to_device_events=[],
-            presence_events=[],
-        ))
+        await async_client.receive_response(
+            SyncResponse(
+                next_batch="sync_next_batch",
+                rooms=Rooms(
+                    invite={},
+                    join={
+                        TEST_ROOM_ID: RoomInfo(
+                            timeline=Timeline(
+                                events=[], limited=False, prev_batch="room_prev_batch"
+                            ),
+                            state=[
+                                room_create_event,
+                                power_levels_event,
+                            ],
+                            ephemeral=[],
+                            account_data=[],
+                        )
+                    },
+                    leave={},
+                ),
+                device_key_count=DeviceOneTimeKeyCount(
+                    curve25519=None, signed_curve25519=None
+                ),
+                device_list=DeviceList(changed=[], left=[]),
+                to_device_events=[],
+                presence_events=[],
+            )
+        )
 
         response = await async_client.has_permission(TEST_ROOM_ID, "kick")
         assert response is True

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -144,7 +144,7 @@ from nio.api import (
 )
 from nio.client.async_client import connect_wrapper, on_request_chunk_sent
 from nio.crypto import OlmDevice, Session, decrypt_attachment
-from nio.responses import PublicRoom, PublicRoomsResponse, RoomUpgradeResponse
+from nio.responses import PublicRoom, PublicRoomsResponse
 
 BASE_URL_V1 = f"https://example.org{MATRIX_API_PATH_V1}"
 BASE_URL_V3 = f"https://example.org{MATRIX_API_PATH_V3}"

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -152,7 +152,7 @@ BASE_MEDIA_URL = f"https://example.org{MATRIX_MEDIA_API_PATH}"
 BASE_LEGACY_MEDIA_URL = f"https://example.org{MATRIX_LEGACY_MEDIA_API_PATH}"
 TEST_ROOM_ID = "!testroom:example.org"
 TEST_ROOM_ID2 = "!testroom2:example.org"
-TEST_ROOM_ID_V12 = "$5hdALbO+xIhzcLTxCkspx5uqry9wO8322h/OI9ApnHE"
+TEST_ROOM_ID_V12 = "!5hdALbO+xIhzcLTxCkspx5uqry9wO8322h/OI9ApnHE"
 
 ALICE_ID = "@alice:example.org"
 ALICE_DEVICE_ID = "JLAFKJWSCS"

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -4965,3 +4965,119 @@ class TestClass:
 
         response = await async_client.has_permission(TEST_ROOM_ID, "kick")
         assert response is True
+
+    async def test_room_upgrade__upgrade_to_v12_excludes_creator_from_new_power_levels(self, async_client, aioresponse):
+        room_create_event_dict = {
+                "event_id": "$create_event_id",
+                "origin_server_ts": 1,
+                "type": "m.room.create",
+                "sender": ALICE_ID,
+                "state_key": "",
+                "content": {"room_version": "11"},
+            }
+        room_create_event = RoomCreateEvent.from_dict(room_create_event_dict)
+        power_levels_event_content = {
+            "users": {
+                ALICE_ID: 100,
+            },
+        }
+        power_levels_event_dict = {
+            "event_id": "$power_levels_event_id",
+            "origin_server_ts": 1,
+            "type": "m.room.power_levels",
+            "sender": ALICE_ID,
+            "state_key": "",
+            "content": power_levels_event_content,
+        }
+        power_levels_event = PowerLevelsEvent.from_dict(power_levels_event_dict)
+        # I am Alice.
+        aioresponse.get(
+            f"{BASE_URL_V3}/account/whoami",
+            status=200,
+            payload={
+                "device_id": ALICE_DEVICE_ID,
+                "user_id": ALICE_ID,
+            },
+            repeat=True,
+        )
+        # Default power levels.
+        aioresponse.get(
+            f"{BASE_URL_V3}/rooms/{TEST_ROOM_ID}/state/m.room.power_levels",
+            status=200,
+            payload=power_levels_event_content,
+            repeat=True,
+        )
+        # Room state
+        aioresponse.get(
+            f"{BASE_URL_V3}/rooms/{TEST_ROOM_ID}/state",
+            status=200,
+            payload=[room_create_event_dict, power_levels_event_dict],
+            repeat=True
+        )
+        # Room has no alias
+        aioresponse.get(
+            f"{BASE_URL_V3}/rooms/{TEST_ROOM_ID}/state/m.room.canonical_alias",
+            status=404,
+            payload={},
+            repeat=True
+        )
+        # I am joined in the TEST_ROOM
+        await async_client.receive_response(
+            SyncResponse(
+                next_batch="sync_next_batch",
+                rooms=Rooms(
+                    invite={},
+                    join={
+                        TEST_ROOM_ID: RoomInfo(
+                            timeline=Timeline(
+                                events=[], limited=False, prev_batch="room_prev_batch"
+                            ),
+                            state=[
+                                room_create_event,
+                                power_levels_event,
+                            ],
+                            ephemeral=[],
+                            account_data=[],
+                        )
+                    },
+                    leave={},
+                ),
+                device_key_count=DeviceOneTimeKeyCount(
+                    curve25519=None, signed_curve25519=None
+                ),
+                device_list=DeviceList(changed=[], left=[]),
+                to_device_events=[],
+                presence_events=[],
+            )
+        )
+        # Expect a `createRoom` API call with the power levels that do not include the creator.
+        room_create_called = asyncio.Event()
+
+        def room_create_cb(url, data, **kwargs):
+            # TODO: Validate `data` completely?
+            if isinstance(data, bytes):
+                data = data.decode(encoding="utf-8")
+            if isinstance(data, str):
+                data = json.loads(data)
+            assert data.get("room_version") == "12"
+            assert (
+                ALICE_ID not in data.get("power_level_content_override", {}).get("users", {})
+            )
+            for event in data.get("initial_state", []):
+                if event["type"] == "m.room.power_levels":
+                    assert ALICE_ID not in event.get("content", {}).get("users", {})
+            room_create_called.set()
+            return CallbackResult(
+                status=200, payload=self.room_id_response(TEST_ROOM_ID_V12)
+            )
+        aioresponse.post(f"{BASE_URL_V3}/createRoom", callback=room_create_cb)
+        # Expect to tombstone the old room
+        aioresponse.put(
+            f"{BASE_URL_V3}/rooms/{TEST_ROOM_ID}/state/m.room.tombstone",
+            status=200,
+            payload={"event_id": "$tombstone_event_id"},
+            repeat=False
+        )
+
+        await async_client.room_upgrade(TEST_ROOM_ID, "12")
+        assert room_create_called.is_set()

--- a/tests/data/events/create_v12.json
+++ b/tests/data/events/create_v12.json
@@ -1,0 +1,15 @@
+{
+    "content": {
+        "m.federate": true,
+        "room_version": "12",
+        "additional_creators": ["@bob:example.org"]
+    },
+    "event_id": "$151957878228ekrDs:localhost",
+    "origin_server_ts": 1519578782185,
+    "sender": "@example:localhost",
+    "state_key": "",
+    "type": "m.room.create",
+    "unsigned": {
+      "age": 1392989709
+    }
+}

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -99,6 +99,12 @@ class TestClass:
         assert isinstance(event, RoomCreateEvent)
         assert event.room_type == "nio.matrix.test"
 
+    def test_create_event_v12(self):
+        parsed_dict = TestClass._load_response("tests/data/events/create_v12.json")
+        event = RoomCreateEvent.from_dict(parsed_dict)
+        assert isinstance(event, RoomCreateEvent)
+        assert event.additional_creators == ["@bob:example.org"]
+
     def test_guest_access_event(self):
         parsed_dict = TestClass._load_response("tests/data/events/guest_access.json")
         event = RoomGuestAccessEvent.from_dict(parsed_dict)

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -174,6 +174,8 @@ class TestClass:
         assert isinstance(event, PowerLevelsEvent)
 
         levels = event.power_levels
+        creator = "@creator:localhost"
+        levels.creators.add(creator)
         admin = "@example:localhost"
         mod = "@alice:localhost"
         higher_user = "@carol:localhost"
@@ -188,34 +190,46 @@ class TestClass:
 
         assert levels.get_user_level(admin) == 100
         assert levels.get_user_level(user) == 0
+        assert levels.get_user_level(creator) > 2**53
 
+        assert levels.can_user_send_state(creator, "m.room.name") is True
         assert levels.can_user_send_state(admin, "m.room.name") is True
         assert levels.can_user_send_state(user, "m.room.name") is False
+        assert levels.can_user_send_message(creator) is True
         assert levels.can_user_send_message(admin) is True
         assert levels.can_user_send_message(user, "m.room.message") is False
 
+        assert levels.can_user_invite(creator) is True
         assert levels.can_user_invite(admin) is True
         assert levels.can_user_invite(user) is True
 
+        assert levels.can_user_kick(creator) is True
         assert levels.can_user_kick(admin) is True
         assert levels.can_user_kick(user) is False
+        assert levels.can_user_kick(creator, creator) is False
+        assert levels.can_user_kick(creator, admin) is True
         assert levels.can_user_kick(admin, admin) is False
         assert levels.can_user_kick(admin, mod) is True
         assert levels.can_user_kick(mod, admin) is False
         assert levels.can_user_kick(mod, higher_user) is True
         assert levels.can_user_kick(higher_user, user) is False
 
+        assert levels.can_user_ban(creator) is True
         assert levels.can_user_ban(admin) is True
         assert levels.can_user_ban(user) is False
+        assert levels.can_user_ban(creator, creator) is False
+        assert levels.can_user_ban(creator, admin) is True
         assert levels.can_user_ban(admin, admin) is False
         assert levels.can_user_ban(admin, mod) is True
         assert levels.can_user_ban(mod, admin) is False
         assert levels.can_user_ban(mod, higher_user) is True
         assert levels.can_user_ban(higher_user, user) is False
 
+        assert levels.can_user_redact(creator) is True
         assert levels.can_user_redact(admin) is True
         assert levels.can_user_redact(user) is False
 
+        assert levels.can_user_notify(creator, "room") is True
         assert levels.can_user_notify(admin, "room") is True
         assert levels.can_user_notify(mod, "room") is False
 

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -175,7 +175,7 @@ class TestClass:
 
         levels = event.power_levels
         creator = "@creator:localhost"
-        levels.creators.add(creator)
+        levels.creators[creator] = True
         admin = "@example:localhost"
         mod = "@alice:localhost"
         higher_user = "@carol:localhost"

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -60,6 +60,25 @@ class TestClass:
         room = self.test_room
         assert room
 
+    def test_supports_room_version_12(self):
+        room = MatrixRoom(TEST_ROOM, BOB_ID)
+        room.room_version = "11"
+        assert room.supports_room_version_12 is False
+
+        room = MatrixRoom(TEST_ROOM, BOB_ID)
+        room.room_version = "12"
+        assert room.supports_room_version_12 is True
+
+        room = MatrixRoom(TEST_ROOM, BOB_ID)
+        room.room_version = "org.matrix.hydra.11"
+        assert room.supports_room_version_12 is True
+
+        # Not sure if this is the correct behavior.
+        # See comments in MatrixRoom.supports_room_version_12().
+        room = MatrixRoom(TEST_ROOM, BOB_ID)
+        room.room_version = "unknown_room_version"
+        assert room.supports_room_version_12 is False
+
     def test_adding_members(self):
         room = self.test_room
         assert not room.users

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -430,6 +430,25 @@ class TestClass:
         )
         assert room.federate is False
         assert room.room_version == "1"
+        assert room.creators == set()
+
+    def test_create_event__room_v12(self):
+        room = self.test_room
+        room.handle_event(
+            RoomCreateEvent.from_dict({
+                "event_id": "event_id",
+                "origin_server_ts": 0,
+                "sender": BOB_ID,
+                "state_key": "",
+                "type": "m.room.create",
+                "content": {
+                    "room_version": "12",
+                    "m.federate": False
+                }
+            })
+        )
+        assert room.federate is False
+        assert room.room_version == "12"
         assert room.creators == {BOB_ID}
 
     def test_guest_access_event(self):

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -430,6 +430,7 @@ class TestClass:
         )
         assert room.federate is False
         assert room.room_version == "1"
+        assert room.creators == {BOB_ID}
 
     def test_guest_access_event(self):
         room = self.test_room

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -454,17 +454,16 @@ class TestClass:
     def test_create_event__room_v12(self):
         room = self.test_room
         room.handle_event(
-            RoomCreateEvent.from_dict({
-                "event_id": "event_id",
-                "origin_server_ts": 0,
-                "sender": BOB_ID,
-                "state_key": "",
-                "type": "m.room.create",
-                "content": {
-                    "room_version": "12",
-                    "m.federate": False
+            RoomCreateEvent.from_dict(
+                {
+                    "event_id": "event_id",
+                    "origin_server_ts": 0,
+                    "sender": BOB_ID,
+                    "state_key": "",
+                    "type": "m.room.create",
+                    "content": {"room_version": "12", "m.federate": False},
                 }
-            })
+            )
         )
         assert room.federate is False
         assert room.room_version == "12"


### PR DESCRIPTION
As per [the security pre-disclosure](https://matrix.org/blog/2025/07/security-predisclosure/), [MSC4289](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/4289-privilege-creators.md), [MSC4291](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/4291-room-ids-as-hashes.md)

Changes:

- [x] remove `:` from RoomRegex
- [x] make `m.room.create` schema no longer require `event_id` in `content.predecessor`
- [x] make `room_upgrade()` comply with the above
- [x] make `RoomCreateEvent` support `additional_creators`
- [x] add `creators` field to `MatrixRoom` so clients don't have to fetch the `m.room.create` manually for it
- [x] make `create_room()` support `additional_creators`
- [x] update power level checking
- [x] add tests