### PR TITLE
Unpin dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,14 @@ license = { file = "LICENSE.md" }
 readme = "README.md"
 requires-python = ">=3.8.0"
 dependencies = [
-    "aiohttp~=3.10",
-    "aiofiles~=24.1",
-    "h11~=0.14",
-    "h2~=4.0",
-    "jsonschema~=4.14",
-    "unpaddedbase64~=2.1",
-    "pycryptodome~=3.10",
-    "aiohttp-socks~=0.8"
+    "aiohttp>=3.10",
+    "aiofiles>=24.1",
+    "h11>=0.14",
+    "h2>=4.0",
+    "jsonschema>=4.14",
+    "unpaddedbase64>=2.1",
+    "pycryptodome>=3.10",
+    "aiohttp-socks>=0.8"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I attempted to upgrade aiofiles to 25.1.0 in Home Assistant, but matrix-nio is currently pinning it to 24.1.0.

Unless there is a strong technical or compatibility-related reason for capping the version, libraries generally shouldn’t enforce strict upper constraints on dependencies. Doing so makes it harder for downstream projects to stay up to date and can unnecessarily block upgrades or security patches. If there is a specific incompatibility with newer releases of certain dependencies, it would be helpful to document it